### PR TITLE
Fix dp sync after upstream change #24105

### DIFF
--- a/tests/full_tests/ci_gsm8k_tests.sh
+++ b/tests/full_tests/ci_gsm8k_tests.sh
@@ -209,13 +209,12 @@ if [ $? -ne 0 ]; then
 fi
 echo "Embedding-model-support for v1 successful"
 
-# Data Parallel failed with recent upstream changes
-# # DP2
-# echo "Testing data parallel size 2 with vllm-hpu plugin v1"
-# echo HABANA_VISIBLE_DEVICES=all VLLM_SKIP_WARMUP=true PT_HPU_LAZY_MODE=1 VLLM_USE_V1=1 python -u vllm-gaudi/examples/data_parallel.py --dp-size 2 --tp-size 2
-# HABANA_VISIBLE_DEVICES=all VLLM_SKIP_WARMUP=true PT_HPU_LAZY_MODE=1 VLLM_USE_V1=1 python -u vllm-gaudi/examples/data_parallel.py --dp-size 2 --tp-size 2
-# if [ $? -ne 0 ]; then
-#     echo "Error: Test failed for data parallel size 2" >&2
-#     exit -1
-# fi
-# echo "Test with data parallel size 2 passed"
+# DP2
+echo "Testing data parallel size 2 with vllm-hpu plugin v1"
+echo HABANA_VISIBLE_DEVICES=all VLLM_SKIP_WARMUP=true PT_HPU_LAZY_MODE=1 VLLM_USE_V1=1 python -u vllm-gaudi/examples/data_parallel.py --dp-size 2 --tp-size 2
+HABANA_VISIBLE_DEVICES=all VLLM_SKIP_WARMUP=true PT_HPU_LAZY_MODE=1 VLLM_USE_V1=1 python -u vllm-gaudi/examples/data_parallel.py --dp-size 2 --tp-size 2
+if [ $? -ne 0 ]; then
+    echo "Error: Test failed for data parallel size 2" >&2
+    exit -1
+fi
+echo "Test with data parallel size 2 passed"

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -2240,9 +2240,7 @@ class HPUModelRunner(KVConnectorModelRunnerMixin):
         self._check_config(batch_size, seq_len, num_blocks, attn_metadata, warmup_mode)
         additional_kwargs = {}
         if htorch.utils.internal.is_lazy():
-            use_graphs = self._use_graphs()
-            if self.model_config.enforce_eager:
-                additional_kwargs.update({"bypass_hpu_graphs": not use_graphs})
+            additional_kwargs.update({"bypass_hpu_graphs": not self._use_graphs()})
         else:
             # no hpu graphs for t.compile?
             use_graphs = False

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -2240,7 +2240,8 @@ class HPUModelRunner(KVConnectorModelRunnerMixin):
         self._check_config(batch_size, seq_len, num_blocks, attn_metadata, warmup_mode)
         additional_kwargs = {}
         if htorch.utils.internal.is_lazy():
-            additional_kwargs.update({"bypass_hpu_graphs": not self._use_graphs()})
+            use_graphs = self._use_graphs()
+            additional_kwargs.update({"bypass_hpu_graphs": not use_graphs})
         else:
             # no hpu graphs for t.compile?
             use_graphs = False


### PR DESCRIPTION
- fix behavior of Lazy + `enforce_eager` in which case hpu graph is NOT used
- disable device group for dp sync when hpu graph is used
- enable DP CI test again 