### PR TITLE
Reduce number of compilations when dynamic shapes is used

### DIFF
--- a/vllm_gaudi/ops/hpu_rotary_embedding.py
+++ b/vllm_gaudi/ops/hpu_rotary_embedding.py
@@ -40,6 +40,11 @@ class HPURotaryEmbedding(RotaryEmbedding):
                                           2,
                                           dim=-1,
                                           output_size=cos_sin.shape[-1])
+
+        if not torch.compiler.is_compiling():
+            torch._dynamo.mark_dynamic(cos, 0)
+            torch._dynamo.mark_dynamic(sin, 0)
+
         self.register_buffer("cos", cos, persistent=False)
         self.register_buffer("sin", sin, persistent=False)
 

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -1976,6 +1976,7 @@ class HPUModelRunner:
         """Entrypoint for a torch.compilation of the model"""
         if (not is_fake_hpu() and not htorch.utils.internal.is_lazy()
                 and not self.vllm_config.model_config.enforce_eager):
+            torch._dynamo.config.force_parameter_static_shapes = False
             self.compile_config = HPUCompileConfig()
             if self.compile_config.regional_compilation:
                 self._compile_methods()


### PR DESCRIPTION
It fixes the issue with to many compilation for Pytorch dynamic shapes ( when VLLM_T_COMPILE_DYNAMIC_SHAPES=1)
It allows making dynamic shapes for registered buffers  (see UnspecializedParamBufferSource in PyTorch) by setting dynamo config.
