### PR TITLE
Fixing padded iterators in _align_and_pad

### DIFF
--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -1,0 +1,76 @@
+import itertools
+
+import pytest
+
+from vllm_gaudi.extension.utils import align_and_pad
+
+
+@pytest.fixture
+def padding_gen():
+    # Fresh infinite generator of -1 for each test invocation
+    return itertools.repeat(-1)
+
+
+class TestAlignAndPad:
+
+    @staticmethod
+    def _materialize_rows(rows):
+        out = []
+        for r in rows:
+            if isinstance(r, list):
+                out.append(r)
+            else:
+                out.append(list(r))
+        return out
+
+    def test_flatten_and_pad_rows(self, padding_gen):
+        data = [[1, 2], [3]]
+        out = align_and_pad(data, (1, 5), padding_gen)
+        out = self._materialize_rows(out)
+        assert len(out) == 1
+        assert out[0] == [1, 2, 3, -1, -1]
+
+    def test_row_and_batch_padding(self, padding_gen):
+        data = [[1], [2, 3]]
+        out = align_and_pad(data, (4, 3), padding_gen)
+        out_materialized = self._materialize_rows(out)
+        assert len(out_materialized) == 4
+        for row in out_materialized:
+            assert len(row) == 3
+        assert out_materialized[0] == [1, -1, -1]
+        assert out_materialized[1] == [2, 3, -1]
+        # Added rows become identical, sourced from the same padded slice (-1s)
+        assert out_materialized[2] == [-1, -1, -1]
+        assert out_materialized[3] == [-1, -1, -1]
+
+    def test_no_padding_needed(self, padding_gen):
+        data = [[1, 2], [3, 4]]
+        out = align_and_pad(data, (2, 2), padding_gen)
+        out = self._materialize_rows(out)
+        assert out == [[1, 2], [3, 4]]
+
+    def test_only_batch_padding(self, padding_gen):
+        data = [[5, 6]]
+        out = align_and_pad(data, (3, 2), padding_gen)
+        out_materialized = self._materialize_rows(out)
+        assert len(out_materialized) == 3
+        assert out_materialized[0] == [5, 6]
+        assert out_materialized[1] == [-1, -1]
+        assert out_materialized[2] == [-1, -1]
+
+    @pytest.mark.parametrize(
+        "data,bucketing,expected_first,expected_last,expected_shape",
+        [
+            ([[1, 2, 3]], (1, 3), [1, 2, 3], [1, 2, 3], (1, 3)),
+            ([[1, 2, 3]], (2, 5), [1, 2, 3, -1, -1], [-1, -1, -1, -1, -1], (2, 5)),
+        ],
+    )
+    def test_parametrized(self, data, bucketing, expected_first, expected_last, expected_shape, padding_gen):
+        out = align_and_pad(data, bucketing, padding_gen)
+        out_materialized = self._materialize_rows(out)
+        target_bs, target_len = expected_shape
+        assert len(out_materialized) == target_bs
+        assert out_materialized[0] == expected_first
+        assert out_materialized[-1] == expected_last
+        for row in out_materialized:
+            assert len(row) == target_len

--- a/vllm_gaudi/extension/utils.py
+++ b/vllm_gaudi/extension/utils.py
@@ -171,6 +171,17 @@ def pad_list(input, target_len, val_generator):
     return input
 
 
+def align_and_pad(data, bucketing, padding_gen):
+    bs = len(data)
+    target_bs, target_len = bucketing
+    if target_bs == 1 and bs > 1:
+        data = [list(itertools.chain(*data))]
+    data = [pad_list(x, target_len, padding_gen) for x in data]
+    padding = itertools.islice(padding_gen, target_len)
+    data = pad_list(data, target_bs, itertools.tee(padding, target_bs - len(data)))
+    return data
+
+
 def with_default(value: Optional[Any], default: Any) -> Any:
     if value is not None:
         return value

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -23,7 +23,7 @@ from vllm_gaudi.extension.profiler import (HabanaHighLevelProfiler, HabanaMemory
                                            format_bytes, setup_profiler)
 from vllm_gaudi.extension.runtime import finalize_config, get_config
 from vllm_gaudi.extension.unified import (create_unified_batch)
-from vllm_gaudi.extension.utils import pad_list, with_default
+from vllm_gaudi.extension.utils import align_and_pad, pad_list, with_default
 from vllm_gaudi.extension.debug import init_debug_logger
 
 from vllm.attention.backends.abstract import AttentionType
@@ -1536,16 +1536,6 @@ class HPUModelRunner(KVConnectorModelRunnerMixin):
         block_usage = torch.tensor(block_usage, dtype=self.model_config.dtype, device='cpu')
         return block_list, block_groups, block_usage
 
-    def _align_and_pad(self, data, bucketing, padding_gen):
-        bs = len(data)
-        target_bs, target_len = bucketing
-        if target_bs == 1 and bs > 1:
-            data = [list(itertools.chain(*data))]
-        data = [pad_list(x, target_len, padding_gen) for x in data]
-        padding = itertools.islice(padding_gen, target_len)
-        data = pad_list(data, target_bs, itertools.tee(padding, target_bs - len(data)))
-        return data
-
     def _align_and_pad_mrope_positions(self, req_ids: list[str], context_lens: list[int], query_lens: list[int],
                                        bucketing: tuple[int, int], padding_gen: int) -> torch.Tensor:
         target_bs, target_len = bucketing
@@ -1705,7 +1695,7 @@ class HPUModelRunner(KVConnectorModelRunnerMixin):
         # For models with multimodal support, we may want to get embeddings
         # for the valid tokens before padding.
         # This would require getting multimodal input embeddings here as well
-        token_ids = self._align_and_pad(contents.token_ids, (target_bs, target_seq), itertools.repeat(-1))
+        token_ids = align_and_pad(contents.token_ids, (target_bs, target_seq), itertools.repeat(-1))
         # Update query_lens and context_lens after padding
         query_lens.extend([0] * (target_bs - len(query_lens)))
         context_lens.extend([0] * (target_bs - len(context_lens)))
@@ -1722,11 +1712,11 @@ class HPUModelRunner(KVConnectorModelRunnerMixin):
             )
 
         else:
-            token_positions = self._align_and_pad(token_positions, (target_bs, target_seq), itertools.repeat(-1))
-        token_slots = self._align_and_pad(token_slots, (target_bs, target_seq), itertools.repeat(-1))
-        token_groups = self._align_and_pad(token_groups, (target_bs, target_seq), itertools.repeat(-1))
-        context_blocks = self._align_and_pad(context_blocks, (target_bs, target_blocks), itertools.repeat(-1))
-        context_groups = self._align_and_pad(context_groups, (target_bs, target_blocks), itertools.repeat(-1))
+            token_positions = align_and_pad(token_positions, (target_bs, target_seq), itertools.repeat(-1))
+        token_slots = align_and_pad(token_slots, (target_bs, target_seq), itertools.repeat(-1))
+        token_groups = align_and_pad(token_groups, (target_bs, target_seq), itertools.repeat(-1))
+        context_blocks = align_and_pad(context_blocks, (target_bs, target_blocks), itertools.repeat(-1))
+        context_groups = align_and_pad(context_groups, (target_bs, target_blocks), itertools.repeat(-1))
 
         # TODO: cycle through dummy slots and blocks
         # dummy_slots = itertools.cycle(

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -1543,7 +1543,7 @@ class HPUModelRunner(KVConnectorModelRunnerMixin):
             data = [list(itertools.chain(*data))]
         data = [pad_list(x, target_len, padding_gen) for x in data]
         padding = itertools.islice(padding_gen, target_len)
-        data = pad_list(data, target_bs, itertools.repeat(padding))
+        data = pad_list(data, target_bs, itertools.tee(padding, target_bs - len(data)))
         return data
 
     def _align_and_pad_mrope_positions(self, req_ids: list[str], context_lens: list[int], query_lens: list[int],


### PR DESCRIPTION
The iterators we are padding currently to match the buckets are taken from the same object of an iterator `itertools.islice(padding_gen, target_len)`. This is done via `itertools.repeat(padding)` being passed to `pad_list` method, where `padding` is mentioned `islice(...)` object.

This creates an issue, where we can call `next()` on such object only `target_len` number of times. If we are padding only one dimension e.g. from 3 to 4, then it is sufficient for our case. But if we have to pad more than one dimension, then all the concurrent calls to `next` on this generator's objects do not return any value. For example, when padding from 12 to 16 we'll only cover the 13th dimension and any `next()` calls on 14th-16th dimensions will have already emptied iterators.

This change returns independent iterators objects for each padded dimensions, instead of using the same iterator everywhere.