### PR TITLE
Use vllm_gaudi.extension logger

### DIFF
--- a/vllm_gaudi/attention/backends/hpu_attn.py
+++ b/vllm_gaudi/attention/backends/hpu_attn.py
@@ -23,9 +23,9 @@ from vllm.attention.backends.mla.common import MLACommonImpl
 from vllm.attention.backends.utils import CommonAttentionState
 from vllm_gaudi.attention.ops.hpu_paged_attn import (HPUPagedAttention,
                                                      HPUPagedAttentionMetadata)
-from vllm.logger import init_logger
 
-logger = init_logger(__name__)
+from vllm_gaudi.extension.logger import logger as init_logger
+logger = init_logger()
 
 
 class HPUAttentionBackend(AttentionBackend):

--- a/vllm_gaudi/platform.py
+++ b/vllm_gaudi/platform.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any, Optional
 import torch
 
 from vllm import envs
-from vllm.logger import init_logger
 
 from vllm.platforms import Platform, PlatformEnum, _Backend
 
@@ -16,7 +15,8 @@ else:
     ModelConfig = None
     VllmConfig = None
 
-logger = init_logger(__name__)
+from vllm_gaudi.extension.logger import logger as init_logger
+logger = init_logger()
 
 
 class HpuPlatform(Platform):

--- a/vllm_gaudi/v1/attention/backends/hpu_attn.py
+++ b/vllm_gaudi/v1/attention/backends/hpu_attn.py
@@ -12,9 +12,8 @@ import torch
 from vllm.attention.backends.abstract import AttentionMetadata
 from vllm_gaudi.attention.backends.hpu_attn import (HPUAttentionBackend,
                                                     HPUAttentionMetadata)
-from vllm.logger import init_logger
-
-logger = init_logger(__name__)
+from vllm_gaudi.extension.logger import logger as init_logger
+logger = init_logger()
 
 
 class HPUAttentionBackendV1(HPUAttentionBackend):

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -24,7 +24,6 @@ from vllm.attention.layer import Attention
 from vllm.attention.selector import get_attn_backend
 from vllm.config import VllmConfig
 from vllm.forward_context import set_forward_context
-from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.layer import FusedMoE
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.sampler import get_sampler
@@ -50,7 +49,8 @@ from vllm.distributed.parallel_state import get_pp_group
 if TYPE_CHECKING:
     from vllm.v1.core.scheduler import SchedulerOutput
 
-logger = init_logger(__name__)
+from vllm_gaudi.extension.logger import logger as init_logger
+logger = init_logger()
 
 _TYPE_CACHE: dict[str, dict[str, Any]] = {}
 

--- a/vllm_gaudi/v1/worker/hpu_worker.py
+++ b/vllm_gaudi/v1/worker/hpu_worker.py
@@ -15,7 +15,6 @@ import vllm.envs as envs
 from vllm.config import ParallelConfig, VllmConfig
 from vllm.distributed import (ensure_model_parallel_initialized,
                               init_distributed_environment)
-from vllm.logger import init_logger
 from vllm.model_executor import set_random_seed
 from vllm.utils import STR_DTYPE_TO_TORCH_DTYPE
 from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
@@ -26,7 +25,8 @@ from vllm_gaudi.utils import is_fake_hpu
 from vllm_gaudi.v1.worker.hpu_model_runner import HPUModelRunner, bool_helper
 from vllm.v1.worker.worker_base import WorkerBase
 
-logger = init_logger(__name__)
+from vllm_gaudi.extension.logger import logger as init_logger
+logger = init_logger()
 
 if TYPE_CHECKING:
     from vllm.v1.core.scheduler import SchedulerOutput


### PR DESCRIPTION
Using default vLLM logger results in logging messages being suppressed by default. This PR switches to vllm_gaudi.extension.logger, which wraps vLLM logger if available (without suppressing messages), or uses non-vLLM logger.