### PR TITLE
[Bucketing] WA for warmup big values - crash

### DIFF
--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -2497,6 +2497,8 @@ class HPUModelRunner:
             prompt_ctx_len = prompt_blocks * self.block_size
             prompt_total_tokens = prompt_query_len + prompt_ctx_len
             for _ in range(prompt_bs):
+                if prompt_total_tokens > self.max_model_len:
+                    continue
                 self._add_dummy_request(requests,
                                         scheduled_tokens,
                                         num_computed_tokens=prompt_ctx_len,


### PR DESCRIPTION
WA for when our query = max_model_len and as we take one context above we end up with too big config.
Temp WA, buckets will be filtered out in: https://github.com/vllm-project/vllm-gaudi/pull/104