### PR TITLE
[FIX_FOR_VLLM_LATEST] Fix for #26440

### DIFF
--- a/vllm_gaudi/platform.py
+++ b/vllm_gaudi/platform.py
@@ -126,6 +126,9 @@ class HpuPlatform(Platform):
 
             print(f"========={compilation_config.custom_ops=}===========")
 
+        # Disable multi-stream for shared experts as no Stream on CPU
+        os.environ["VLLM_DISABLE_SHARED_EXPERTS_STREAM"] = "0"
+
     @classmethod
     def is_pin_memory_available(cls):
         logger.warning("Pin memory is not supported on HPU.")


### PR DESCRIPTION
Fix for "[Performance] Dual stream execution of "shared_experts" and "selected_experts" inside FusedMoE #26440"
Similar to [Bugfix][CPU] Disable dual stream execution for experts on CPU #27320