### PR TITLE
Fix defragmentation for MLA-based models

### DIFF
--- a/vllm_gaudi/extension/defragmentation.py
+++ b/vllm_gaudi/extension/defragmentation.py
@@ -51,7 +51,7 @@ class CacheSwapUtils(torch.nn.Module):
         dsts = torch.tensor(dsts, dtype=torch.long, device='cpu').to('hpu', non_blocking=True)
         key_caches = [cache[0] for cache in self.kv_caches]
         self(srcs, dsts, key_caches)
-        if not is_mla:
+        if not self.is_mla:
             value_caches = [cache[1] for cache in self.kv_caches]
             self(srcs, dsts, value_caches)
 


### PR DESCRIPTION
MLA-based models don't have key-value pairs in cache and utilize a single latent cache, so trying to swap anything in value cache will fail, as the cache is None. GSM8k seems to work fine now with contiguous PA + defrag + APC disabled on deepseek-ai/DeepSeek-V2-Lite-Chat:
```
VLLM_SKIP_WARMUP=true VLLM_CONTIGUOUS_PA=true VLLM_DEFRAG=true PT_HPU_LAZY_MODE=1 lm_eval --model vllm --model_args pretrained=deepseek-ai/DeepSeek-V2-Lite-Chat,,enforce_eager=False,dtype=bfloat16,max_num_seqs=128,gpu_memory_utilization=0.8,max_model_len=4096,enable_prefix_caching=False,add_bos_token=false,tensor_parallel_size=1,max_gen_toks=2048 --tasks gsm8k_cot_llama --batch_size auto --trust_remote_code --apply_chat_template --fewshot_as_multiturn --num_fewshot 8

|     Tasks     |Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|---------------|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k_cot_llama|      3|flexible-extract|     8|exact_match|↑  |0.7074|±  |0.0125|
|               |       |strict-match    |     8|exact_match|↑  |0.6952|±  |0.0127|
```