### PR TITLE
Install pytorch from habanalabs-installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Learn more:
     cd vllm
     git checkout $VLLM_COMMIT_HASH
     pip install -r <(sed '/^[torch]/d' requirements/build.txt)
+    wget -nv https://vault.habana.ai/artifactory/gaudi-installer/[latest-version]/habanalabs-installer.sh
+    chmod +x habanalabs-installer.sh
+    export HABANALABS_VIRTUAL_DIR=[YOUR_PYTHON_VENV]
+    ./habanalabs-installer.sh install --type pytorch --venv
     VLLM_TARGET_DEVICE=empty pip install --no-build-isolation -e .
     cd ..
     ```


### PR DESCRIPTION
We really need this command, I deleted everything and retested. You need to use add torch in the tests with gaudi2 and gaudi3.