### PR TITLE
[TEMP-WA] Skip Qwen3-30B-A3B in tests - Bug introduced in upstream #24772 

### DIFF
--- a/tests/full_tests/ci_gsm8k_tests.sh
+++ b/tests/full_tests/ci_gsm8k_tests.sh
@@ -153,16 +153,16 @@ fi
 echo "Test with deepseek R1 passed"
 
 # used to check HPUATTN + MOE + ExpertParallel
-echo "Testing GSM8K on QWEN3-30B-A3B"
-echo VLLM_CONTIGUOUS_PA=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=1 VLLM_USE_V1=1 TP_SIZE=2 \
-pytest -v -s vllm-gaudi/tests/models/language/generation/test_common.py --model_card_path vllm-gaudi/tests/full_tests/model_cards/Qwen3-30B-A3B.yaml
-VLLM_CONTIGUOUS_PA=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=1 VLLM_USE_V1=1 TP_SIZE=2 \
-pytest -v -s vllm-gaudi/tests/models/language/generation/test_common.py --model_card_path vllm-gaudi/tests/full_tests/model_cards/Qwen3-30B-A3B.yaml
-if [ $? -ne 0 ]; then
-    echo "Error: Test failed for QWEN3-30B-A3B" >&2
-    exit -1
-fi
-echo "Test with QWEN3-30B-A3B passed"
+# echo "Testing GSM8K on QWEN3-30B-A3B"
+# echo VLLM_CONTIGUOUS_PA=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=1 VLLM_USE_V1=1 TP_SIZE=2 \
+# pytest -v -s vllm-gaudi/tests/models/language/generation/test_common.py --model_card_path vllm-gaudi/tests/full_tests/model_cards/Qwen3-30B-A3B.yaml
+# VLLM_CONTIGUOUS_PA=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=1 VLLM_USE_V1=1 TP_SIZE=2 \
+# pytest -v -s vllm-gaudi/tests/models/language/generation/test_common.py --model_card_path vllm-gaudi/tests/full_tests/model_cards/Qwen3-30B-A3B.yaml
+# if [ $? -ne 0 ]; then
+#     echo "Error: Test failed for QWEN3-30B-A3B" >&2
+#     exit -1
+# fi
+# echo "Test with QWEN3-30B-A3B passed"
 
 # multimodal-support with qwen2.5-vl
 echo "Testing Qwen2.5-VL-7B"


### PR DESCRIPTION
- After [#24772](https://github.com/vllm-project/vllm/pull/24772), there's a bug in `Qwen3MoeSparseMoeBlock` forward call (assertion for 2d max hidden_state dims)
- An issue has been created pending resolution [#24806](https://github.com/vllm-project/vllm/issues/24806)
- Re-enable once resolved in upstream