### PR TITLE
Fix undefined behavior in copy_blocks when source and destination blocks overlap

### DIFF
--- a/vllm_gaudi/extension/cache_ops.py
+++ b/vllm_gaudi/extension/cache_ops.py
@@ -32,8 +32,11 @@ def copy_blocks(key_caches, value_caches, block_mapping):
     dst = block_mapping[1]
 
     for key_cache, value_cache in zip(key_caches, value_caches):
-        key_cache.index_copy_(0, dst, key_cache.index_select(0, src))
-        value_cache.index_copy_(0, dst, value_cache.index_select(0, src))
+        # read once, write once - no overlap
+        k_values = key_cache.index_select(0, src)   # gather
+        v_values = value_cache.index_select(0, src)
+        key_cache.index_put_([dst], k_values)       # scatter
+        value_cache.index_put_([dst], v_values)
 
     if key_caches[0].device.type == 'hpu':
         htorch.core.mark_step()


### PR DESCRIPTION
### Summary
`copy_blocks` uses `index_copy_` with overlapping source and destination indices, which is explicitly undefined behavior in PyTorch.
On HPU/GPU devices this can silently corrupt the KV cache when the same physical block appears more than once in the `block_mapping` list.
The patch switches to a gather-then-scatter sequence (`index_select` + `index_put_`) so that every source block is read before any destination slot is overwritten.

#### Changes
`copy_blocks`: introduce temporary tensors to avoid read-after-write hazards

#### Issue reproduction
The below unit test fails on main branch and passes after the fix.

```py
import torch
import habana_frameworks.torch as htorch


def copy_blocks_new(key_caches, value_caches, block_mapping):
    if block_mapping.numel() == 0:
        return

    block_mapping = block_mapping.transpose(0, 1)
    src = block_mapping[0]
    dst = block_mapping[1]

    for key_cache, value_cache in zip(key_caches, value_caches):
        # read once, write once - no overlap
        k_values = key_cache.index_select(0, src)   # gather
        v_values = value_cache.index_select(0, src)
        key_cache.index_put_([dst], k_values)       # scatter
        value_cache.index_put_([dst], v_values)


def copy_blocks_old(key_caches, value_caches, block_mapping):
    if block_mapping.numel() == 0:
        return

    block_mapping = block_mapping.transpose(0, 1)
    src = block_mapping[0]
    dst = block_mapping[1]

    for key_cache, value_cache in zip(key_caches, value_caches):
        key_cache.index_copy_(0, dst, key_cache.index_select(0, src))
        value_cache.index_copy_(0, dst, value_cache.index_select(0, src))

    if key_caches[0].device.type == 'hpu':
        htorch.core.mark_step()


def test_copy(fn, name):
    num_blocks, block_size, num_heads, head_size = 4, 128, 8, 64
    k = torch.arange(num_blocks * block_size * num_heads * head_size,
                     dtype=torch.bfloat16, device='hpu').view(num_blocks, num_heads, block_size, head_size)
    v = k + 1000

    mapping = torch.tensor([[2, 0], [1, 0]], dtype=torch.long, device='hpu')

    orig_k = k.clone().cpu()
    orig_v = v.clone().cpu()

    fn([k], [v], mapping)           # run the function under test
    torch.hpu.synchronize()

    dst = 0
    src = 1

    try:
        torch.testing.assert_close(k[dst].cpu(), orig_k[src])
        torch.testing.assert_close(v[dst].cpu(), orig_v[src])
        print(f"�~\~T {name}: overlap chain copied correctly")
    except AssertionError as e:
        print(f"�~\~X {name}: FAILED �~@~S {e}")

#  run both
test_copy(copy_blocks_old, "OLD (UB)")
test_copy(copy_blocks_new, "NEW (safe)")
```

Running the test.py
```sh
>>> python test.py
✘ OLD (UB): FAILED – Tensor-likes are not close!

Mismatched elements: 21376 / 65536 (32.6%)
Greatest absolute difference: 66048.0 at index (0, 8, 1) (up to 1e-05 allowed)
Greatest relative difference: 1.0 at index (0, 4, 0) (up to 0.016 allowed)

✔ NEW (safe): overlap chain copied correctly
```
