### PR TITLE
Fix math log2 exponential bucket error if max_model_len <= block_size

### DIFF
--- a/vllm_gaudi/extension/bucketing/exponential.py
+++ b/vllm_gaudi/extension/bucketing/exponential.py
@@ -37,7 +37,7 @@ class ExponentialBucketingStrategy():
         prompt_bs_bucket_cfg = [1, 2, max_num_prefill_seqs, prompt_bs_limit]
         max_prompt_seq_limit = math.ceil(math.log2(max_num_batched_tokens))
         prompt_query_bucket_cfg = [block_size, block_size, max_num_batched_tokens, max_prompt_seq_limit]
-        max_ctx = math.ceil((max_model_len - prompt_query_bucket_cfg[0]) // block_size)
+        max_ctx = max(1, math.ceil((max_model_len - prompt_query_bucket_cfg[0]) // block_size))
         max_prompt_ctx_limit = 2 if max_ctx == 1 else math.ceil(math.log2(max_ctx)) + 1
         prompt_ctx_bucket_cfg = [0, 1, max_ctx, max_prompt_ctx_limit]
 


### PR DESCRIPTION
INC calibration fails with math domain error when math.log2 op has undefined result during INC calibration. The INC calibration scripts uses  max_model_len=128 which results in max_ctx=0. log2 of zero is undefined.

`PT_HPU_LAZY_MODE=1 ./calibrate_model.sh -m meta-llama/Llama-3.1-70B -d NeelNanda/pile-10k -o ./inc2 -b 1 -t 2 -l 5`


ESC[1;36m(Worker_TP1 pid=65456)ESC[0;0m INFO 10-22 22:53:05 [hpu_worker.py:242] Initializing cache engine took 74.67 GiB of device memory (109 GiB/126.5 GiB used) and -1.967 GiB of host memory (93.07 GiB/1007 GiB used)
ESC[1;36m(Worker_TP1 pid=65456)ESC[0;0m ERROR 10-22 22:53:05 [multiproc_executor.py:703] WorkerProc hit an exception.
ESC[1;36m(Worker_TP1 pid=65456)ESC[0;0m ERROR 10-22 22:53:05 [multiproc_executor.py:703] Traceback (most recent call last):
ESC[1;36m(Worker_TP1 pid=65456)ESC[0;0m ERROR 10-22 22:53:05 [multiproc_executor.py:703]   File "/tmp/vllm/vllm/v1/executor/multiproc_executor.py", line 698, in worker_busy_loop
ESC[1;36m(Worker_TP1 pid=65456)ESC[0;0m ERROR 10-22 22:53:05 [multiproc_executor.py:703]     output = func(*args, **kwargs)
ESC[1;36m(Worker_TP1 pid=65456)ESC[0;0m ERROR 10-22 22:53:05 [multiproc_executor.py:703]   File "/tmp/vllm/vllm/v1/worker/worker_base.py", line 305, in initialize_from_config
ESC[1;36m(Worker_TP1 pid=65456)ESC[0;0m ERROR 10-22 22:53:05 [multiproc_executor.py:703]     self.worker.initialize_from_config(kv_cache_config)  # type: ignore
ESC[1;36m(Worker_TP1 pid=65456)ESC[0;0m ERROR 10-22 22:53:05 [multiproc_executor.py:703]   File "/tmp/vllm-gaudi/vllm_gaudi/v1/worker/hpu_worker.py", line 243, in initialize_from_config
ESC[1;36m(Worker_TP1 pid=65456)ESC[0;0m ERROR 10-22 22:53:05 [multiproc_executor.py:703]     self.compile_or_warm_up_model()
ESC[1;36m(Worker_TP1 pid=65456)ESC[0;0m ERROR 10-22 22:53:05 [multiproc_executor.py:703]   File "/tmp/vllm-gaudi/vllm_gaudi/v1/worker/hpu_worker.py", line 249, in compile_or_warm_up_model
ESC[1;36m(Worker_TP1 pid=65456)ESC[0;0m ERROR 10-22 22:53:05 [multiproc_executor.py:703]     self.model_runner.warmup_model()
ESC[1;36m(Worker_TP1 pid=65456)ESC[0;0m ERROR 10-22 22:53:05 [multiproc_executor.py:703]   File "/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py", line 116, in decorate_context
ESC[1;36m(Worker_TP1 pid=65456)ESC[0;0m ERROR 10-22 22:53:05 [multiproc_executor.py:703]     return func(*args, **kwargs)
ESC[1;36m(Worker_TP1 pid=65456)ESC[0;0m ERROR 10-22 22:53:05 [multiproc_executor.py:703]   File "/tmp/vllm-gaudi/vllm_gaudi/v1/worker/hpu_model_runner.py", line 4028, in warmup_model
ESC[1;36m(Worker_TP1 pid=65456)ESC[0;0m ERROR 10-22 22:53:05 [multiproc_executor.py:703]     self.bucketing_manager.generate_prompt_buckets()
ESC[1;36m(Worker_TP1 pid=65456)ESC[0;0m ERROR 10-22 22:53:05 [multiproc_executor.py:703]   File "/tmp/vllm-gaudi/vllm_gaudi/extension/bucketing/common.py", line 110, in generate_prompt_buckets
ESC[1;36m(Worker_TP1 pid=65456)ESC[0;0m ERROR 10-22 22:53:05 [multiproc_executor.py:703]     bs_cfg, query_cfg, ctx_cfg = strategy.get_prompt_cfgs(max_num_prefill_seqs=self.max_num_prefill_seqs,
ESC[1;36m(Worker_TP1 pid=65456)ESC[0;0m ERROR 10-22 22:53:05 [multiproc_executor.py:703]   File "/tmp/vllm-gaudi/vllm_gaudi/extension/bucketing/exponential.py", line 42, in get_prompt_cfgs
ESC[1;36m(Worker_TP1 pid=65456)ESC[0;0m ERROR 10-22 22:53:05 [multiproc_executor.py:703]     max_prompt_ctx_limit = 2 if max_ctx == 1 else math.ceil(math.log2(max_ctx)) + 1
ESC[1;36m(Worker_TP1 pid=65456)ESC[0;0m ERROR 10-22 22:53:05 [multiproc_executor.py:703] ValueError: math domain error