### PR TITLE
Enable synchronized weight loader

### DIFF
--- a/vllm_gaudi/__init__.py
+++ b/vllm_gaudi/__init__.py
@@ -1,13 +1,10 @@
 from vllm_gaudi.platform import HpuPlatform
-import os
 
 
 def register():
     """Register the HPU platform."""
     HpuPlatform.set_torch_compile()
-    if os.getenv("VLLM_WEIGHT_LOAD_FORCE_SYNC",
-                 "false").lower() in ("true", "1"):
-        HpuPlatform.set_synchronized_weight_loader()
+    HpuPlatform.set_synchronized_weight_loader()
     return "vllm_gaudi.platform.HpuPlatform"
 
 


### PR DESCRIPTION
After discussion it was agreed that we should do synchronized loading always, aligning the behavior with V0.