### PR TITLE
Port: Experimental - fatal errro from 0.12 release (#398)

### DIFF
--- a/vllm_gaudi/extension/runtime.py
+++ b/vllm_gaudi/extension/runtime.py
@@ -74,7 +74,7 @@ def finalize_config():
         logger().warning(
             f"Following environment variables are considered experimental: {', '.join(experimental_flags)}")
         logger().warning(
-            "In future releases using those flags without VLLM_ENABLE_EXPERIMENTAL_FLAGS will trigger a fatal error.")
+            "From v0.12.0 release using those flags without VLLM_ENABLE_EXPERIMENTAL_FLAGS will trigger a fatal error.")
         logger().warning(footer)
 
     dump('Environment', environment_values)


### PR DESCRIPTION
Port: https://github.com/vllm-project/vllm-gaudi/pull/398