### PR TITLE
Fix sed command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > This is an early developer preview of the vLLM Gaudi Plugin and is not yet intended for general use. For a more stable experience, consider using the [HabanaAI/vllm-fork](https://github.com/HabanaAI/vllm-fork) or the in-tree Gaudi implementation available in [vllm-project/vllm](https://github.com/vllm-project/vllm).
 
 # Welcome to vLLM x Intel Gaudi
@@ -15,11 +15,11 @@ This plugin follows the [[RFC]: Hardware pluggable](https://github.com/vllm-proj
 
 Learn more:
 
-📚 [Intel Gaudi Documentation](https://docs.habana.ai/en/v1.21.1/index.html)  
+📚 [Intel Gaudi Documentation](https://docs.habana.ai/en/v1.21.1/index.html)
 🚀 [vLLM Plugin System Overview](https://docs.vllm.ai/en/latest/design/plugin_system.html)
 
 ## Getting Started
-1. Install vLLM with `pip` or [from source](https://docs.vllm.ai/en/latest/getting_started/installation/gpu/index.html#build-wheel-from-source):  
+1. Install vLLM with `pip` or [from source](https://docs.vllm.ai/en/latest/getting_started/installation/gpu/index.html#build-wheel-from-source):
 
     ```bash
     pip install vllm
@@ -31,7 +31,7 @@ Learn more:
     # Build vLLM from source for empty platform, reusing existing torch installation
     git clone https://github.com/vllm-project/vllm
     cd vllm
-    pip install -r <(sed '/^[torch]/d' requirements/build.txt)
+    pip install -r <(sed '/^torch/d' requirements/build.txt)
     VLLM_TARGET_DEVICE=empty pip install --no-build-isolation -e .
     cd ..
     ```
@@ -50,7 +50,7 @@ Learn more:
 # Build vLLM from source for empty platform, reusing existing torch installation
 git clone https://github.com/vllm-project/vllm
 cd vllm
-pip install -r <(sed '/^[torch]/d' requirements/build.txt)
+pip install -r <(sed '/^torch/d' requirements/build.txt)
 VLLM_TARGET_DEVICE=empty pip install --no-build-isolation -e .
 cd ..
 


### PR DESCRIPTION
the command sed '/^[torch]/d' requirements/build.txt instructs sed to delete any line in the file requirements/build.txt that starts with the character t, o, r, c, or h.

However, it's likely intended to match the literal string "torch" at the beginning of the line. The correct regular expression for that would be ^torch.