### PR TITLE
Add torch from habanalabs-installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Learn more:
     cd vllm
     git checkout $VLLM_COMMIT_HASH
     pip install -r <(sed '/^[torch]/d' requirements/build.txt)
-
     wget -nv https://vault.habana.ai/artifactory/gaudi-installer/[latest-version]/habanalabs-installer.sh
     chmod +x habanalabs-installer-[latest-version].sh
     export HABANALABS_VIRTUAL_DIR=[YOUR_PYTHON_VENv]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Learn more:
     pip install -r <(sed '/^[torch]/d' requirements/build.txt)
     wget -nv https://vault.habana.ai/artifactory/gaudi-installer/[latest-version]/habanalabs-installer.sh
     chmod +x habanalabs-installer.sh
-    export HABANALABS_VIRTUAL_DIR=[YOUR_PYTHON_VENv]
+    export HABANALABS_VIRTUAL_DIR=[YOUR_PYTHON_VENV]
     ./habanalabs-installer.sh install --type pytorch --venv
     VLLM_TARGET_DEVICE=empty pip install --no-build-isolation -e .
     cd ..

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ Learn more:
     cd vllm
     git checkout $VLLM_COMMIT_HASH
     pip install -r <(sed '/^[torch]/d' requirements/build.txt)
+
+    wget -nv https://vault.habana.ai/artifactory/gaudi-installer/[latest-version]/habanalabs-installer.sh
+    chmod +x habanalabs-installer-[latest-version].sh
+    export HABANALABS_VIRTUAL_DIR=[YOUR_PYTHON_VENv]
+    ./habanalabs-installer-[latest-version].sh install --type pytorch --venv
     VLLM_TARGET_DEVICE=empty pip install --no-build-isolation -e .
     cd ..
     ```

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ Learn more:
     git checkout $VLLM_COMMIT_HASH
     pip install -r <(sed '/^[torch]/d' requirements/build.txt)
     wget -nv https://vault.habana.ai/artifactory/gaudi-installer/[latest-version]/habanalabs-installer.sh
-    chmod +x habanalabs-installer-[latest-version].sh
+    chmod +x habanalabs-installer.sh
     export HABANALABS_VIRTUAL_DIR=[YOUR_PYTHON_VENv]
-    ./habanalabs-installer-[latest-version].sh install --type pytorch --venv
+    ./habanalabs-installer.sh install --type pytorch --venv
     VLLM_TARGET_DEVICE=empty pip install --no-build-isolation -e .
     cd ..
     ```


### PR DESCRIPTION
We really need this command, I deleted everything and retested. You need to use add torch in the tests with gaudi2 and gaudi3.