### PR TITLE
Gemma3 Multimodal optimization

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
     extras_require={},
     entry_points={
         "vllm.platform_plugins": ["hpu = vllm_gaudi:register"],
-        "vllm.general_plugins": ["hpu_custom_ops = vllm_gaudi:register_ops"],
+        "vllm.general_plugins":
+        ["hpu_custom_ops = vllm_gaudi:register_ops", "hpu_custom_models = vllm_gaudi:register_models"],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,9 @@ setup(
     extras_require={},
     entry_points={
         "vllm.platform_plugins": ["hpu = vllm_gaudi:register"],
-        "vllm.general_plugins":
-        ["hpu_custom_ops = vllm_gaudi:register_ops", "hpu_custom_models = vllm_gaudi:register_models"],
+        "vllm.general_plugins": [
+            "01.hpu_custom_ops = vllm_gaudi:register_ops",
+            "02.hpu_custom_models = vllm_gaudi:register_models",
+        ],
     },
 )

--- a/tests/full_tests/ci_gsm8k_tests.sh
+++ b/tests/full_tests/ci_gsm8k_tests.sh
@@ -13,12 +13,11 @@ echo $VLLM_GAUDI_PREFIX
 # Gemma3 with image input
 run_gemma3_test() {
     echo "➡️ Testing gemma-3-4b-it..."
-    #VLLM_SKIP_WARMUP=true PT_HPU_LAZY_MODE=1 VLLM_USE_V1=1 python -u "${VLLM_GAUDI_PREFIX}/tests/models/language/generation/generation_mm.py" --model-card-path "${VLLM_GAUDI_PREFIX}/tests/full_tests/model_cards/gemma-3-4b-it.yaml"
-    #echo "✅ Test with multimodal-support with gemma-3-4b-it passed."
-    #echo "➡️ Testing gemma-3-27b-it..."
-    #VLLM_SKIP_WARMUP=true PT_HPU_LAZY_MODE=1 VLLM_USE_V1=1 python -u "${VLLM_GAUDI_PREFIX}/tests/models/language/generation/generation_mm_multi.py" --model-card-path "${VLLM_GAUDI_PREFIX}/tests/full_tests/model_cards/gemma-3-27b-it.yaml"
-    #echo "✅ Test with multimodal-support with multiple images gemma-3-27b-it passed."
-    # echo "Skipping gemma-3-4b-it due to changes from https://github.com/vllm-project/vllm/pull/26715 
+    VLLM_SKIP_WARMUP=true PT_HPU_LAZY_MODE=1 VLLM_USE_V1=1 python -u "${VLLM_GAUDI_PREFIX}/tests/models/language/generation/generation_mm.py" --model-card-path "${VLLM_GAUDI_PREFIX}/tests/full_tests/model_cards/gemma-3-4b-it.yaml"
+    echo "✅ Test with multimodal-support with gemma-3-4b-it passed."
+    echo "➡️ Testing gemma-3-4b-it with multiple images(applying sliding_window)..."
+    VLLM_SKIP_WARMUP=true PT_HPU_LAZY_MODE=1 VLLM_USE_V1=1 python -u "${VLLM_GAUDI_PREFIX}/tests/models/language/generation/generation_mm_multi.py" --model-card-path "${VLLM_GAUDI_PREFIX}/tests/full_tests/model_cards/gemma-3-27b-it.yaml"
+    echo "✅ Test with multimodal-support with multiple images gemma-3-27b-it passed."
 }
 
 # Basic model test

--- a/vllm_gaudi/__init__.py
+++ b/vllm_gaudi/__init__.py
@@ -20,3 +20,8 @@ def register_ops():
     import vllm_gaudi.ops.hpu_gptq  # noqa: F401
     import vllm_gaudi.ops.hpu_awq  # noqa: F401
     import vllm_gaudi.ops.hpu_multihead_attn  # noqa: F401
+
+
+def register_models():
+    from .models import register_model
+    register_model()

--- a/vllm_gaudi/__init__.py
+++ b/vllm_gaudi/__init__.py
@@ -23,5 +23,6 @@ def register_ops():
 
 
 def register_models():
+    import vllm_gaudi.models.utils  # noqa: F401
     from .models import register_model
     register_model()

--- a/vllm_gaudi/attention/backends/hpu_attn.py
+++ b/vllm_gaudi/attention/backends/hpu_attn.py
@@ -570,9 +570,13 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
 
             common_args = self.common_attention_args(block_list, key_cache, value_cache, attn_metadata.block_size)
 
-            if self.sliding_window and hasattr(attn_metadata,
-                                               'window_attn_bias') and attn_metadata.window_attn_bias is not None:
-                attn_bias = attn_metadata.window_attn_bias
+            if self.sliding_window:
+                if hasattr(attn_metadata, 'window_attn_bias') and attn_metadata.window_attn_bias is not None:
+                    attn_bias = attn_metadata.window_attn_bias
+                else:
+                    attn_bias = None
+                    window_size = (self.sliding_window, 0)
+                    common_args['window_size'] = window_size
 
             out = ops.prompt_attention(impl=self.prefill_impl,
                                        query=query.view(query_shape),

--- a/vllm_gaudi/extension/bucketing/common.py
+++ b/vllm_gaudi/extension/bucketing/common.py
@@ -59,6 +59,18 @@ class HPUBucketingManager():
         self.fallback_seq_base_step = 32
         self.fallback_blocks_base_step = 32
 
+        self.use_sliding_window = get_config().PT_HPU_SDPA_QKV_SLICE_MODE_FWD
+        if self.use_sliding_window:
+            self.slice_size = get_config().PT_HPU_SDPA_BC_FACTOR if \
+                get_config().PT_HPU_SDPA_BC_FACTOR is not None else 1024
+            self.slice_thld = get_config().VLLM_FUSEDSDPA_SLIDE_THLD if \
+                get_config().VLLM_FUSEDSDPA_SLIDE_THLD is not None else 8192
+
+            msg = (
+                f"use_sliding_window {self.use_sliding_window}, slice_size {self.slice_size}, threshold {self.slice_thld}"
+            )
+            logger().info(msg)
+
     ### GENERATE BUCKETS FUNCTIONS ###
 
     def get_bucketing_strategy(self):
@@ -120,6 +132,13 @@ class HPUBucketingManager():
                                                    self.max_num_seqs, self.max_num_prefill_seqs,
                                                    self.max_num_batched_tokens, self.block_size, self.num_hpu_blocks)
             self.log_generate_info(True)
+            if self.use_sliding_window:
+                self.prompt_buckets = [
+                    t for t in self.prompt_buckets
+                    if t[2] != 0 or (t[2] == 0 and (t[1] < self.slice_thld or
+                                                    (t[1] >= self.slice_thld and t[1] % self.slice_size == 0)))
+                ]
+                self.log_generate_info(True)
         else:
             logger().info("Bucketing is off - skipping prompt buckets generation")
             self.prompt_buckets = []
@@ -164,7 +183,11 @@ class HPUBucketingManager():
     def generate_fallback_bucket(self, batch_size, seq_len, ctx):
         assert self.max_num_batched_tokens is not None
         new_batch_size = calc_fallback_value(batch_size, self.fallback_bs_base_step)
-        new_seq_len = min(calc_fallback_value(seq_len, self.fallback_seq_base_step), self.max_num_batched_tokens)
+        if self.use_sliding_window and seq_len >= self.slice_thld:
+            new_seq_len = math.ceil(seq_len / self.slice_size) * self.slice_size
+        else:
+            new_seq_len = min(calc_fallback_value(seq_len, self.fallback_seq_base_step), self.max_num_batched_tokens)
+
         if self.num_hpu_blocks is None:
             new_ctx = 0
         else:

--- a/vllm_gaudi/extension/bucketing/vision.py
+++ b/vllm_gaudi/extension/bucketing/vision.py
@@ -1,0 +1,166 @@
+import os
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+MODEL_CONFIGS = {
+    # Batch-based models
+    'gemma-3': {
+        'is_batch_based': True,
+        'buckets': [1, 2, 4, 8]
+    },
+    'internvl': {
+        'is_batch_based': True,
+        'buckets': [1, 2, 4, 6, 8]
+    },
+
+    # Pixel-based models
+    'qwen2.5-vl': {
+        'is_batch_based': False,
+        'buckets': [1600, 3136, 4096, 6400, 7744, 9216, 12544]
+    },
+    'ovis2.5': {
+        'is_batch_based': False,
+        'buckets': [784, 1600, 3136, 4096, 6400, 7744, 9216, 12544]
+    }
+}
+
+
+class HPUVisionBucketManager:
+    '''
+    This class is used to bucket image tokens
+    '''
+
+    def __init__(self, model_name, is_batch_based=True):
+        config = self._get_model_config(model_name)
+
+        self.is_batch_based = is_batch_based if is_batch_based is not None else config['is_batch_based']
+
+        envvar = os.environ.get('VLLM_MULTIMODAL_BUCKETS', "")
+        if envvar == 'None':
+            self.multimodal_buckets = None
+        else:
+            if envvar == "":
+                multimodal_buckets = config['buckets']
+            else:
+                multimodal_buckets = [int(x) for x in envvar.split(',')]
+            self.multimodal_buckets = self._process_buckets(multimodal_buckets)
+
+    def _get_model_config(self, model_name):
+        """Get configuration for model"""
+        model_name_lower = model_name.lower()
+
+        # Find matching config
+        for key, config in MODEL_CONFIGS.items():
+            if key.replace('-', '').replace('.', '') in model_name_lower.replace('-', '').replace('.', ''):
+                return config
+
+        # Default config
+        logger.info("MultiModal bucket config file for {model_name} not found.")
+        return {'is_batch_based': True, 'buckets': [1, 2, 4, 8]}
+
+    def _process_buckets(self, buckets):
+        #TODO If there is any limitation(such as if batch bucket need to be aligned by n, then put the assert check here!)
+
+        return sorted(buckets)
+
+    def get_multimodal_bucket(self, curr_num_image_patches):
+        if self.multimodal_buckets is not None:
+            for mm_bucket in self.multimodal_buckets:
+                if curr_num_image_patches <= mm_bucket:
+                    return mm_bucket
+            return curr_num_image_patches
+        else:
+            return 0
+
+    def find_factor(self, desired_patches, orig):
+        for i in range(orig + 1, desired_patches + 1):
+            if desired_patches % i == 0:
+                if i % 2 != 0:
+                    continue
+                else:
+                    return i
+        return None
+
+    def find_padding(self, h_orig, w_orig, desired_patches):
+        best_pad_h, best_pad_w = 0, 0
+        if desired_patches % h_orig == 0:
+            best_pad_h = 0
+            w_factor = desired_patches // h_orig
+            best_pad_w = w_factor - w_orig if (w_factor > w_orig and w_factor % 2 == 0) else 0
+        elif desired_patches % w_orig == 0:
+            best_pad_w = 0
+            h_factor = desired_patches // w_orig
+            best_pad_h = h_factor - h_orig if (h_factor > h_orig and h_factor % 2 == 0) else 0
+        elif desired_patches % h_orig != 0 and desired_patches % w_orig != 0:
+            if h_orig > w_orig:
+                w_factor = self.find_factor(desired_patches, w_orig)
+                if w_factor is not None:
+                    best_pad_w = w_factor - w_orig
+                    h_factor = desired_patches // w_factor
+                    if h_factor > h_orig:
+                        best_pad_h = h_factor - h_orig
+            else:
+                h_factor = self.find_factor(desired_patches, h_orig)
+                if h_factor is not None:
+                    best_pad_h = h_factor - h_orig
+                    w_factor = desired_patches // h_factor
+                    if w_factor > w_orig:
+                        best_pad_w = w_factor - w_orig
+
+        if (best_pad_h + h_orig) * (best_pad_w + w_orig) != desired_patches:
+            best_pad_h, best_pad_w = 0, 0
+
+        return best_pad_h, best_pad_w
+
+    def pad_multimodal_data(self, pixel_values, image_grid_thw):
+
+        import pdb
+        pdb.set_trace()
+        desired_number_of_pixels = self.get_multimodal_bucket(pixel_values.shape[0])
+        padding_len = desired_number_of_pixels - pixel_values.shape[0]
+        if padding_len <= 0:
+            return pixel_values, image_grid_thw
+
+        logger_msg = "Padding current number pixel " \
+            + str(pixel_values.shape[0]) \
+            + " to " \
+            + str(desired_number_of_pixels)
+        logger.info(logger_msg)
+
+        h_orig, w_orig = image_grid_thw[0, 1].item(), image_grid_thw[0, 2].item()
+        pad_h, pad_w = self.find_padding(h_orig, w_orig, desired_number_of_pixels)
+        if pad_h == 0 and pad_w == 0:
+            return pixel_values, image_grid_thw
+
+        constant_value = -100
+        pixel_values = torch.cat([
+            pixel_values,
+            torch.ones((padding_len, pixel_values.shape[1]), device=pixel_values.device) * constant_value
+        ])
+
+        image_grid_thw = torch.tensor([[1, h_orig + pad_h, w_orig + pad_w]],
+                                      device=image_grid_thw.device,
+                                      dtype=image_grid_thw.dtype)
+
+        assert image_grid_thw.prod(-1).sum() == desired_number_of_pixels
+        return pixel_values, image_grid_thw
+
+    def greedy_plan(self, batchsize, available_batchsizes):
+        # sort descending
+        available_batchsizes_sorted = sorted(available_batchsizes, key=lambda x: -x)
+        idx = 0
+        left_to_process = batchsize
+        result = []
+        while (left_to_process > 0 and idx < len(available_batchsizes_sorted)):
+            if available_batchsizes_sorted[idx] <= left_to_process:
+                result += [available_batchsizes_sorted[idx]]
+                left_to_process -= available_batchsizes_sorted[idx]
+            else:
+                idx += 1
+        if left_to_process > 0:
+            result += [available_batchsizes_sorted[-1]]  # this will be padded
+        return result
+
+    def __repr__(self):
+        return str(self.multimodal_buckets)

--- a/vllm_gaudi/extension/bucketing/vision.py
+++ b/vllm_gaudi/extension/bucketing/vision.py
@@ -3,22 +3,14 @@ from vllm.logger import init_logger
 
 logger = init_logger(__name__)
 
-MODEL_CONFIGS = {
+MULTIMODAL_CONFIG = {
     # Batch-based models
     'gemma-3': {
         'is_batch_based': True,
         'buckets': [1, 2, 4, 8]
     },
-    'internvl': {
-        'is_batch_based': True,
-        'buckets': [1, 2, 4, 6, 8]
-    },
 
     # Pixel-based models
-    'qwen2.5-vl': {
-        'is_batch_based': False,
-        'buckets': [1600, 3136, 4096, 6400, 7744, 9216, 12544]
-    },
     'ovis2.5': {
         'is_batch_based': False,
         'buckets': [784, 1600, 3136, 4096, 6400, 7744, 9216, 12544]
@@ -32,7 +24,7 @@ class HPUVisionBucketManager:
     '''
 
     def __init__(self, model_name, is_batch_based=True):
-        config = self._get_model_config(model_name)
+        config = self._get_multimodal_config(model_name)
 
         self.is_batch_based = is_batch_based if is_batch_based is not None else config['is_batch_based']
 
@@ -46,12 +38,12 @@ class HPUVisionBucketManager:
                 multimodal_buckets = [int(x) for x in envvar.split(',')]
             self.multimodal_buckets = self._process_buckets(multimodal_buckets)
 
-    def _get_model_config(self, model_name):
+    def _get_multimodal_config(self, model_name):
         """Get configuration for model"""
         model_name_lower = model_name.lower()
 
         # Find matching config
-        for key, config in MODEL_CONFIGS.items():
+        for key, config in MULTIMODAL_CONFIG.items():
             if key.replace('-', '').replace('.', '') in model_name_lower.replace('-', '').replace('.', ''):
                 return config
 

--- a/vllm_gaudi/extension/features.py
+++ b/vllm_gaudi/extension/features.py
@@ -38,6 +38,11 @@ def get_user_flags():
         # Non-vllm flags that are also important to print
         Env('EXPERIMENTAL_WEIGHT_SHARING', str),
         Env('PT_HPU_WEIGHT_SHARING', str),
+
+        # Sliding window flags
+        Env('PT_HPU_SDPA_QKV_SLICE_MODE_FWD', boolean),
+        Env('PT_HPU_SDPA_BC_FACTOR', int),
+        Env('VLLM_FUSEDSDPA_SLIDE_THLD', int),
     ]
     return to_dict(flags)
 

--- a/vllm_gaudi/extension/ops.py
+++ b/vllm_gaudi/extension/ops.py
@@ -302,10 +302,12 @@ def _fsdpa_prompt_attention(query: torch.Tensor,
                             is_causal: bool,
                             attn_bias: Optional[torch.Tensor] = None,
                             valid_seq_lengths: Optional[torch.Tensor] = None,
+                            window_size: Optional[int] = None,
                             **ignored_args) -> torch.Tensor:
     query = query.transpose(1, 2)
     key = key.transpose(1, 2)
     value = value.transpose(1, 2)
+    padding_side = 'right'
     if get_config().fp32_softmax:
         softmax_mode = 'fp32'
     else:
@@ -317,8 +319,14 @@ def _fsdpa_prompt_attention(query: torch.Tensor,
         # TODO: causal + attn_bias is not yet supported
         is_causal = False
         valid_seq_lengths = None
-    attn_weights = fsdpa_op(query, key, value, attn_bias, 0.0, is_causal, scale, softmax_mode, recompute_mode,
-                            valid_seq_lengths, 'right')
+
+    args = [
+        query, key, value, attn_bias, 0.0, is_causal, scale, softmax_mode, recompute_mode, valid_seq_lengths,
+        padding_side
+    ]
+    args += [window_size] if window_size else []
+    attn_weights = fsdpa_op(*args)
+
     attn_weights = attn_weights.transpose(1, 2)
     return attn_weights
 

--- a/vllm_gaudi/extension/utils.py
+++ b/vllm_gaudi/extension/utils.py
@@ -148,20 +148,15 @@ class ModuleFusedSDPA(torch.nn.Module):
         recompute_mode,
         valid_sequence_lengths,
         padding_side="left",
+        window_size=None,
     ):
-        return self._hpu_kernel_fsdpa.apply(
-            query,
-            key,
-            value,
-            attn_mask,
-            dropout_p,
-            is_causal,
-            scale,
-            softmax_mode,
-            recompute_mode,
-            valid_sequence_lengths,
-            padding_side,
-        )
+        if window_size is not None:
+            return self._hpu_kernel_fsdpa.apply(query, key, value, attn_mask, dropout_p, is_causal, scale, softmax_mode,
+                                                recompute_mode, valid_sequence_lengths, padding_side, False, False,
+                                                window_size)
+        else:
+            return self._hpu_kernel_fsdpa.apply(query, key, value, attn_mask, dropout_p, is_causal, scale, softmax_mode,
+                                                recompute_mode, valid_sequence_lengths, padding_side)
 
 
 def pad_list(input, target_len, val_generator):

--- a/vllm_gaudi/models/__init__.py
+++ b/vllm_gaudi/models/__init__.py
@@ -1,0 +1,9 @@
+from vllm.model_executor.models.registry import ModelRegistry
+
+
+def register_model():
+    from vllm_gaudi.models.gemma3_mm import HpuGemma3ForConditionalGeneration
+
+    ModelRegistry.register_model(
+        "Gemma3ForConditionalGeneration",  # Original architecture identifier in vLLM
+        "vllm_gaudi.models.gemma3_mm:HpuGemma3ForConditionalGeneration")

--- a/vllm_gaudi/models/__init__.py
+++ b/vllm_gaudi/models/__init__.py
@@ -2,7 +2,7 @@ from vllm.model_executor.models.registry import ModelRegistry
 
 
 def register_model():
-    from vllm_gaudi.models.gemma3_mm import HpuGemma3ForConditionalGeneration
+    from vllm_gaudi.models.gemma3_mm import HpuGemma3ForConditionalGeneration  # noqa: F401
 
     ModelRegistry.register_model(
         "Gemma3ForConditionalGeneration",  # Original architecture identifier in vLLM

--- a/vllm_gaudi/models/gemma3_mm.py
+++ b/vllm_gaudi/models/gemma3_mm.py
@@ -1,0 +1,56 @@
+import torch
+from vllm.config import VllmConfig
+from vllm.model_executor.models.gemma3_mm import (Gemma3ForConditionalGeneration, Gemma3MultiModalProcessor,
+                                                  Gemma3ProcessingInfo, Gemma3DummyInputsBuilder, Gemma3ImageInputs)
+from vllm.multimodal import MULTIMODAL_REGISTRY
+
+
+@MULTIMODAL_REGISTRY.register_processor(Gemma3MultiModalProcessor,
+                                        info=Gemma3ProcessingInfo,
+                                        dummy_inputs=Gemma3DummyInputsBuilder)
+class HpuGemma3ForConditionalGeneration(Gemma3ForConditionalGeneration):
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__(vllm_config=vllm_config, prefix=prefix)
+
+    def _process_image_input(self, image_input: Gemma3ImageInputs) -> list[torch.Tensor]:
+        assert self.vision_tower is not None
+        pixel_values = image_input["pixel_values"]
+        num_patches = image_input["num_patches"]
+
+        batch_breakdown = self.greedy_plan(pixel_values.shape[0],
+                                           [1, 2, 4, 8])  ##self.vision_buckets.multimodal_buckets)
+        start_idx = 0
+        image_embeds_multibatches = []
+
+        for i in batch_breakdown:
+            end_idx = start_idx + i
+            indices = torch.arange(start_idx, end_idx)
+            batch_sliced_pixel_values = torch.index_select(pixel_values, dim=0, index=indices)
+
+            image_features = self._image_pixels_to_features(
+                self.vision_tower,
+                batch_sliced_pixel_values,
+            )
+            image_embeds = self.multi_modal_projector(image_features)
+            image_embeds_multibatches += [image_embeds.clone()]
+            start_idx = end_idx
+        image_embeds = torch.cat(image_embeds_multibatches, dim=0)
+
+        return [e.flatten(0, 1) for e in image_embeds.split(num_patches.tolist())]
+
+    def greedy_plan(self, batchsize, available_batchsizes):
+        # sort descending
+        available_batchsizes_sorted = sorted(available_batchsizes, key=lambda x: -x)
+        idx = 0
+        left_to_process = batchsize
+        result = []
+        while (left_to_process > 0 and idx < len(available_batchsizes_sorted)):
+            if available_batchsizes_sorted[idx] <= left_to_process:
+                result += [available_batchsizes_sorted[idx]]
+                left_to_process -= available_batchsizes_sorted[idx]
+            else:
+                idx += 1
+        if left_to_process > 0:
+            result += [available_batchsizes_sorted[-1]]  # this will be padded
+        return result

--- a/vllm_gaudi/models/gemma3_mm.py
+++ b/vllm_gaudi/models/gemma3_mm.py
@@ -19,39 +19,30 @@ class HpuGemma3ForConditionalGeneration(Gemma3ForConditionalGeneration):
         pixel_values = image_input["pixel_values"]
         num_patches = image_input["num_patches"]
 
-        batch_breakdown = self.vision_bucket_manager.greedy_plan(pixel_values.shape[0],
-                                                                 self.vision_bucket_manager.multimodal_buckets)
-        start_idx = 0
-        image_embeds_multibatches = []
+        if hasattr(self, 'vision_bucket_manager'):
+            batch_breakdown = self.vision_bucket_manager.greedy_plan(pixel_values.shape[0],
+                                                                     self.vision_bucket_manager.multimodal_buckets)
+            start_idx = 0
+            image_embeds_multibatches = []
 
-        for i in batch_breakdown:
-            end_idx = start_idx + i
-            indices = torch.arange(start_idx, end_idx)
-            batch_sliced_pixel_values = torch.index_select(pixel_values, dim=0, index=indices)
+            for i in batch_breakdown:
+                end_idx = start_idx + i
+                indices = torch.arange(start_idx, end_idx).to(pixel_values.device)
+                batch_sliced_pixel_values = torch.index_select(pixel_values, dim=0, index=indices)
 
+                image_features = self._image_pixels_to_features(
+                    self.vision_tower,
+                    batch_sliced_pixel_values,
+                )
+                image_embeds = self.multi_modal_projector(image_features)
+                image_embeds_multibatches += [image_embeds.clone()]
+                start_idx = end_idx
+            image_embeds = torch.cat(image_embeds_multibatches, dim=0)
+        else:
             image_features = self._image_pixels_to_features(
                 self.vision_tower,
-                batch_sliced_pixel_values,
+                pixel_values,
             )
             image_embeds = self.multi_modal_projector(image_features)
-            image_embeds_multibatches += [image_embeds.clone()]
-            start_idx = end_idx
-        image_embeds = torch.cat(image_embeds_multibatches, dim=0)
 
         return [e.flatten(0, 1) for e in image_embeds.split(num_patches.tolist())]
-
-    def greedy_plan(self, batchsize, available_batchsizes):
-        # sort descending
-        available_batchsizes_sorted = sorted(available_batchsizes, key=lambda x: -x)
-        idx = 0
-        left_to_process = batchsize
-        result = []
-        while (left_to_process > 0 and idx < len(available_batchsizes_sorted)):
-            if available_batchsizes_sorted[idx] <= left_to_process:
-                result += [available_batchsizes_sorted[idx]]
-                left_to_process -= available_batchsizes_sorted[idx]
-            else:
-                idx += 1
-        if left_to_process > 0:
-            result += [available_batchsizes_sorted[-1]]  # this will be padded
-        return result

--- a/vllm_gaudi/models/utils.py
+++ b/vllm_gaudi/models/utils.py
@@ -1,0 +1,60 @@
+import torch
+from vllm.multimodal import NestedTensors
+from vllm.model_executor.models import utils
+from vllm.model_executor.models.utils import (_embedding_count_expression, _flatten_embeddings)
+
+
+def _merge_multimodal_embeddings(
+    inputs_embeds: torch.Tensor,
+    multimodal_embeddings: NestedTensors,
+    is_multimodal: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Merge ``multimodal_embeddings`` into ``inputs_embeds`` by overwriting the
+    positions in ``inputs_embeds`` corresponding to placeholder tokens in
+    ``input_ids``.
+
+    Note:
+        This updates ``inputs_embeds`` in place.
+    """
+    if len(multimodal_embeddings) == 0:
+        return inputs_embeds
+
+    import habana_frameworks.torch.core as htcore
+    htcore.mark_step()
+
+    mm_embeds_flat = _flatten_embeddings(multimodal_embeddings)
+    input_dtype = inputs_embeds.dtype
+
+    try:
+        # TODO: Replaced masked_scatter with torch.where to avoid HPU performance issues
+        # with non_zero_i8 ops in TPC kernel. However, torch.where creates dynamic operations
+        # causing recompilation on each run. Need to find a static operation alternative.
+
+        # For debugging
+        # inputs_embeds[is_multimodal] = mm_embeds_flat.to(dtype=input_dtype)
+        #htcore.mark_step()
+        # NOTE: This can avoid D2H sync (#22105), but fails to
+        # raise an error if is_multimodal.sum() < len(mm_embeds_flat)
+        # inputs_embeds.masked_scatter_(is_multimodal.unsqueeze(-1),
+        #                               mm_embeds_flat.to(dtype=input_dtype))
+
+        multimodal_positions = torch.where(is_multimodal)[0][:mm_embeds_flat.shape[0]]
+        inputs_embeds[0, multimodal_positions] = mm_embeds_flat.to(dtype=input_dtype)
+
+    except RuntimeError as e:
+        num_actual_tokens = len(mm_embeds_flat)
+        num_expected_tokens = is_multimodal.sum().item()
+
+        if num_actual_tokens != num_expected_tokens:
+            expr = _embedding_count_expression(multimodal_embeddings)
+
+            raise ValueError(f"Attempted to assign {expr} = {num_actual_tokens} "
+                             f"multimodal tokens to {num_expected_tokens} placeholders") from e
+
+        raise ValueError("Error during masked scatter operation") from e
+
+    return inputs_embeds
+
+
+utils._merge_multimodal_embeddings = _merge_multimodal_embeddings

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -350,6 +350,22 @@ class HpuModelAdapter(torch.nn.Module, KVConnectorModelRunnerMixin):
         self.num_tokens_across_dp = [self.dummy_num_input_tokens] * self.vllm_config.parallel_config.data_parallel_size
         self.dummy_num_tokens_across_dp_cpu = torch.tensor(self.num_tokens_across_dp, device='cpu', dtype=torch.int32)
 
+        # Vision embedding can be also wrapped in HPU graph once all the dynamic shape is removed.
+        # Performance can be greatly improved.
+        if htorch.utils.internal.is_lazy() and \
+           MULTIMODAL_REGISTRY.supports_multimodal_inputs(vllm_config.model_config):
+            if self.is_mm_optimized:
+                if hasattr(self.model, 'vision_tower'):
+                    logger.info("[Multimodal] Wrapping vision_tower")
+                    self.model.vision_tower = htorch.hpu.wrap_in_hpu_graph(self.model.vision_tower,
+                                                                           disable_tensor_cache=False)
+                if hasattr(self.model, 'multi_modal_projector'):
+                    logger.info("[Multimodal] Wrapping multi_modal_projector")
+                    self.model.multi_modal_projector = \
+                            htorch.hpu.wrap_in_hpu_graph( \
+                            self.model.multi_modal_projector, \
+                            disable_tensor_cache=True)
+
     def _get_rotary_embedding_module(self, model: torch.nn.Module):
         """
         Dynamically get the RotaryEmbedding layer in the model.
@@ -839,6 +855,7 @@ class HPUModelRunner(KVConnectorModelRunnerMixin):
                                               max_num_batched_tokens=self.max_num_batched_tokens,
                                               max_model_len=self.max_model_len)
             self.graphed_buckets: set[Any] = set()
+            self.graphed_multimodal_buckets: set[Any] = set()
         else:
             logger.info("Bucketing is OFF.")
         self._PAD_SLOT_ID = -1
@@ -1392,6 +1409,8 @@ class HPUModelRunner(KVConnectorModelRunnerMixin):
         return mm_embeds, is_mm_embed
 
     def get_model(self) -> torch.nn.Module:
+        if isinstance(self.model, HpuModelAdapter):
+            return self.model.model
         assert self.model is not None
         return self.model
 
@@ -2979,7 +2998,6 @@ class HPUModelRunner(KVConnectorModelRunnerMixin):
             logits_prompt = []
             logits_decode = []
             structured_output = True
-
         if self.use_async_scheduling:
             invalid_req_indices = []
         ######################### PREFILLS #########################
@@ -2994,10 +3012,13 @@ class HPUModelRunner(KVConnectorModelRunnerMixin):
                     # Run the multimodal encoder if any.
                     with self.profiler.record_event('internal', 'prepare_input_encoders'):
                         self._execute_mm_encoder(scheduler_output, req_id)
+                    htorch.core.mark_step()
 
                     mm_embeds, is_mm_embed = self._gather_mm_embeddings(scheduler_output,
                                                                         req_id,
                                                                         total_num_scheduled_tokens=token_ids.shape[-1])
+                    htorch.core.mark_step()
+
                     # TODO: Only get embeddings for valid token_ids. Ignore token_ids[<pad_idxs>] # noqa E501
                     # This may require moving multimodal input preps into _prepare_inputs,        # noqa E501
                     # to avoid padding issues.
@@ -3536,6 +3557,15 @@ class HPUModelRunner(KVConnectorModelRunnerMixin):
                    f"free_mem:{free_mem}")
         logger.info(msg)
 
+    def log_warmup_multimodal(self, phase, i, max_i, batch_size, seq_len, img_args):
+        free_mem = format_bytes(HabanaMemoryProfiler.current_free_device_memory())
+        msg = (f"[Warmup][{phase}][{i+1}/{max_i}] "
+               f"batch_size:{batch_size} "
+               f"seq_len:{seq_len} "
+               f"img_args:{img_args} "
+               f"free_mem:{free_mem}")
+        logger.info(msg)
+
     def warmup_sampler(self):
         """
         Warmup the sampler with different temperature, top-p, and top-k values.
@@ -4017,6 +4047,73 @@ class HPUModelRunner(KVConnectorModelRunnerMixin):
             decode_cfg = (decode_cfg[0], 1, decode_cfg[1])
         return prompt_cfg, decode_cfg
 
+    def _get_mm_dummy_batch(
+        self,
+        modality: str,
+        max_items_per_batch: int,
+    ) -> BatchedTensorInputs:
+        """Dummy data for profiling and precompiling multimodal models."""
+        assert self.mm_budget is not None
+
+        dummy_decoder_data = self.mm_registry.get_decoder_dummy_data(
+            model_config=self.model_config,
+            seq_len=self.max_model_len,
+            mm_counts={modality: 1},
+            cache=self.mm_budget.cache,
+        )
+        dummy_mm_data = dummy_decoder_data.multi_modal_data
+
+        # Result in the maximum GPU consumption of the model
+        dummy_mm_item = dummy_mm_data[modality][0]
+        dummy_mm_items = [dummy_mm_item] * max_items_per_batch
+
+        return next(mm_kwargs_group for _, _, mm_kwargs_group in group_mm_kwargs_by_modality(
+            dummy_mm_items,
+            device=self.device,
+            pin_memory=self.pin_memory,
+        ))
+
+    def warmup_multimodal_graphs(self, buckets):
+
+        phase = 'Graph/Multimodal'
+        from vllm.v1.worker.utils import MultiModalBudget
+        self.mm_budget = MultiModalBudget(
+            self.model_config,
+            self.scheduler_config,
+            self.mm_registry,
+        ) if self.supports_mm_inputs else None
+
+        #self.mm_budget.mm_limits : {'image': 2}
+        for modality, max_items in self.mm_budget.mm_limits.items():
+            phase = f'Graph/Multimodal({modality})'
+            num_candidates = len(buckets)
+
+            for idx, img_arg in enumerate(buckets):
+                # some model might need checks .. Not needed for Gemma.
+                # if img_arg > max_items:
+                #     logger.warning(f"mm bucket {idx} is bigger than max_limit {max_items} for {modality}, skip warmup ")
+                #     continue
+
+                # Create dummy batch of multimodal inputs.
+                batched_dummy_mm_inputs = self._get_mm_dummy_batch(
+                    modality,
+                    img_arg,
+                )
+                #htorch.core.mark_step()
+                # Run multimodal encoder.
+                dummy_encoder_outputs = \
+                     self.model.get_multimodal_embeddings(
+                     **batched_dummy_mm_inputs)
+                #htorch.core.mark_step()
+
+                sanity_check_mm_encoder_outputs(
+                    dummy_encoder_outputs,
+                    expected_num_items=img_arg,
+                )
+
+                self.graphed_buckets.add(img_arg)
+                self.log_warmup_multimodal(phase, idx, num_candidates, 1, 0, img_arg)
+
     @torch.inference_mode()
     def warmup_model(self) -> None:
         if not self.enable_bucketing:
@@ -4027,6 +4124,13 @@ class HPUModelRunner(KVConnectorModelRunnerMixin):
         else:
             self.bucketing_manager.generate_prompt_buckets()
             self.bucketing_manager.generate_decode_buckets()
+
+            if self.supports_mm_inputs:
+                # Delayed multimodal buckets during warmup until model is loaded.
+                from vllm_gaudi.extension.bucketing.vision import HPUVisionBuckets
+                #TODO: Check - is_batch_based = is_batch_based(self.get_model())
+                self.get_model().vision_buckets = HPUVisionBuckets()
+                print(f"Multimodal bucket : {self.get_model().vision_buckets.multimodal_buckets}")
 
             max_bucket = max(self.bucketing_manager.decode_buckets[-1][0], self.bucketing_manager.prompt_buckets[-1][0])
             if max_bucket > self.input_batch.max_num_reqs:
@@ -4069,6 +4173,10 @@ class HPUModelRunner(KVConnectorModelRunnerMixin):
         self.profiler.start('internal', 'warmup')
         start_mem = HabanaMemoryProfiler.current_device_memory_usage()
         start_time = time.perf_counter()
+
+        # Most model's multimodal embedding has to be run without COMPILE ONLY mode.
+        if self.supports_mm_inputs:
+            self.warmup_multimodal_graphs(self.get_model().vision_buckets.multimodal_buckets)
 
         compile_only_mode_context = functools.partial(bc.env_setting, "PT_COMPILE_ONLY_MODE", True)
         can_use_compile_only_mode = True

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -4067,10 +4067,12 @@ class HPUModelRunner(KVConnectorModelRunnerMixin):
         dummy_mm_item = dummy_mm_data[modality][0]
         dummy_mm_items = [dummy_mm_item] * max_items_per_batch
 
+        self.model.model = cast(SupportsMultiModal, self.model.model)
         return next(mm_kwargs_group for _, _, mm_kwargs_group in group_mm_kwargs_by_modality(
             dummy_mm_items,
             device=self.device,
             pin_memory=self.pin_memory,
+            merge_by_field_config=self.model.model.merge_by_field_config,
         ))
 
     def warmup_multimodal_graphs(self, buckets):


### PR DESCRIPTION
This is to optimize gemma3 multimodal memory/performance. 
 - bucket vision tower based on batch bucket to reduce recompile overhead 
 - modify merge_multimodal to use torch.where instead of masked_scatter for performance issue 
 - add warmup multimodal bucket to precompile vision tower 
 - port PT_HPU_SDPA_QKV_SLICE_MODE_FWD feature from vllm-fork v0 : this is necessary to reduce the memory for the longer sequence length. 
 - add 01,02 prefix for the general plugin so the order of initialization of plugins is guaranteed(ops followed by model) 