### PR TITLE
[SW-243111] Add correctors for decode buckets

### DIFF
--- a/tests/unit_tests/test_bucketing.py
+++ b/tests/unit_tests/test_bucketing.py
@@ -64,5 +64,5 @@ def test_generate_decode_buckets():
     blocks_range = [128, 256, 384, 512, 640, 768, 896, 1024, 1152, 1280, 1408, 1536, 1664, 1792, 1920, 2048]
     buckets = generate_buckets(bs_range, [1, 1, 1], blocks_range, False, max_model_len, bs, prompt_bs,
                                max_num_batched_tokens, block_size, max_blocks)
-    assert len(buckets) == 15
+    assert len(buckets) == 18
     assert all(ctx <= bs * (max_model_len // block_size) for bs, _, ctx in buckets)


### PR DESCRIPTION
Decode buckets will not be setup properly if maximum context value is missing from context range. Fillters will only remove certain buckets, but will not introduce new values in the defined ranges. Instead, for decode buckets, use a corrector function that will truncate context lenght values to the maximum.

---------