### PR TITLE
Prevents 'HPUModelRunner' object has no attribute 'graphed_buckets'

### DIFF
--- a/vllm_gaudi/v1/worker/hpu_worker.py
+++ b/vllm_gaudi/v1/worker/hpu_worker.py
@@ -245,7 +245,7 @@ class HPUWorker(WorkerBase):
     def compile_or_warm_up_model(self) -> None:
         # Don't run the warmup if in eager or if the model is already warmed up
         if not self.model_config.enforce_eager \
-            and not self.model_runner.graphed_buckets:
+            and not getattr(self.model_runner, "graphed_buckets", []):
             self.model_runner.warmup_model()
         # Reset the seed to ensure that the random state is not affected by
         # the model initialization and profiling.


### PR DESCRIPTION
When trying to profile workloads on v1 using VLLM_PROFILE_PROMPT env variable, ''HPUModelRunner' object has no attribute 'graphed_buckets'' error is seen.
This patch fixes that.