### PR TITLE
add commit-id to distinguish image and container for each PR

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -36,7 +36,7 @@ jobs:
         run: |
           echo "Attempting to build Docker image..."
           # Ensure this image is accessible from GitHub Actions (e.g., public registry or authenticated private registry).
-          docker build --no-cache -t hpu-plugin-v1-test-env-pre-merge -f - . <<EOF
+          docker build --no-cache -t hpu-plugin-v1-test-env-pre-merge-${{ github.event.pull_request.head.sha }} -f - . <<EOF
           FROM 1.22-619-pt2.7.1:latest
 
           COPY ./ /workspace/vllm-gaudi
@@ -80,16 +80,16 @@ jobs:
       - name: Run pytest in tests/unit_tests
         run: |
           EXITCODE=1
-          remove_docker_containers() { docker rm -f hpu-plugin-v1-test-unit-tests || true; }
+          remove_docker_containers() { docker rm -f hpu-plugin-v1-test-unit-tests-${{ github.event.pull_request.head.sha }} || true; }
           trap 'remove_docker_containers; exit $EXITCODE;' EXIT
           remove_docker_containers
 
           echo "Running HPU plugin v1 unit tests"
-          docker run --rm --runtime=habana --name=hpu-plugin-v1-test-unit-tests --network=host \
+          docker run --rm --runtime=habana --name=hpu-plugin-v1-test-unit-tests-${{ github.event.pull_request.head.sha }} --network=host \
             -e HABANA_VISIBLE_DEVICES=all \
             -e HF_HOME=/workspace/hf_cache \
             -v /mnt/hf_cache:/workspace/hf_cache \
-            hpu-plugin-v1-test-env-pre-merge \
+            hpu-plugin-v1-test-env-pre-merge-${{ github.event.pull_request.head.sha }} \
             /bin/bash -c "pytest -vvv --durations=10 --durations-min=1.0 /workspace/vllm-gaudi/tests/unit_tests"
           
           EXITCODE=$?
@@ -104,16 +104,16 @@ jobs:
       - name: Run test scripts
         run: |
           EXITCODE=1
-          remove_docker_containers() { docker rm -f hpu-plugin-v1-e2e-tests || true; }
+          remove_docker_containers() { docker rm -f hpu-plugin-v1-test-e2e-tests-${{ github.event.pull_request.head.sha }} || true; }
           trap 'remove_docker_containers; exit $EXITCODE;' EXIT
           remove_docker_containers
 
           echo "Running HPU plugin v1 e2e tests"
-          docker run --rm --runtime=habana --name=hpu-plugin-v1-test-pre-merge --network=host \
+          docker run --rm --runtime=habana --name=hpu-plugin-v1-test-e2e-tests-${{ github.event.pull_request.head.sha }} --network=host \
             -e HABANA_VISIBLE_DEVICES=all \
             -e HF_HOME=/workspace/hf_cache \
             -v /mnt/hf_cache:/workspace/hf_cache \
-            hpu-plugin-v1-test-env-pre-merge \
+            hpu-plugin-v1-test-env-pre-merge-${{ github.event.pull_request.head.sha }} \
             /bin/bash "/workspace/vllm-gaudi/tests/full_tests/ci_gsm8k_tests.sh"
           
           EXITCODE=$?


### PR DESCRIPTION
Current CI does not distinguish PR during image build and container launch

If multiple CI triggered, it will overwrite other PR's docker image.

In this commit, I propose to use difference name for each PR docker/container.