### PR TITLE
Fix the failing introduced by upstream 22685

### DIFF
--- a/tests/full_tests/ci_gsm8k_tests.sh
+++ b/tests/full_tests/ci_gsm8k_tests.sh
@@ -122,19 +122,16 @@ fi
 echo "Test with deepseek R1 passed"
 
 # used to check HPUATTN + MOE + ExpertParallel
-#NOTE(adobrzyn): CI broked, to be brought back after fix
-echo "Skipping GSM8K on QWEN3-30B-A3B"
-
-# echo "Testing GSM8K on QWEN3-30B-A3B"
-# echo VLLM_CONTIGUOUS_PA=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=1 VLLM_USE_V1=1 TP_SIZE=2 \
-# pytest -v -s vllm-gaudi/tests/models/language/generation/test_common.py --model_card_path vllm-gaudi/tests/full_tests/model_cards/Qwen3-30B-A3B.yaml
-# VLLM_CONTIGUOUS_PA=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=1 VLLM_USE_V1=1 TP_SIZE=2 \
-# pytest -v -s vllm-gaudi/tests/models/language/generation/test_common.py --model_card_path vllm-gaudi/tests/full_tests/model_cards/Qwen3-30B-A3B.yaml
-# if [ $? -ne 0 ]; then
-#     echo "Error: Test failed for QWEN3-30B-A3B" >&2
-#     exit -1
-# fi
-# echo "Test with QWEN3-30B-A3B passed"
+echo "Testing GSM8K on QWEN3-30B-A3B"
+echo VLLM_CONTIGUOUS_PA=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=1 VLLM_USE_V1=1 TP_SIZE=2 \
+pytest -v -s vllm-gaudi/tests/models/language/generation/test_common.py --model_card_path vllm-gaudi/tests/full_tests/model_cards/Qwen3-30B-A3B.yaml
+VLLM_CONTIGUOUS_PA=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=1 VLLM_USE_V1=1 TP_SIZE=2 \
+pytest -v -s vllm-gaudi/tests/models/language/generation/test_common.py --model_card_path vllm-gaudi/tests/full_tests/model_cards/Qwen3-30B-A3B.yaml
+if [ $? -ne 0 ]; then
+    echo "Error: Test failed for QWEN3-30B-A3B" >&2
+    exit -1
+fi
+echo "Test with QWEN3-30B-A3B passed"
 
 # multimodal-support with qwen2.5-vl
 echo "Testing Qwen2.5-VL-7B"


### PR DESCRIPTION
root cause:
upstream added a new get_compressed_expert_map which used dynamic shape. => monkeypatch with different impl

Now, bring the QWEN3-30B EP=2 test back