### PR TITLE
Adjusted vllm profiler to recent changes in vllm structures

### DIFF
--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -2073,6 +2073,7 @@ class HPUModelRunner:
             mm_hashes=[],
             mm_positions=[],
             sampling_params=sampling_params,
+            pooling_params=None,
             block_ids=[block_ids],
             num_computed_tokens=num_computed_tokens,
             lora_request=None,
@@ -2091,7 +2092,8 @@ class HPUModelRunner:
         return seq_lengths
 
     def _execute_dummy_scenario(self, prompt_cfg, decode_cfg):
-        from vllm.v1.core.sched.output import NewRequestData, SchedulerOutput
+        from vllm.v1.core.sched.output import (NewRequestData, SchedulerOutput,
+                                               CachedRequestData)
         requests: list[NewRequestData] = []
         scheduled_tokens: dict[str, int] = {}
 
@@ -2117,7 +2119,7 @@ class HPUModelRunner:
                                         scheduled_tokens=1)
         sched_output = SchedulerOutput(
             scheduled_new_reqs=requests,
-            scheduled_cached_reqs=[],
+            scheduled_cached_reqs=CachedRequestData.make_empty(),
             num_scheduled_tokens=scheduled_tokens,
             total_num_scheduled_tokens=sum(scheduled_tokens.values()),
             scheduled_spec_decode_tokens={},
@@ -2130,7 +2132,7 @@ class HPUModelRunner:
         )
         cleanup = SchedulerOutput(
             scheduled_new_reqs=[],
-            scheduled_cached_reqs=[],
+            scheduled_cached_reqs=CachedRequestData.make_empty(),
             num_scheduled_tokens={},
             total_num_scheduled_tokens=0,
             scheduled_spec_decode_tokens={},


### PR DESCRIPTION
This PR is adjusting interface changes of vllm profiler to updated changes in RequestCachedData and NewRequestData from vllm project.

Without  this adjustment there was a crash when asking for profiling(VLLM_PROFILE_DECODE=124,1024 PT_HPU_LAZY_MODE=0 ./run_benchmark_throughput.sh):
<img width="1570" height="976" alt="image" src="https://github.com/user-attachments/assets/1a8c88fa-4c3c-4b7c-9093-d72e3dfbed00" />

Dumped traces were inspected and they seem (with this fix) contain valid information
