### PR TITLE
Reduce number of compilations when dynamic shapes are enabled

### DIFF
--- a/vllm_gaudi/ops/hpu_rotary_embedding.py
+++ b/vllm_gaudi/ops/hpu_rotary_embedding.py
@@ -40,6 +40,11 @@ class HPURotaryEmbedding(RotaryEmbedding):
                                           2,
                                           dim=-1,
                                           output_size=cos_sin.shape[-1])
+
+        if not torch.compiler.is_compiling():
+            torch._dynamo.mark_dynamic(cos, 0)
+            torch._dynamo.mark_dynamic(sin, 0)
+
         self.register_buffer("cos", cos, persistent=False)
         self.register_buffer("sin", sin, persistent=False)
 

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -2421,6 +2421,26 @@ class HPUModelRunner:
             f"Warmup finished in {elapsed_time:.0f} secs, "
             f"allocated {format_bytes(end_mem - start_mem)} of device memory")
         logger.info(msg)
+        print("------------------------------------- dynamo compilations:")
+        compilation_metrics = torch._dynamo.utils.compilation_time_metrics
+        longest_key_length = max(len(key) for key in compilation_metrics)
+        time_comp = 0
+        for key, value in compilation_metrics.items():
+            # print(f"{key:<{longest_key_length}} ", end="")
+            time_comp += sum(value)
+            if key == "_compile.compile_inner":
+                number_comp = len(value) - 1
+            # else:
+            #     print(f" {'':6}", end="")
+            # for v in value:
+            #     print(f" {v:6.3f}", end="")
+            # print()
+        # print("----------------------------------------------------------")
+        print(torch._dynamo.utils.compile_times(aggregate=True))
+        print(f"Number of compilations: {number_comp} (+1)")
+        print(f"Compilations took {time_comp:.0f} s")
+        print("----------------------------------------------------------")
+
         self.profiler.end()
 
     def shutdown_inc(self):

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -1976,6 +1976,7 @@ class HPUModelRunner:
     def _maybe_compile(self, *args, **kwargs):
         if not is_fake_hpu() and not htorch.utils.internal.is_lazy(
         ) and not self.vllm_config.model_config.enforce_eager:
+            torch._dynamo.config.force_parameter_static_shapes = False
             if os.getenv('VLLM_REGIONAL_COMPILATION',
                          'true').strip().lower() in ("1", "true"):
                 compiled_methods = [


### PR DESCRIPTION
It fixes the issue with to many compilation for PyTorch dynamic shapes ( when VLLM_T_COMPILE_DYNAMIC_SHAPES=1).
It allows Dynamo to use dynamic shapes for registered buffers  (see UnspecializedParamBufferSource in PyTorch) by setting dynamo config.
