### PR TITLE
[CI] Don't fetch PyTorch for building vLLM upstream

### DIFF
--- a/.github/workflows/hourly-ci.yaml
+++ b/.github/workflows/hourly-ci.yaml
@@ -94,7 +94,8 @@ jobs:
           ENV PT_HPU_ENABLE_LAZY_COLLECTIVES=true
 
           # Ensure setup.py install works as expected
-          RUN VLLM_TARGET_DEVICE=empty pip install .
+          RUN pip install -r <(sed '/^[torch]/d' requirements/build.txt)
+          RUN VLLM_TARGET_DEVICE=empty pip install --no-build-isolation .
 
           # install development dependencies (for testing)
           RUN python3 -m pip install -e tests/vllm_test_utils

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -53,7 +53,8 @@ jobs:
           ENV PT_HPU_ENABLE_LAZY_COLLECTIVES=true
 
           # Ensure setup.py install works as expected
-          RUN VLLM_TARGET_DEVICE=empty pip install .
+          RUN pip install -r <(sed '/^[torch]/d' requirements/build.txt)
+          RUN VLLM_TARGET_DEVICE=empty pip install --no-build-isolation .
 
           # install development dependencies (for testing)
           RUN python3 -m pip install -e tests/vllm_test_utils


### PR DESCRIPTION
This PR shortens the CI execution time significantly by using preinstalled PyTorch during vLLM build.