### PR TITLE
{GITHUB ACTION}[BO_ACTION] New action for release branch out

### DIFF
--- a/.github/workflows/create-release-branch.yaml
+++ b/.github/workflows/create-release-branch.yaml
@@ -350,7 +350,7 @@ jobs:
           check_status "Performance Tests" "${{ needs.run_hpu_perf_tests.result }}"
           
           REPORT_BODY+="\n---\n"
-          if [ $FAILED_COUNT -gt 0 ]; then
+          if [ "$FAILED_COUNT" -gt 0 ]; then
             SUBJECT="❌ Build Failed for ${{ needs.prepare-release-branch.outputs.branch_name }}"
             REPORT_BODY+="**Overall Status: FAILED**\n\n"
             REPORT_BODY+="**${FAILED_COUNT} job(s) failed:**\n"
@@ -365,7 +365,7 @@ jobs:
           ${REPORT_BODY}
           EOF
           
-          echo "SUBJECT=$SUBJECT" >> $GITHUB_ENV
+          echo "SUBJECT=$SUBJECT" >> "$GITHUB_ENV"
 
       - name: "Create GitHub Issue with Summary"
         uses: peter-evans/create-issue-from-file@v5

--- a/.github/workflows/create-release-branch.yaml
+++ b/.github/workflows/create-release-branch.yaml
@@ -1,0 +1,348 @@
+# This workflow creates a new release branch, fetches a corresponding vLLM tag,
+# commits the tag's commit ID, and then runs a full suite of tests against the new branch.
+
+name: "Create Release Branch and Set vLLM Commit"
+
+on:
+  # This enables manual triggering of the workflow from the GitHub Actions UI.
+  workflow_dispatch:
+    inputs:
+      branch_name:
+        description: "The new release branch name (e.g., 'releases/v0.11.0')"
+        required: true
+        type: string
+      commit_id:
+        description: "Optional: Specific commit ID on main to branch from. Defaults to latest main."
+        required: false
+        type: string
+
+# Required permissions for creating a branch and pushing a commit.
+permissions:
+  contents: write
+  issues: write # Added permission to allow creating issues
+
+jobs:
+  create-release-branch:
+    name: "Create Release Branch"
+    runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.extract_tag.outputs.tag_name }}
+      commit_id: ${{ steps.get_commit.outputs.commit_id }}
+      branch_name: ${{ github.event.inputs.branch_name }}
+
+    steps:
+      # Step 1: Check out the 'main' branch to use as the base for the new branch.
+      - name: "Checkout the main branch"
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.commit_id || 'main' }}
+
+      # Step 2: Extract the tag name from the branch name input.
+      - name: "Extract Tag Name"
+        id: extract_tag
+        run: |
+          BRANCH_NAME="${{ github.event.inputs.branch_name }}"
+          if [[ "$BRANCH_NAME" != releases/* ]]; then
+            echo "::error::Branch name must follow the 'releases/**' pattern."
+            exit 1
+          fi
+          TAG_NAME="${BRANCH_NAME#releases/}"
+          echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
+          echo "Extracted tag name: $TAG_NAME"
+
+      # Step 3: Fetch the commit ID for the corresponding tag from the remote vLLM repository.
+      - name: "Get vLLM Commit ID for Tag"
+        id: get_commit
+        run: |
+          TAG_NAME="${{ steps.extract_tag.outputs.tag_name }}"
+          VLLM_REPO="https://github.com/vllm-project/vllm.git"
+          echo "Looking up commit ID for tag '$TAG_NAME' in '$VLLM_REPO'..."
+          VLLM_COMMIT_ID=$(git ls-remote "$VLLM_REPO" "refs/tags/$TAG_NAME" | cut -f1)
+          if [ -z "$VLLM_COMMIT_ID" ]; then
+            echo "::error::Could not find tag '$TAG_NAME' in the vLLM repository."
+            exit 1
+          fi
+          echo "Found vLLM commit ID: $VLLM_COMMIT_ID"
+          echo "commit_id=$VLLM_COMMIT_ID" >> "$GITHUB_OUTPUT"
+
+      # Step 4: Configure Git user details for the new commit.
+      - name: "Configure Git"
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      # Step 5: Create the new branch, write the commit ID to a file, and push to the repository.
+      - name: "Commit VLLM_STABLE_COMMIT and Push"
+        run: |
+          git checkout -b "${{ github.event.inputs.branch_name }}"
+          echo "${{ steps.get_commit.outputs.commit_id }}" > VLLM_STABLE_COMMIT
+          echo "Created VLLM_STABLE_COMMIT file."
+          git add VLLM_STABLE_COMMIT
+          git commit -m "Set vLLM stable commit for ${{ steps.extract_tag.outputs.tag_name }}"
+          git push -u origin "${{ github.event.inputs.branch_name }}"
+          echo "✅ Successfully created and pushed branch '${{ github.event.inputs.branch_name }}'."
+
+  setup_and_build:
+    runs-on: hourly-ci
+    needs: [create-release-branch]
+    steps:
+      - name: "Checkout the new release branch"
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.create-release-branch.outputs.branch_name }}
+      - name: Setup Docker environment and build image
+        run: |
+          echo "Attempting to build Docker image..."
+          docker build \
+            --no-cache \
+            --build-arg VLLM_COMMIT_ARG=${{ needs.create-release-branch.outputs.commit_id }} \
+            -t hpu-plugin-v1-${{ needs.create-release-branch.outputs.tag_name }} \
+            -f - . <<EOF
+          FROM vault.habana.ai/gaudi-docker/1.22.0/ubuntu24.04/habanalabs/pytorch-installer-2.7.1:latest
+
+          COPY ./ /workspace/vllm-gaudi
+          WORKDIR /workspace
+
+          ARG VLLM_COMMIT_ARG
+          RUN git clone https://github.com/vllm-project/vllm.git vllm
+          WORKDIR /workspace/vllm
+          RUN git checkout \$VLLM_COMMIT_ARG
+
+          RUN pip install pytest pytest_asyncio pytest-timeout
+          RUN pip install git+https://github.com/EleutherAI/lm-evaluation-harness.git
+
+          ENV no_proxy=localhost,127.0.0.1
+          ENV PT_HPU_ENABLE_LAZY_COLLECTIVES=true
+
+          RUN bash -c 'pip install -r <(sed "/^[torch]/d" requirements/build.txt)'
+          RUN VLLM_TARGET_DEVICE=empty pip install --no-build-isolation .
+
+          RUN python3 -m pip install -e tests/vllm_test_utils
+
+          WORKDIR /workspace/vllm-gaudi
+          RUN pip install -e .
+
+          WORKDIR /workspace
+          RUN ln -s /workspace/vllm/tests /workspace/tests \
+              && ln -s /workspace/vllm/examples /workspace/examples \
+              && ln -s /workspace/vllm/benchmarks /workspace/benchmarks
+          EOF
+          echo "Docker image built successfully."
+
+  run_unit_tests:
+    needs: [create-release-branch, setup_and_build]
+    runs-on: hourly-ci
+    steps:
+      - name: Run pytest in tests/unit_tests
+        run: |
+          EXITCODE=1
+          remove_docker_containers() { docker rm -f hpu-plugin-v1-test-unit-tests-hourly-ci || true; }
+          trap 'remove_docker_containers; exit $EXITCODE;' EXIT
+          remove_docker_containers
+
+          echo "Running HPU plugin v1 unit tests"
+          docker run --rm --runtime=habana --name=hpu-plugin-v1-test-unit-tests-hourly-ci --network=host \
+            -e HABANA_VISIBLE_DEVICES=all \
+            -e HF_HOME=/workspace/hf_cache \
+            -e HF_TOKEN=${{ secrets.HF_TOKEN }} \
+            -v /mnt/hf_cache:/workspace/hf_cache \
+            hpu-plugin-v1-${{ needs.create-release-branch.outputs.tag_name }} \
+            /bin/bash -c "pytest -vvv --timeout=300 --durations=10 --durations-min=1.0 /workspace/vllm-gaudi/tests/unit_tests"
+
+          EXITCODE=$?
+          echo "Test script exited with code: $EXITCODE"
+
+  discover_tests:
+    runs-on: hourly-ci
+    needs: [create-release-branch]
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: "Checkout the new release branch"
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.create-release-branch.outputs.branch_name }}
+      - name: Discover test functions
+        id: set-matrix
+        run: |
+          TEST_FUNCTIONS=$( grep '^run_' ./tests/full_tests/ci_gsm8k_tests.sh | \
+              awk '{print $1}' | \
+              sed 's/()//' | \
+              jq -R . | jq -s -c . )
+
+          echo "Discovered test matrix: $TEST_FUNCTIONS"
+          if [ "$TEST_FUNCTIONS" = "[]" ]; then
+            echo "::error::No test functions were discovered. Failing the workflow."
+            exit 1
+          fi
+          echo "matrix=$TEST_FUNCTIONS" >> "$GITHUB_OUTPUT"
+
+  e2e:
+    needs: [create-release-branch, setup_and_build, discover_tests]
+    runs-on: hourly-ci
+    strategy:
+      fail-fast: false
+      matrix:
+        test_function: ${{ fromJson(needs.discover_tests.outputs.matrix) }}
+
+    steps:
+      - name: Run test suite - ${{ matrix.test_function }}
+        run: |
+          EXITCODE=1
+          CONTAINER_NAME="hpu-plugin-test-${{ matrix.test_function }}-${{ github.run_id }}"
+          remove_docker_containers() { docker rm -f $CONTAINER_NAME || true; }
+          trap 'remove_docker_containers; exit $EXITCODE;' EXIT
+          remove_docker_containers
+
+          echo "Running HPU plugin test: ${{ matrix.test_function }}"
+          docker run --rm --runtime=habana --name=$CONTAINER_NAME --network=host \
+            -e HABANA_VISIBLE_DEVICES=all \
+            -e HF_HOME=/workspace/hf_cache \
+            -e HF_TOKEN=${{ secrets.HF_TOKEN }} \
+            -v /mnt/hf_cache:/workspace/hf_cache \
+            hpu-plugin-v1-${{ needs.create-release-branch.outputs.tag_name }} \
+            /bin/bash "/workspace/vllm-gaudi/tests/full_tests/ci_gsm8k_tests.sh" "${{ matrix.test_function }}"
+
+          EXITCODE=$?
+          echo "Test script exited with code: $EXITCODE"
+
+  run_data_parallel_test:
+    needs: [create-release-branch, setup_and_build]
+    runs-on: hourly-ci
+    steps:
+      - name: Run Data Parallel test
+        run: |
+          EXITCODE=1
+          remove_docker_containers() { docker rm -f hpu-plugin-v1-test-dp-tests-hourly-ci || true; }
+          trap 'remove_docker_containers; exit $EXITCODE;' EXIT
+          remove_docker_containers
+
+          echo "Running HPU plugin v1 dp tests"
+          docker run --rm --runtime=habana --name=hpu-plugin-v1-test-dp-tests-hourly-ci --network=host \
+            -e HABANA_VISIBLE_DEVICES=all \
+            -e HF_HOME=/workspace/hf_cache \
+            -e VLLM_SKIP_WARMUP=true \
+            -e PT_HPU_LAZY_MODE=1 \
+            -e VLLM_USE_V1=1 \
+            -e HF_TOKEN=${{ secrets.HF_TOKEN }} \
+            -v /mnt/hf_cache:/workspace/hf_cache \
+            hpu-plugin-v1-${{ needs.create-release-branch.outputs.tag_name }} \
+            /bin/bash -c "python -u /workspace/vllm-gaudi/examples/data_parallel.py --dp-size 2 --tp-size 2"
+
+          EXITCODE=$?
+          echo "Test script exited with code: $EXITCODE"
+
+  run_pd_disaggregate_test:
+    needs: [create-release-branch, setup_and_build]
+    runs-on: hourly-ci
+    steps:
+      - name: Run PD disaggregate test
+        run: |
+          EXITCODE=1
+          remove_docker_containers() { docker rm -f hpu-plugin-v1-test-pd-tests-hourly-ci || true; }
+          trap 'remove_docker_containers; exit $EXITCODE;' EXIT
+          remove_docker_containers
+
+          echo "Running HPU plugin v1 nixl pd tests"
+          docker run --rm --runtime=habana --name=hpu-plugin-v1-test-pd-tests-hourly-ci --network=host \
+            -e HABANA_VISIBLE_DEVICES=all \
+            -e HF_HOME=/workspace/hf_cache \
+            -e HF_TOKEN=${{ secrets.HF_TOKEN }} \
+            -v /mnt/hf_cache:/workspace/hf_cache \
+            -v /mnt/wheels_cache:/workspace/wheels_cache \
+            hpu-plugin-v1-${{ needs.create-release-branch.outputs.tag_name }} \
+            /bin/bash -c "
+              pip install lm-eval[api] &&
+              cd /workspace/vllm-gaudi/tests/unit_tests &&
+              ./run_accuracy_test.sh
+            "
+          EXITCODE=$?
+          echo "Test script exited with code: $EXITCODE"
+
+  run_hpu_perf_tests:
+    needs: [create-release-branch, setup_and_build]
+    runs-on: hourly-ci
+    steps:
+      - name: Run Sharegpt performance tests with warmup
+        run: |
+          EXITCODE=1
+          CONTAINER_NAME="hpu-plugin-v1-test-perf-tests-${{ github.run_id }}"
+          remove_docker_containers() { docker rm -f $CONTAINER_NAME || true; }
+          trap 'remove_docker_containers; exit $EXITCODE;' EXIT
+          remove_docker_containers
+
+          echo "Running HPU plugin v1 perf tests"
+          docker run --rm --runtime=habana --name=$CONTAINER_NAME --network=host \
+            -e HABANA_VISIBLE_DEVICES=all \
+            -e HF_TOKEN=${{ secrets.HF_TOKEN }} \
+            -e HF_HOME=/workspace/hf_cache \
+            -v /mnt/hf_cache:/workspace/hf_cache \
+            hpu-plugin-v1-${{ needs.create-release-branch.outputs.tag_name }} \
+            /bin/bash "/workspace/vllm-gaudi/tests/full_tests/ci_perf_tests.sh"
+          
+          EXITCODE=$?
+          echo "Test script exited with code: $EXITCODE"
+
+  summarize_and_notify:
+    name: "Summarize Test Results and Notify"
+    runs-on: ubuntu-latest
+    # This job runs after all test jobs, and 'always()' ensures it runs even if tests fail.
+    if: always()
+    needs:
+      - create-release-branch
+      - run_unit_tests
+      - e2e
+      - run_data_parallel_test
+      - run_pd_disaggregate_test
+      - run_hpu_perf_tests
+    steps:
+      - name: "Generate Summary Report"
+        id: summary
+        run: |
+          REPORT_BODY="## Test Summary for : ${{ needs.create-release-branch.outputs.branch_name }}\n\n"
+          REPORT_BODY+="See the full workflow run [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).\n\n"
+          FAILED_TESTS=""
+          FAILED_COUNT=0
+          
+          check_status() {
+            JOB_NAME=$1
+            JOB_RESULT=$2
+            if [ "$JOB_RESULT" == "success" ]; then
+              REPORT_BODY+="✅ $JOB_NAME: Passed\n"
+            else
+              REPORT_BODY+="❌ $JOB_NAME: ${JOB_RESULT^}\n" # Capitalize first letter
+              FAILED_TESTS+="* $JOB_NAME\n"
+              FAILED_COUNT=$((FAILED_COUNT+1))
+            fi
+          }
+          
+          check_status "Unit Tests" "${{ needs.run_unit_tests.result }}"
+          check_status "End-to-End Tests" "${{ needs.e2e.result }}"
+          check_status "Data Parallel Test" "${{ needs.run_data_parallel_test.result }}"
+          check_status "PD Disaggregate Test" "${{ needs.run_pd_disaggregate_test.result }}"
+          check_status "Performance Tests" "${{ needs.run_hpu_perf_tests.result }}"
+          
+          REPORT_BODY+="\n---\n"
+          if [ $FAILED_COUNT -gt 0 ]; then
+            SUBJECT="❌ Build Failed for ${{ needs.create-release-branch.outputs.branch_name }}"
+            REPORT_BODY+="**Overall Status: FAILED**\n\n"
+            REPORT_BODY+="**${FAILED_COUNT} job(s) failed:**\n"
+            REPORT_BODY+="$FAILED_TESTS"
+          else
+            SUBJECT="✅ Build Succeeded for ${{ needs.create-release-branch.outputs.branch_name }}"
+            REPORT_BODY+="**Overall Status: PASSED**\n\nAll tests passed successfully."
+          fi
+          
+          # Use a heredoc to handle multiline report body
+          cat <<EOF > report.md
+          ${REPORT_BODY}
+          EOF
+          
+          echo "SUBJECT=$SUBJECT" >> $GITHUB_ENV
+
+      - name: "Create GitHub Issue with Summary"
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: ${{ env.SUBJECT }}
+          content-filepath: ./report.md

--- a/.github/workflows/create-release-branch.yaml
+++ b/.github/workflows/create-release-branch.yaml
@@ -11,10 +11,6 @@ on:
         description: "The new release branch name (e.g., 'releases/v0.11.0')"
         required: true
         type: string
-      commit_id:
-        description: "Optional: Specific commit ID on main to branch from. Defaults to latest main."
-        required: false
-        type: string
 
 # Required permissions for creating a branch and pushing a commit.
 permissions:
@@ -22,22 +18,43 @@ permissions:
   issues: write # Added permission to allow creating issues
 
 jobs:
-  create-release-branch:
-    name: "Create Release Branch"
+  prepare-release-branch:
+    name: "Prepare Release Branch"
     runs-on: ubuntu-latest
     outputs:
       tag_name: ${{ steps.extract_tag.outputs.tag_name }}
-      commit_id: ${{ steps.get_commit.outputs.commit_id }}
+      commit_id: ${{ steps.get_vllm_commit.outputs.commit_id }}
       branch_name: ${{ github.event.inputs.branch_name }}
 
     steps:
-      # Step 1: Check out the 'main' branch to use as the base for the new branch.
-      - name: "Checkout the main branch"
+      # Step 1: Check if the target branch already exists on the remote.
+      - name: "Check for existing branch"
+        id: check_branch
+        run: |
+          BRANCH_NAME="${{ github.event.inputs.branch_name }}"
+          if git ls-remote --exit-code --heads origin "$BRANCH_NAME" > /dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "✅ Branch '$BRANCH_NAME' already exists. Will use it for testing."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "➡️ Branch '$BRANCH_NAME' does not exist. Will create it."
+          fi
+
+      # Step 2: Checkout the correct code based on whether the branch exists.
+      - name: "Checkout existing branch"
+        if: steps.check_branch.outputs.exists == 'true'
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.commit_id || 'main' }}
+          ref: ${{ github.event.inputs.branch_name }}
 
-      # Step 2: Extract the tag name from the branch name input.
+      - name: "Checkout base for new branch"
+        if: steps.check_branch.outputs.exists == 'false'
+        uses: actions/checkout@v4
+        with:
+          # This checks out the branch that the workflow was manually triggered on.
+          ref: ${{ github.ref_name }}
+
+      # Step 3: Extract tag name from the input. This is always needed for outputs.
       - name: "Extract Tag Name"
         id: extract_tag
         run: |
@@ -50,53 +67,64 @@ jobs:
           echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
           echo "Extracted tag name: $TAG_NAME"
 
-      # Step 3: Fetch the commit ID for the corresponding tag from the remote vLLM repository.
-      - name: "Get vLLM Commit ID for Tag"
-        id: get_commit
+      # Step 4: Get the vLLM commit ID. If branch exists, read from file. If not, fetch from the remote tag.
+      - name: "Get vLLM Commit ID"
+        id: get_vllm_commit
         run: |
-          TAG_NAME="${{ steps.extract_tag.outputs.tag_name }}"
-          VLLM_REPO="https://github.com/vllm-project/vllm.git"
-          echo "Looking up commit ID for tag '$TAG_NAME' in '$VLLM_REPO'..."
-          VLLM_COMMIT_ID=$(git ls-remote "$VLLM_REPO" "refs/tags/$TAG_NAME" | cut -f1)
-          if [ -z "$VLLM_COMMIT_ID" ]; then
-            echo "::error::Could not find tag '$TAG_NAME' in the vLLM repository."
-            exit 1
+          if [ "${{ steps.check_branch.outputs.exists }}" == 'true' ]; then
+            if [ -f "VLLM_STABLE_COMMIT" ]; then
+              VLLM_COMMIT_ID=$(cat VLLM_STABLE_COMMIT | tr -d '[:space:]')
+              echo "Read vLLM commit from existing branch file: $VLLM_COMMIT_ID"
+            else
+              echo "::error::Branch exists but VLLM_STABLE_COMMIT file not found!"
+              exit 1
+            fi
+          else
+            TAG_NAME="${{ steps.extract_tag.outputs.tag_name }}"
+            VLLM_REPO="https://github.com/vllm-project/vllm.git"
+            VLLM_COMMIT_ID=$(git ls-remote "$VLLM_REPO" "refs/tags/$TAG_NAME" | cut -f1)
+            if [ -z "$VLLM_COMMIT_ID" ]; then
+              echo "::error::Could not find tag '$TAG_NAME' in the vLLM repository."
+              exit 1
+            fi
+            echo "Fetched vLLM commit ID for tag '$TAG_NAME': $VLLM_COMMIT_ID"
           fi
-          echo "Found vLLM commit ID: $VLLM_COMMIT_ID"
           echo "commit_id=$VLLM_COMMIT_ID" >> "$GITHUB_OUTPUT"
 
-      # Step 4: Configure Git user details for the new commit.
+      # Step 5: Configure Git user (only needed for new branch creation).
       - name: "Configure Git"
+        if: steps.check_branch.outputs.exists == 'false'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      # Step 5: Create the new branch, write the commit ID to a file, and push to the repository.
-      - name: "Commit VLLM_STABLE_COMMIT and Push"
+      # Step 6: Create and push the new branch only if it did not already exist.
+      - name: "Create and Push New Branch"
+        if: steps.check_branch.outputs.exists == 'false'
         run: |
-          git checkout -b "${{ github.event.inputs.branch_name }}"
-          echo "${{ steps.get_commit.outputs.commit_id }}" > VLLM_STABLE_COMMIT
-          echo "Created VLLM_STABLE_COMMIT file."
+          BRANCH_NAME="${{ github.event.inputs.branch_name }}"
+          git checkout -b "$BRANCH_NAME"
+          echo "${{ steps.get_vllm_commit.outputs.commit_id }}" > VLLM_STABLE_COMMIT
           git add VLLM_STABLE_COMMIT
           git commit -m "Set vLLM stable commit for ${{ steps.extract_tag.outputs.tag_name }}"
-          git push -u origin "${{ github.event.inputs.branch_name }}"
-          echo "✅ Successfully created and pushed branch '${{ github.event.inputs.branch_name }}'."
+          git push -u origin "$BRANCH_NAME"
+          echo "✅ Successfully created and pushed new branch '$BRANCH_NAME'."
 
   setup_and_build:
     runs-on: hourly-ci
-    needs: [create-release-branch]
+    needs: [prepare-release-branch]
     steps:
-      - name: "Checkout the new release branch"
+      - name: "Checkout the release branch"
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.create-release-branch.outputs.branch_name }}
+          ref: ${{ needs.prepare-release-branch.outputs.branch_name }}
       - name: Setup Docker environment and build image
         run: |
           echo "Attempting to build Docker image..."
           docker build \
             --no-cache \
-            --build-arg VLLM_COMMIT_ARG=${{ needs.create-release-branch.outputs.commit_id }} \
-            -t hpu-plugin-v1-${{ needs.create-release-branch.outputs.tag_name }} \
+            --build-arg VLLM_COMMIT_ARG=${{ needs.prepare-release-branch.outputs.commit_id }} \
+            -t hpu-plugin-v1-${{ needs.prepare-release-branch.outputs.tag_name }} \
             -f - . <<EOF
           FROM vault.habana.ai/gaudi-docker/1.22.0/ubuntu24.04/habanalabs/pytorch-installer-2.7.1:latest
 
@@ -130,7 +158,7 @@ jobs:
           echo "Docker image built successfully."
 
   run_unit_tests:
-    needs: [create-release-branch, setup_and_build]
+    needs: [prepare-release-branch, setup_and_build]
     runs-on: hourly-ci
     steps:
       - name: Run pytest in tests/unit_tests
@@ -146,7 +174,7 @@ jobs:
             -e HF_HOME=/workspace/hf_cache \
             -e HF_TOKEN=${{ secrets.HF_TOKEN }} \
             -v /mnt/hf_cache:/workspace/hf_cache \
-            hpu-plugin-v1-${{ needs.create-release-branch.outputs.tag_name }} \
+            hpu-plugin-v1-${{ needs.prepare-release-branch.outputs.tag_name }} \
             /bin/bash -c "pytest -vvv --timeout=300 --durations=10 --durations-min=1.0 /workspace/vllm-gaudi/tests/unit_tests"
 
           EXITCODE=$?
@@ -154,14 +182,14 @@ jobs:
 
   discover_tests:
     runs-on: hourly-ci
-    needs: [create-release-branch]
+    needs: [prepare-release-branch]
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - name: "Checkout the new release branch"
+      - name: "Checkout the release branch"
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.create-release-branch.outputs.branch_name }}
+          ref: ${{ needs.prepare-release-branch.outputs.branch_name }}
       - name: Discover test functions
         id: set-matrix
         run: |
@@ -178,7 +206,7 @@ jobs:
           echo "matrix=$TEST_FUNCTIONS" >> "$GITHUB_OUTPUT"
 
   e2e:
-    needs: [create-release-branch, setup_and_build, discover_tests]
+    needs: [prepare-release-branch, setup_and_build, discover_tests]
     runs-on: hourly-ci
     strategy:
       fail-fast: false
@@ -200,14 +228,14 @@ jobs:
             -e HF_HOME=/workspace/hf_cache \
             -e HF_TOKEN=${{ secrets.HF_TOKEN }} \
             -v /mnt/hf_cache:/workspace/hf_cache \
-            hpu-plugin-v1-${{ needs.create-release-branch.outputs.tag_name }} \
+            hpu-plugin-v1-${{ needs.prepare-release-branch.outputs.tag_name }} \
             /bin/bash "/workspace/vllm-gaudi/tests/full_tests/ci_gsm8k_tests.sh" "${{ matrix.test_function }}"
 
           EXITCODE=$?
           echo "Test script exited with code: $EXITCODE"
 
   run_data_parallel_test:
-    needs: [create-release-branch, setup_and_build]
+    needs: [prepare-release-branch, setup_and_build]
     runs-on: hourly-ci
     steps:
       - name: Run Data Parallel test
@@ -226,14 +254,14 @@ jobs:
             -e VLLM_USE_V1=1 \
             -e HF_TOKEN=${{ secrets.HF_TOKEN }} \
             -v /mnt/hf_cache:/workspace/hf_cache \
-            hpu-plugin-v1-${{ needs.create-release-branch.outputs.tag_name }} \
+            hpu-plugin-v1-${{ needs.prepare-release-branch.outputs.tag_name }} \
             /bin/bash -c "python -u /workspace/vllm-gaudi/examples/data_parallel.py --dp-size 2 --tp-size 2"
 
           EXITCODE=$?
           echo "Test script exited with code: $EXITCODE"
 
   run_pd_disaggregate_test:
-    needs: [create-release-branch, setup_and_build]
+    needs: [prepare-release-branch, setup_and_build]
     runs-on: hourly-ci
     steps:
       - name: Run PD disaggregate test
@@ -250,7 +278,7 @@ jobs:
             -e HF_TOKEN=${{ secrets.HF_TOKEN }} \
             -v /mnt/hf_cache:/workspace/hf_cache \
             -v /mnt/wheels_cache:/workspace/wheels_cache \
-            hpu-plugin-v1-${{ needs.create-release-branch.outputs.tag_name }} \
+            hpu-plugin-v1-${{ needs.prepare-release-branch.outputs.tag_name }} \
             /bin/bash -c "
               pip install lm-eval[api] &&
               cd /workspace/vllm-gaudi/tests/unit_tests &&
@@ -260,7 +288,7 @@ jobs:
           echo "Test script exited with code: $EXITCODE"
 
   run_hpu_perf_tests:
-    needs: [create-release-branch, setup_and_build]
+    needs: [prepare-release-branch, setup_and_build]
     runs-on: hourly-ci
     steps:
       - name: Run Sharegpt performance tests with warmup
@@ -277,7 +305,7 @@ jobs:
             -e HF_TOKEN=${{ secrets.HF_TOKEN }} \
             -e HF_HOME=/workspace/hf_cache \
             -v /mnt/hf_cache:/workspace/hf_cache \
-            hpu-plugin-v1-${{ needs.create-release-branch.outputs.tag_name }} \
+            hpu-plugin-v1-${{ needs.prepare-release-branch.outputs.tag_name }} \
             /bin/bash "/workspace/vllm-gaudi/tests/full_tests/ci_perf_tests.sh"
           
           EXITCODE=$?
@@ -286,10 +314,9 @@ jobs:
   summarize_and_notify:
     name: "Summarize Test Results and Notify"
     runs-on: ubuntu-latest
-    # This job runs after all test jobs, and 'always()' ensures it runs even if tests fail.
     if: always()
     needs:
-      - create-release-branch
+      - prepare-release-branch
       - run_unit_tests
       - e2e
       - run_data_parallel_test
@@ -299,7 +326,7 @@ jobs:
       - name: "Generate Summary Report"
         id: summary
         run: |
-          REPORT_BODY="## Test Summary for : ${{ needs.create-release-branch.outputs.branch_name }}\n\n"
+          REPORT_BODY="## Test Summary for Branch: ${{ needs.prepare-release-branch.outputs.branch_name }}\n\n"
           REPORT_BODY+="See the full workflow run [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).\n\n"
           FAILED_TESTS=""
           FAILED_COUNT=0
@@ -324,12 +351,12 @@ jobs:
           
           REPORT_BODY+="\n---\n"
           if [ $FAILED_COUNT -gt 0 ]; then
-            SUBJECT="❌ Build Failed for ${{ needs.create-release-branch.outputs.branch_name }}"
+            SUBJECT="❌ Build Failed for ${{ needs.prepare-release-branch.outputs.branch_name }}"
             REPORT_BODY+="**Overall Status: FAILED**\n\n"
             REPORT_BODY+="**${FAILED_COUNT} job(s) failed:**\n"
             REPORT_BODY+="$FAILED_TESTS"
           else
-            SUBJECT="✅ Build Succeeded for ${{ needs.create-release-branch.outputs.branch_name }}"
+            SUBJECT="✅ Build Succeeded for ${{ needs.prepare-release-branch.outputs.branch_name }}"
             REPORT_BODY+="**Overall Status: PASSED**\n\nAll tests passed successfully."
           fi
           
@@ -346,3 +373,5 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           title: ${{ env.SUBJECT }}
           content-filepath: ./report.md
+          # Optional: Add labels to the issue
+          labels: branch-out-report, automated

--- a/.github/workflows/create-release-branch.yaml
+++ b/.github/workflows/create-release-branch.yaml
@@ -73,7 +73,7 @@ jobs:
         run: |
           if [ "${{ steps.check_branch.outputs.exists }}" == 'true' ]; then
             if [ -f "VLLM_STABLE_COMMIT" ]; then
-              VLLM_COMMIT_ID=$(cat VLLM_STABLE_COMMIT | tr -d '[:space:]')
+              VLLM_COMMIT_ID=$(tr -d '[:space:]' < VLLM_STABLE_COMMIT)
               echo "Read vLLM commit from existing branch file: $VLLM_COMMIT_ID"
             else
               echo "::error::Branch exists but VLLM_STABLE_COMMIT file not found!"
@@ -374,4 +374,4 @@ jobs:
           title: ${{ env.SUBJECT }}
           content-filepath: ./report.md
           # Optional: Add labels to the issue
-          labels: branch-out-report, automated
+          labels: release-report, automated

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -3,7 +3,9 @@ name: Basic HPU test suite
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main]
+    branches: 
+      - main
+      - releases/**
 
   # Allow manual triggering for testing purposes
   workflow_dispatch: {}
@@ -167,30 +169,50 @@ jobs:
     outputs:
       target_commit: ${{ steps.checkout_vllm_upstream.outputs.TEST_VLLM_COMMIT }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Fetch full history for accurate commit comparison
+          ref: ${{ github.event.pull_request.head.sha }}
+          clean: true # Ensure a clean workspace before checkout
       - name: Read Stable Commit from Target Branch
         id: read_stable_commit
         run: |
-          TARGET_BRANCH="vllm/last-good-commit-for-vllm-gaudi"
           TARGET_FILE="VLLM_STABLE_COMMIT"
-          
-          echo "Attempting to read $TARGET_FILE from branch $TARGET_BRANCH..."
-          
-          # Fetch the specific branch; `|| true` prevents failure if the branch doesn't exist
-          git fetch origin "$TARGET_BRANCH" --no-tags --depth=1 || true
-          
-          # Try to read the file; `|| COMMIT_HASH=""` prevents failure if the file doesn't exist
-          COMMIT_HASH=$(git show "origin/$TARGET_BRANCH:$TARGET_FILE" 2>/dev/null) || COMMIT_HASH=""
-          
-          # Clean up any extra whitespace
-          COMMIT_HASH=$(echo "$COMMIT_HASH" | tr -d '[:space:]')
-          
-          if [ -z "$COMMIT_HASH" ]; then
-            echo "::warning::Stable commit hash not found or file is empty."
+          COMMIT_HASH=""
+
+          # 1. Primary Check: Look in the current branch
+          echo "INFO: Checking for '$TARGET_FILE' in the current branch..."
+          if [ -f "$TARGET_FILE" ]; then
+            COMMIT_HASH=$(tr -d '[:space:]' < "$TARGET_FILE")
+            if [ -n "$COMMIT_HASH" ]; then
+              echo "✅ Found stable commit in current branch: $COMMIT_HASH"
+            else
+              echo "::warning:: File '$TARGET_FILE' is empty in current branch. Proceeding to fallback."
+            fi
           else
-            echo "Stable commit hash recorded: $COMMIT_HASH"
+            echo "INFO: File not found in current branch. Proceeding to fallback."
+          fi
+
+          # 2. Fallback Check: Look in the remote branch if the first check failed
+          if [ -z "$COMMIT_HASH" ]; then
+            TARGET_BRANCH="vllm/last-good-commit-for-vllm-gaudi"
+            echo "➡️ Fallback: Attempting to read '$TARGET_FILE' from branch '$TARGET_BRANCH'..."
+            
+            git fetch origin "$TARGET_BRANCH" --no-tags --depth=1 || true
+            
+            # Read file from the remote branch; suppress errors if not found
+            COMMIT_HASH=$(git show "origin/$TARGET_BRANCH:$TARGET_FILE" 2>/dev/null) || COMMIT_HASH=""
+            COMMIT_HASH=$(echo "$COMMIT_HASH" | tr -d '[:space:]')
+            
+            if [ -n "$COMMIT_HASH" ]; then
+              echo "✅ Found stable commit in fallback branch: $COMMIT_HASH"
+            else
+              echo "::error:: Fallback failed. Could not find a valid commit hash in either location."
+            fi
           fi
           
-          # Save the hash (or an empty string) to an environment variable
+          # 3. Export the final result
           echo "VLLM_STABLE_COMMIT=$COMMIT_HASH" >> "$GITHUB_ENV"
       - name: Determine Target Commit Based on PR Title
         id: determine_commit
@@ -255,7 +277,7 @@ jobs:
             -f - . <<EOF
           FROM vault.habana.ai/gaudi-docker/1.22.0/ubuntu24.04/habanalabs/pytorch-installer-2.7.1:latest
 
-          ARG VLLM_COMMIT_ARG=main
+          ARG VLLM_COMMIT_ARG
 
           COPY ./ /workspace/vllm-gaudi
           WORKDIR /workspace

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -56,7 +56,7 @@ from vllm.v1.worker.utils import bind_kv_cache
 from vllm.v1.utils import CpuGpuBuffer
 from vllm_gaudi.v1.worker.hpu_input_batch import InputBatch, CachedRequestState
 from vllm.distributed.parallel_state import get_pp_group
-from vllm.model_executor.models.interfaces import (supports_eagle3, supports_transcription)
+from vllm.model_executor.models.interfaces import (SupportsMultiModal, supports_eagle3, supports_transcription)
 from vllm.model_executor.models.interfaces_base import (VllmModelForPooling, is_pooling_model, is_text_generation_model)
 from vllm.tasks import GenerationTask, PoolingTask, SupportedTask
 from vllm.transformers_utils.config import is_interleaved
@@ -1218,11 +1218,13 @@ class HPUModelRunner(KVConnectorModelRunnerMixin):
                     mm_kwargs.extend(req_mm_kwargs)
 
                 # Input all modalities at once
+                self.model.model = cast(SupportsMultiModal, self.model.model)
                 mm_kwargs_combined: BatchedTensorInputs = {}
                 for _, _, mm_kwargs_group in group_mm_kwargs_by_modality(
                         mm_kwargs,
                         device=self.device,
                         pin_memory=self.pin_memory,
+                        merge_by_field_config=self.model.model.merge_by_field_config,
                 ):
                     mm_kwargs_combined.update(mm_kwargs_group)
 
@@ -1270,10 +1272,12 @@ class HPUModelRunner(KVConnectorModelRunnerMixin):
         # multimodal inputs. The proper solution should be reordering the
         # encoder outputs.
         encoder_outputs = []
+        self.model.model = cast(SupportsMultiModal, self.model.model)
         for _, num_items, mm_kwargs_group in group_mm_kwargs_by_modality(
                 mm_kwargs,
                 device=self.device,
                 pin_memory=self.pin_memory,
+                merge_by_field_config=self.model.model.merge_by_field_config,
         ):
             # Run the encoder.
             # `curr_group_outputs` is either of the following:


### PR DESCRIPTION
create a new BO release after the upstream delivers the latest vllm release.
 
1. Create a BO, for example, releases/v0.11.0.
2. Generate a file with the SHA values from the upstream releases corresponding to the upstream release tag.
3. Run CI check to get the BO results and save the CI output.