### PR TITLE
Remove sync point from _prepare_sampling

### DIFF
--- a/vllm_gaudi/utils.py
+++ b/vllm_gaudi/utils.py
@@ -58,6 +58,19 @@ def async_h2d_copy(source, dest_tensor=None, dtype=None, device='hpu'):
     return cpu_tensor.to(device, non_blocking=True)
 
 
+def async_h2d_update(source: torch.Tensor, dest: torch.Tensor, indices: list[int], device='hpu'):
+    """
+    Asynchronously update specific rows of a device tensor from a CPU tensor.
+
+    Args:
+        source: CPU tensor with data to copy
+        dest: Device tensor to update
+        indices: List of row indices in dest to update
+        device: Target device
+    """
+    dest[indices] = source[indices].to(device, non_blocking=True)
+
+
 def make_ndarray_with_pad_align(
     x: list[list[T]],
     pad: T,

--- a/vllm_gaudi/v1/worker/hpu_input_batch.py
+++ b/vllm_gaudi/v1/worker/hpu_input_batch.py
@@ -570,21 +570,23 @@ class InputBatch:
         skip_copy: bool = False,
     ) -> SamplingMetadata:
         req_indices: list[int] = [self.req_id_to_index[req_id] for req_id, _ in req_id_output_token_ids]
+
+        def async_h2d_update(tensor_cpu: torch.Tensor, tensor: torch.Tensor) -> None:
+            # Using in-place .copy_ triggers a sync point.
+            tensor[req_indices] = tensor_cpu[req_indices].to(self.device, non_blocking=True)
+
         prompt_token_ids = None
         if not skip_copy:
-            self.temperature[req_indices].copy_(self.temperature_cpu_tensor[req_indices], non_blocking=True)
-            self.top_p[req_indices].copy_(self.top_p_cpu_tensor[req_indices], non_blocking=True)
-            self.top_k[req_indices].copy_(self.top_k_cpu_tensor[req_indices], non_blocking=True)
+            async_h2d_update(self.temperature_cpu_tensor, self.temperature)
+            async_h2d_update(self.top_p_cpu_tensor, self.top_p)
+            async_h2d_update(self.top_k_cpu_tensor, self.top_k)
             if not self.no_penalties:
                 # Since syncing these tensors is expensive only copy them
                 # if necessary i.e. if there are requests which require
                 # penalties to be applied during sampling.
-                self.frequency_penalties[req_indices].copy_(self.frequency_penalties_cpu_tensor[req_indices],
-                                                            non_blocking=True)
-                self.presence_penalties[req_indices].copy_(self.presence_penalties_cpu_tensor[req_indices],
-                                                           non_blocking=True)
-                self.repetition_penalties[req_indices].copy_(self.repetition_penalties_cpu_tensor[req_indices],
-                                                             non_blocking=True)
+                async_h2d_update(self.frequency_penalties_cpu_tensor, self.frequency_penalties)
+                async_h2d_update(self.presence_penalties_cpu_tensor, self.presence_penalties)
+                async_h2d_update(self.repetition_penalties_cpu_tensor, self.repetition_penalties)
                 # The prompt tokens are used only for applying penalties during
                 # the sampling process. Hence copy these tensors only when
                 # there are requests which need penalties to be applied.
@@ -608,8 +610,7 @@ class InputBatch:
         if not self.no_allowed_token_ids:
             assert self.allowed_token_ids_mask is not None
             assert self.allowed_token_ids_mask_cpu_tensor is not None
-            self.allowed_token_ids_mask[req_indices].copy_(self.allowed_token_ids_mask_cpu_tensor[req_indices],
-                                                           non_blocking=True)
+            async_h2d_update(self.allowed_token_ids_mask_cpu_tensor, self.allowed_token_ids_mask)
             allowed_token_ids_mask = self.allowed_token_ids_mask[req_indices]
         return SamplingMetadata(
             temperature=self.temperature[req_indices],


### PR DESCRIPTION
Using `.copy_()` operator triggers unwanted sync points between prompts. Instead, we can make async copy of CPU tensor and assign it to the destination. 