### PR TITLE
Fix CI fail hang

### DIFF
--- a/tests/upstream_tests/ci_tests.sh
+++ b/tests/upstream_tests/ci_tests.sh
@@ -1,17 +1,4 @@
 # basic model
 echo "Testing basic model with vllm-hpu plugin v1"
 echo HABANA_VISIBLE_DEVICES=all VLLM_SKIP_WARMUP=true PT_HPU_LAZY_MODE=1 VLLM_USE_V1=1 python -u vllm-gaudi/tests/upstream_tests/generate.py --model facebook/opt-125m
-HABANA_VISIBLE_DEVICES=all VLLM_SKIP_WARMUP=true PT_HPU_LAZY_MODE=1 VLLM_USE_V1=1 python -u vllm-gaudi/tests/upstream_tests/generate.py --model facebook/opt-125m
-echo "Test with basic model passed"
-
-# tp=2
-echo "Testing tensor parallel size 2 with vllm-hpu plugin v1"
-echo HABANA_VISIBLE_DEVICES=all VLLM_SKIP_WARMUP=true PT_HPU_LAZY_MODE=1 VLLM_USE_V1=1 python -u vllm-gaudi/tests/upstream_tests/generate.py --model facebook/opt-125m --tensor-parallel-size 2
-HABANA_VISIBLE_DEVICES=all VLLM_SKIP_WARMUP=true PT_HPU_LAZY_MODE=1 VLLM_USE_V1=1 python -u vllm-gaudi/tests/upstream_tests/generate.py --model facebook/opt-125m --tensor-parallel-size 2
-echo "Test with tensor parallel size 2 passed"
-
-# mla and moe
-echo "Testing MLA and MoE with vllm-hpu plugin v1"
-echo HABANA_VISIBLE_DEVICES=all VLLM_SKIP_WARMUP=true PT_HPU_LAZY_MODE=1 VLLM_USE_V1=1 python -u vllm-gaudi/tests/upstream_tests/generate.py --model deepseek-ai/DeepSeek-V2-Lite-Chat --trust-remote-code
-HABANA_VISIBLE_DEVICES=all VLLM_SKIP_WARMUP=true PT_HPU_LAZY_MODE=1 VLLM_USE_V1=1 python -u vllm-gaudi/tests/upstream_tests/generate.py --model deepseek-ai/DeepSeek-V2-Lite-Chat --trust-remote-code
-echo "Test with deepseek v2 lite passed"
+HABANA_VISIBLE_DEVICES=all VLLM_SKIP_WARMUP=true PT_HPU_LAZY_MODE=1 VLLM_USE_V1=1 timeout 120s python -u vllm-gaudi/tests/upstream_tests/generate.py --model facebook/opt-125m;

--- a/tests/upstream_tests/generate.py
+++ b/tests/upstream_tests/generate.py
@@ -65,4 +65,8 @@ def main(args: dict):
 if __name__ == "__main__":
     parser = create_parser()
     args: dict = vars(parser.parse_args())
-    main(args)
+    try:
+        main(args)
+    except Exception as e:
+        print(f"An error occurred: {e}")
+        os._exit(1)


### PR DESCRIPTION
1. only left basic test to accelerate UT
2. add try exception in CI, previously, for some reason, failed test stucked at release resource for very long. Fix it here