### PR TITLE
Enable modification of prompt BS

### DIFF
--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -1582,8 +1582,9 @@ class HPUModelRunner(KVConnectorModelRunnerMixin):
         # for the valid tokens before padding.
         # This would require getting multimodal input embeddings here as well
         token_ids = self._align_and_pad(contents.token_ids, (target_bs, target_seq), itertools.repeat(-1))
-        # Update query_lens after padding
+        # Update query_lens and context_lens after padding
         query_lens.extend([0] * (target_bs - len(query_lens)))
+        context_lens.extend([0] * (target_bs - len(context_lens)))
 
         # If the model uses M-RoPE, we need to fill
         # and pad the M-RoPE positions for the scheduled prefill tokens


### PR DESCRIPTION
Enable modification of prefill BS with usage of `VLLM_PROMPT_BS_BUCKET_MAX` environment variable. The default size of prefill BS is set to 1 (remains the same as it was before the change).
cherry-pick: https://github.com/vllm-project/vllm-gaudi/pull/258
