### PR TITLE
Port G2 scaling convert from vllm-fork #1505

### DIFF
--- a/tests/full_tests/ci_gsm8k_tests.sh
+++ b/tests/full_tests/ci_gsm8k_tests.sh
@@ -61,28 +61,25 @@ if [ $? -ne 0 ]; then
 fi
 echo "Test with deepseek_v2 + inc dynamic quantization + tp 2 successful"
 
-# Chendi: commenting out dyamic scaling test, as it is only works on G3 and failed on G2
-# Don't delete them, once we have G3 CI node, we can enable it.
+# QWEN3 + blockfp8 + dynamic scaling
+echo "Testing Qwen3-8B-FP8 + blockfp8 + dynamic scaling"
+echo HABANA_VISIBLE_DEVICES=all VLLM_CONTIGUOUS_PA=False VLLM_SKIP_WARMUP=true PT_HPU_LAZY_MODE=1 VLLM_USE_V1=1 python -u vllm-gaudi/tests/full_tests/generate.py --model Qwen/Qwen3-8B-FP8 --trust-remote-code
+HABANA_VISIBLE_DEVICES=all VLLM_CONTIGUOUS_PA=False VLLM_SKIP_WARMUP=true PT_HPU_LAZY_MODE=1 VLLM_USE_V1=1 python -u vllm-gaudi/tests/full_tests/generate.py --model Qwen/Qwen3-8B-FP8 --trust-remote-code
+if [ $? -ne 0 ]; then
+    echo "Error: Test failed for Qwen3-8B-FP8 + blockfp8 + dynamic scaling" >&2
+    exit -1
+fi
+echo "Test with Qwen3-8B-FP8 + blockfp8 + dynamic scaling successful"
 
-# # QWEN3 + blockfp8 + dynamic scaling
-# echo "Testing Qwen3-8B-FP8 + blockfp8 + dynamic scaling"
-# echo HABANA_VISIBLE_DEVICES=all VLLM_CONTIGUOUS_PA=False VLLM_SKIP_WARMUP=true PT_HPU_LAZY_MODE=1 VLLM_USE_V1=1 python -u vllm-gaudi/tests/full_tests/generate.py --model Qwen/Qwen3-8B-FP8 --trust-remote-code
-# HABANA_VISIBLE_DEVICES=all VLLM_CONTIGUOUS_PA=False VLLM_SKIP_WARMUP=true PT_HPU_LAZY_MODE=1 VLLM_USE_V1=1 python -u vllm-gaudi/tests/full_tests/generate.py --model Qwen/Qwen3-8B-FP8 --trust-remote-code
-# if [ $? -ne 0 ]; then
-#     echo "Error: Test failed for Qwen3-8B-FP8 + blockfp8 + dynamic scaling" >&2
-#     exit -1
-# fi
-# echo "Test with Qwen3-8B-FP8 + blockfp8 + dynamic scaling successful"
-
-# # QWEN3 compressed tensor + dynamic scaling
-# echo "Testing Qwen3-8B-FP8-dynamic + compressed-tensor + dynamic scaling"
-# echo HABANA_VISIBLE_DEVICES=all VLLM_CONTIGUOUS_PA=False VLLM_SKIP_WARMUP=true PT_HPU_LAZY_MODE=1 VLLM_USE_V1=1 python -u vllm-gaudi/tests/full_tests/generate.py --model RedHatAI/Qwen3-8B-FP8-dynamic --trust-remote-code
-# HABANA_VISIBLE_DEVICES=all VLLM_CONTIGUOUS_PA=False VLLM_SKIP_WARMUP=true PT_HPU_LAZY_MODE=1 VLLM_USE_V1=1 python -u vllm-gaudi/tests/full_tests/generate.py --model RedHatAI/Qwen3-8B-FP8-dynamic --trust-remote-code
-# if [ $? -ne 0 ]; then
-#     echo "Error: Test failed for Qwen3-8B-FP8-dynamic + compressed-tensor + dynamic scaling" >&2
-#     exit -1
-# fi
-# echo "Test with Qwen3-8B-FP8-dynamic + compressed-tensor + dynamic scaling successful"
+# QWEN3 compressed tensor + dynamic scaling
+echo "Testing Qwen3-8B-FP8-dynamic + compressed-tensor + dynamic scaling"
+echo HABANA_VISIBLE_DEVICES=all VLLM_CONTIGUOUS_PA=False VLLM_SKIP_WARMUP=true PT_HPU_LAZY_MODE=1 VLLM_USE_V1=1 python -u vllm-gaudi/tests/full_tests/generate.py --model RedHatAI/Qwen3-8B-FP8-dynamic --trust-remote-code
+HABANA_VISIBLE_DEVICES=all VLLM_CONTIGUOUS_PA=False VLLM_SKIP_WARMUP=true PT_HPU_LAZY_MODE=1 VLLM_USE_V1=1 python -u vllm-gaudi/tests/full_tests/generate.py --model RedHatAI/Qwen3-8B-FP8-dynamic --trust-remote-code
+if [ $? -ne 0 ]; then
+    echo "Error: Test failed for Qwen3-8B-FP8-dynamic + compressed-tensor + dynamic scaling" >&2
+    exit -1
+fi
+echo "Test with Qwen3-8B-FP8-dynamic + compressed-tensor + dynamic scaling successful"
 
 # structured output
 echo "Testing structured output"

--- a/vllm_gaudi/extension/ops.py
+++ b/vllm_gaudi/extension/ops.py
@@ -698,12 +698,26 @@ def dynamic_quant(data, single_scale = False):
         data, 1.0 / scale, False, False, torch.float8_e4m3fn)[0]
     return data_fp8, scale.float()
 
+def gaudi_weight_wrapper(weight_loader):
+    """Wrapper for Gaudi weight conversion."""
+
+    def wrapper(*args, **kwargs):
+        # args[0] is parameter, args[1] is loaded_weight
+        # weights will be always in fp8, but scales will be in fp32,
+        # so we can detect it by dtype
+        loaded_weight = args[1]
+        if loaded_weight.dtype == torch.float8_e4m3fn:
+            loaded_weight = (loaded_weight.float() * 0.5).to(
+                torch.float8_e4m3fn)
+        else:
+            loaded_weight = (loaded_weight.data * 2.0)
+        args = (args[0], loaded_weight) + args[2:]
+
+        weight_loader(*args, **kwargs)
+
+    return wrapper
 
 def fp8_block_linear_postprocess_weights(layer, force_channel_fp8=False):
-    torch.hpu.synchronize()
-    if torch.isnan(layer.weight.data).any():
-        raise ValueError("NaN detected in weights. Please use the flag VLLM_HPU_CONVERT_TO_FP8UZ to convert it at runtime or" \
-        " convert the weights using scripts/deepseek_gaudi2 from vllm-hpu-extension")
     weight, orig_M, orig_N = pad_block_fp8_weight_naive(
         layer.weight.data,
         layer.weight_scale_inv.data,

--- a/vllm_gaudi/ops/hpu_fp8.py
+++ b/vllm_gaudi/ops/hpu_fp8.py
@@ -18,6 +18,9 @@ from vllm_gaudi.extension.ops import (VllmMixtureOfExpertsOpFP8PerChannel,
 class Fp8LinearMethod(OrigFp8LinearMethod):
 
     def create_weights(self, *args, **kwargs) -> None:
+        if hpu_ops.is_hpu_gaudi2:
+            kwargs['weight_loader'] = hpu_ops.gaudi_weight_wrapper(
+                kwargs.get('weight_loader'))
         super().create_weights(*args, **kwargs)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
@@ -66,6 +69,12 @@ class HPUFp8MoEMethod(Fp8MoEMethod):
         self.allow_deep_gemm = False
 
         self.topk_indices_dtype = None
+
+    def create_weights(self, *args, **kwargs) -> None:
+        if hpu_ops.is_hpu_gaudi2:
+            kwargs['weight_loader'] = hpu_ops.gaudi_weight_wrapper(
+                kwargs.get('weight_loader'))
+        super().create_weights(*args, **kwargs)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         num_experts = layer.local_num_experts


### PR DESCRIPTION
Now both compressed_tensor / blockfp8 gets correct result

* block fp8 model
```
VLLM_SKIP_WARMUP=true VLLM_CONTIGUOUS_PA=False PT_HPU_LAZY_MODE=1 \
lm_eval   --model vllm --tasks gsm8k --num_fewshot 5 --batch_size 128 \
--model_args "pretrained=Qwen/Qwen3-8B-FP8,tensor_parallel_size=1,trust_remote_code=true,max_model_len=4096,dtype=bfloat16" 
```

vllm (pretrained=Qwen/Qwen3-8B-FP8,tensor_parallel_size=1,trust_remote_code=true,max_model_len=4096,dtype=bfloat16), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: 128
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8772|±  |0.0090|
|     |       |strict-match    |     5|exact_match|↑  |0.8741|±  |0.0091|


* compressed-tensor
```
VLLM_SKIP_WARMUP=true VLLM_CONTIGUOUS_PA=False PT_HPU_LAZY_MODE=1 \
lm_eval \
  --model vllm --tasks gsm8k --num_fewshot 5 --batch_size 128 \
  --model_args "pretrained=RedHatAI/Qwen3-8B-FP8-dynamic,tensor_parallel_size=1,trust_remote_code=true,max_model_len=4096,dtype=bfloat16"  
```
2025-08-29:05:34:04 INFO     [loggers.evaluation_tracker:280] Output path not provided, skipping saving results aggregated
vllm (pretrained=RedHatAI/Qwen3-8B-FP8-dynamic,tensor_parallel_size=1,trust_remote_code=true,max_model_len=4096,dtype=bfloat16), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: 128
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8810|±  |0.0089|
|     |       |strict-match    |     5|exact_match|↑  |0.8757|±  |0.0091|

