### PR TITLE
Specify output tensor in matmul_qk

### DIFF
--- a/vllm_gaudi/extension/ops.py
+++ b/vllm_gaudi/extension/ops.py
@@ -52,6 +52,14 @@ def block2batch(tensor, block_mapping, matmul_op=torch.matmul):
     return b2b_impl(tensor, block_mapping.t(), matmul_op)
 
 
+def matmul_shape(lhs, rhs):
+    lhs_shape = list(lhs.shape)
+    rhs_shape = list(rhs.shape)
+    common_shape = [max(left, right) for left, right in zip(lhs_shape[:-2], rhs_shape[:-2])]
+    result = common_shape + [lhs_shape[-2]] + [rhs_shape[-1]]
+    return result
+
+
 def pipelined_pa(attn, value, block_bias, block_groups, block_mapping, batch_size, matmul_av_op, batch2block_matmul_op,
                  block2batch_matmul_op):
     # When fp32_softmax is enabled attn is left in fp32 after Q@K
@@ -133,10 +141,10 @@ def flat_pa_mla(query, key_cache, value_cache, block_list, block_mapping, block_
     else:
         key = key.transpose(2, 3)
 
-    attn = matmul_qk_op(query, key)
+    attn = None
     if get_config().fp32_softmax:
-        attn = attn.float()
-        htcore.mark_step()
+        attn = torch.empty(matmul_shape(query, key), dtype=torch.float32, device=query.device)
+    attn = matmul_qk_op(query, key, out=attn)
 
     attn = pipelined_pa(attn,
                         value,
@@ -176,12 +184,12 @@ def flat_pa(query, key_cache, value_cache, block_list, block_mapping, block_bias
             block_bias = block_bias.unsqueeze(2)
     key = key.transpose(-2, -1)
 
-    attn = matmul_qk_op(query, key)
+    attn = None
     if get_config().fp32_softmax:
-        attn = attn.float()
-        htcore.mark_step()
+        attn = torch.empty(matmul_shape(query, key), dtype=torch.float32, device=query.device)
         if position_bias is not None:
             position_bias = position_bias.float()
+    attn = matmul_qk_op(query, key, out=attn)
     if position_bias is not None:
         if attn.dtype != position_bias.dtype:
             attn = attn.to(dtype=position_bias.dtype)

--- a/vllm_gaudi/extension/utils.py
+++ b/vllm_gaudi/extension/utils.py
@@ -26,8 +26,8 @@ class Matmul(torch.nn.Module):
     def __init__(self):
         super(Matmul, self).__init__()
 
-    def forward(self, x, y):
-        return torch.matmul(x, y)
+    def forward(self, x, y, **kwargs):
+        return torch.matmul(x, y, **kwargs)
 
 
 class Softmax(torch.nn.Module):


### PR DESCRIPTION
Some models (like Qwen) require softmax to be executed in fp32 precision. In the past, we were explicitly casted `matmul_qk` output. Such solution requires `mark_step` to ensure cast will be executed, which breaks graph and could affect performance.
This PR provides solution with specifying output tensor in `torch.matmul`, so we can avoid `mark_step`.

Original idea: https://github.com/HabanaAI/vllm-hpu-extension/commit/ad671aa71efcfbdc31c55115c39824ce79c75d3d