### PR TITLE
port fused const norm blocksoftmax to vllm-gaudi

### DIFF
--- a/vllm_gaudi/attention/backends/hpu_attn.py
+++ b/vllm_gaudi/attention/backends/hpu_attn.py
@@ -13,7 +13,8 @@ import torch
 import vllm_gaudi.extension.kernels as kernels
 import vllm_gaudi.extension.ops as ops
 from vllm_gaudi.extension.runtime import get_config
-from vllm_gaudi.extension.utils import (FP8Matmul, Matmul, ModuleFusedSDPA, Softmax, VLLMFP8KVCache, VLLMKVCache)
+from vllm_gaudi.extension.utils import (FP8Matmul, Matmul, ModuleFusedSDPA, Softmax, VLLMFP8KVCache, VLLMKVCache,
+                                        BlockSoftmaxConstMax)
 
 from vllm.attention.backends.abstract import (AttentionBackend, AttentionImpl, AttentionLayer, AttentionMetadata,
                                               AttentionType)

--- a/vllm_gaudi/attention/backends/hpu_attn.py
+++ b/vllm_gaudi/attention/backends/hpu_attn.py
@@ -379,8 +379,7 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
         HPUFusedSDPA = kernels.fsdpa()
         self.fused_scaled_dot_product_attention = None if HPUFusedSDPA is None \
             else ModuleFusedSDPA(HPUFusedSDPA)
-        # self.block_softmax_max_const = BlockSoftmaxConstMax()
-        self.block_softmax_max_const = None
+        self.block_softmax_max_const = BlockSoftmaxConstMax()
         self.prefill_impl = get_config().prompt_attn_impl
         self.use_contiguous_pa = get_config().use_contiguous_pa
         self.use_merged_prefill = get_config().merged_prefill

--- a/vllm_gaudi/attention/backends/hpu_attn.py
+++ b/vllm_gaudi/attention/backends/hpu_attn.py
@@ -379,6 +379,8 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
         HPUFusedSDPA = kernels.fsdpa()
         self.fused_scaled_dot_product_attention = None if HPUFusedSDPA is None \
             else ModuleFusedSDPA(HPUFusedSDPA)
+        # self.block_softmax_max_const = BlockSoftmaxConstMax()
+        self.block_softmax_max_const = None
         self.prefill_impl = get_config().prompt_attn_impl
         self.use_contiguous_pa = get_config().use_contiguous_pa
         self.use_merged_prefill = get_config().merged_prefill
@@ -509,8 +511,8 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
             if (attn_metadata.block_list is None and self.prompt_position_bias is not None
                     and self.alibi_slopes is not None):
                 assert attn_bias is not None, \
-                        'attn_bias must be set before calling ' \
-                        'model.forward with alibi biases'
+                    'attn_bias must be set before calling ' \
+                    'model.forward with alibi biases'
                 slice_1_size = attn_bias.size(-2)
                 slice_2_size = attn_bias.size(-1)
                 if self.max_seq_len >= max(slice_1_size, slice_2_size):
@@ -592,6 +594,7 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
             'keys_fetch_func': self.k_cache.fetch_from_cache,
             'values_fetch_func': self.v_cache.fetch_from_cache,
             'softmax_op': self.softmax,
+            'block_softmax_max_const_op': self.block_softmax_max_const,
             'block_list': block_list,
             'key_cache': key_cache,
             'value_cache': value_cache,
@@ -705,7 +708,7 @@ def _make_prompt_alibi_bias(
     bias = torch.arange(seq_len, dtype=dtype, device=alibi_slopes.device)
     bias = bias[None, :] - bias[:, None]  # Shape: [seq_len, seq_len]
 
-    #padded_len = (seq_len + 7) // 8 * 8
+    # padded_len = (seq_len + 7) // 8 * 8
     num_heads = alibi_slopes.shape[0]
     per_head_bias = torch.empty(
         1,

--- a/vllm_gaudi/extension/features.py
+++ b/vllm_gaudi/extension/features.py
@@ -82,5 +82,7 @@ def get_features():
         Value('dynamic_shapes_compilation', True, env_var='VLLM_T_COMPILE_DYNAMIC_SHAPES', env_var_type=boolean),
         Value('fullgraph_compilation', False, env_var='VLLM_T_COMPILE_FULLGRAPH', env_var_type=boolean),
         Value('unified_attn', False),
+        Value('const_norm_value', 10.0, env_var='VLLM_SOFTMAX_CONST_NORM_VALUE'),
+        Value('fused_block_softmax_with_const_max', False, env_var='VLLM_FUSED_BLOCK_SOFTMAX_WITH_CONST_MAX'),
     ]
     return split_values_and_flags(features)

--- a/vllm_gaudi/extension/ops.py
+++ b/vllm_gaudi/extension/ops.py
@@ -106,9 +106,7 @@ def pipelined_pa(attn, value, block_bias, block_groups, block_mapping, batch_siz
 def pa_block_softmax_with_const_max(attn, value, block_bias, block_groups, block_mapping, batch_size, matmul_av_op,
                                     batch2block_matmul_op, block2batch_matmul_op, block_softmax_max_const_op):
     const_norm_value = get_config().const_norm_value
-    # print(f"ops attn dtype: {attn.dtype}, block_bias dtype: {block_bias.dtype}, block_groups dtype: {block_groups.dtype}, batch_size: {batch_size}, const_norm_value: {const_norm_value}")
-    # attn = block_softmax_max_const_op(attn, block_bias, block_groups, batch_size, const_norm_value)
-    attn = torch.ops.hpu.block_softmax_const_max(attn, block_bias, block_groups, batch_size, const_norm_value)
+    attn = block_softmax_max_const_op(attn, block_bias, block_groups, batch_size, const_norm_value)
     attn = matmul_av_op(attn, value)
     return attn
 

--- a/vllm_gaudi/extension/utils.py
+++ b/vllm_gaudi/extension/utils.py
@@ -175,3 +175,12 @@ def with_default(value: Optional[Any], default: Any) -> Any:
     if value is not None:
         return value
     return default
+
+
+class BlockSoftmaxConstMax(torch.nn.Module):
+
+    def __init__(self):
+        super(BlockSoftmaxConstMax, self).__init__()
+
+    def forward(self, attn, block_bias, block_groups, batch_size, const_norm_value):
+        return torch.ops.hpu.block_softmax_const_max(attn, block_bias, block_groups, batch_size, const_norm_value)

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -3045,6 +3045,9 @@ class HPUModelRunner:
         num_candidates = len(buckets)
         captured_all = True
         for idx, (batch_size, seq_len, num_blocks) in enumerate(reversed(buckets)):
+            if seq_len > self.max_num_tokens:
+                captured_all = False
+                continue
             # Graph memory usage is proportional to seq dimension in a batch
             phase = f"Graph/{'prompt' if is_prompt else 'decode'}"
             if is_prompt:


### PR DESCRIPTION
SW-240342 - pending on TPC kernel shows on engineering build image.
Tested on 
```
1.23.0/ubuntu24.04/habanalabs/pytorch-installer-2.8.0:1.23.0-326 
```

Seems the TPC kernel is not there, Got error saying:
```
(EngineCore_DP0 pid=9330) ERROR 09-11 01:42:31 [core.py:720]   File "/.../dev/vllm-gaudi/vllm_gaudi/extension/utils.py", line 186, in forward
(EngineCore_DP0 pid=9330) ERROR 09-11 01:42:31 [core.py:720]     return torch.ops.hpu.block_softmax_const_max(attn, block_bias, block_groups, batch_size, const_norm_value)
(EngineCore_DP0 pid=9330) ERROR 09-11 01:42:31 [core.py:720]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=9330) ERROR 09-11 01:42:31 [core.py:720]   File "/usr/local/lib/python3.12/dist-packages/torch/_ops.py", line 1243, in __call__
(EngineCore_DP0 pid=9330) ERROR 09-11 01:42:31 [core.py:720]     return self._op(*args, **kwargs)
(EngineCore_DP0 pid=9330) ERROR 09-11 01:42:31 [core.py:720]            ^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=9330) ERROR 09-11 01:42:31 [core.py:720] RuntimeError: block_softmax_const_max is not yet supported on HPU. 
```