### PR TITLE
Fix defragmenter compilation

### DIFF
--- a/vllm_gaudi/extension/defragmentation.py
+++ b/vllm_gaudi/extension/defragmentation.py
@@ -78,10 +78,7 @@ class OnlineDefragmenter:
             if config.bridge_mode == 'lazy':
                 self.cache_utils = htorch.hpu.wrap_in_hpu_graph(self.cache_utils, disable_tensor_cache=True)
             elif config.bridge_mode == 'eager':
-                self.cache_utils.forward = torch.compile(self.cache_utils.forward,
-                                                         backend='hpu_backend',
-                                                         fullgraph=True,
-                                                         dynamic=False)
+                self.cache_utils = torch.compile(self.cache_utils, backend='hpu_backend', fullgraph=True, dynamic=False)
         if self.debug:
             self.debug('initialized')
 


### PR DESCRIPTION
From testing, it seems like the forward pass of defragmenter is running eagerly, even though it's being compiled. This fix compiles the full module and significantly speeds up the forward pass in eager/compile mode. VLLM_DEFRAG_WITH_GRAPHS=1 is still needed for compiling defragmenter.