### PR TITLE
fix qwen3-30B-A3B-FP8 - The number of dims cannot be packed into CompleteArgumentSpec:65535 

### DIFF
--- a/vllm_gaudi/extension/ops.py
+++ b/vllm_gaudi/extension/ops.py
@@ -717,6 +717,15 @@ def gaudi_weight_wrapper(weight_loader):
 
     return wrapper
 
+def synced_weight_loader(weight_loader):
+    """Wrapper for Gaudi weight conversion."""
+
+    def wrapper(*args, **kwargs):
+        weight_loader(*args, **kwargs)
+        torch.hpu.synchronize()
+
+    return wrapper
+
 def fp8_block_linear_postprocess_weights(layer, force_channel_fp8=False):
     weight, orig_M, orig_N = pad_block_fp8_weight_naive(
         layer.weight.data,

--- a/vllm_gaudi/ops/hpu_fp8.py
+++ b/vllm_gaudi/ops/hpu_fp8.py
@@ -21,6 +21,8 @@ class Fp8LinearMethod(OrigFp8LinearMethod):
         if hpu_ops.is_hpu_gaudi2:
             kwargs['weight_loader'] = hpu_ops.gaudi_weight_wrapper(
                 kwargs.get('weight_loader'))
+        kwargs['weight_loader'] = hpu_ops.synced_weight_loader(
+            kwargs.get('weight_loader'))
         super().create_weights(*args, **kwargs)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
@@ -74,6 +76,8 @@ class HPUFp8MoEMethod(Fp8MoEMethod):
         if hpu_ops.is_hpu_gaudi2:
             kwargs['weight_loader'] = hpu_ops.gaudi_weight_wrapper(
                 kwargs.get('weight_loader'))
+        kwargs['weight_loader'] = hpu_ops.synced_weight_loader(
+            kwargs.get('weight_loader'))
         super().create_weights(*args, **kwargs)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:


### PR DESCRIPTION
This PR is on top of #112 

With the fix, we can run qwen3-30B-A3B-FP8 successfully on G2 and G3 now

```

 VLLM_SKIP_WARMUP=true VLLM_CONTIGUOUS_PA=False PT_HPU_LAZY_MODE=1 lm_eval   --model vllm --tasks gsm8k --num_fewshot 5 --batch_size 128 --model_args "pretrained=Qwen/Qwen3-30B-A3B-FP8,tensor_parallel_size=1,trust_remote_code=true,max_model_len=4096,dtype=bfloat16" 

```

2025-08-29:06:12:48 INFO     [loggers.evaluation_tracker:280] Output path not provided, skipping saving results aggregated
vllm (pretrained=Qwen/Qwen3-30B-A3B-FP8,tensor_parallel_size=1,trust_remote_code=true,max_model_len=4096,dtype=bfloat16), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: 128
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8711|±  |0.0092|
|     |       |strict-match    |     5|exact_match|↑  |0.8908|±  |0.0086| 
 

