### PR TITLE
[SW-242466] Update not_over_max_model_len filter to fix warmup perf regression

### DIFF
--- a/tests/unit_tests/test_bucketing.py
+++ b/tests/unit_tests/test_bucketing.py
@@ -50,7 +50,7 @@ def test_generate_prompt_buckets():
     ctx_range = [0, 1, 2, 3, 4]
     buckets = generate_buckets(bs_range, query_range, ctx_range, True, max_model_len, bs, prompt_bs,
                                max_num_batched_tokens, block_size, max_blocks)
-    assert len(buckets) == 17
+    assert len(buckets) == 25
 
 
 def test_generate_decode_buckets():

--- a/vllm_gaudi/extension/bucketing/common.py
+++ b/vllm_gaudi/extension/bucketing/common.py
@@ -250,10 +250,10 @@ def generate_buckets(bs_range, query_range, ctx_range, is_prompt, max_model_len,
     # filter rules for buckets
     # prompt
     def not_over_max_model_len(bs, query, ctx):
-        smaller_than_limit = bs * (query + ctx * block_size) <= max_model_len
+        smaller_than_limit = (query + ctx * block_size) <= max_model_len
         if not smaller_than_limit:
             omitted_buckets.add(
-                ("condition: bs * (query + ctx * block_size) <= max_model_len", "-> bs, query, ctx: ", bs, query, ctx))
+                ("condition: (query + ctx * block_size) <= max_model_len", "-> bs, query, ctx: ", bs, query, ctx))
         return smaller_than_limit
 
     def not_over_max_num_batched_tokens(bs, query, ctx):


### PR DESCRIPTION
Fix performance regression caused by missing warmup buckets associated with https://github.com/vllm-project/vllm-gaudi/pull/331