### PR TITLE
Add fused_experts to HPUFp8MoEMethod to fix Deepseek

### DIFF
--- a/vllm_gaudi/ops/hpu_fp8.py
+++ b/vllm_gaudi/ops/hpu_fp8.py
@@ -75,6 +75,7 @@ class HPUFp8MoEMethod(Fp8MoEMethod):
         self.allow_deep_gemm = False
 
         self.topk_indices_dtype = None
+        self.fused_experts = None
 
     def create_weights(self, *args, **kwargs) -> None:
         if hpu_ops.is_hpu_gaudi2:


### PR DESCRIPTION
Currently we will fail on this check in vLLM: https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/layers/fused_moe/layer.py#L1899 as we don't have `fused_experts` argument at all. 