### PR TITLE
Fix concat error when there is no prefill/decode tokens

### DIFF
--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -3183,7 +3183,10 @@ class HPUModelRunner(KVConnectorModelRunnerMixin):
                     decode_sampled_token_ids = [tensor.cpu() for tensor in decode_sampled_token_ids]
                 else:
                     decode_sampled_token_ids = [tensor.cpu()[:num_decodes] for tensor in decode_sampled_token_ids]
-                sampled_token_ids_list = torch.cat(decode_sampled_token_ids + prefill_sampled_token_ids).tolist()
+                sampled_token_ids_list = []
+                # When there is no prompt or decode, skip concat to avoid error
+                if (len(prefill_sampled_token_ids) + len(decode_sampled_token_ids)) > 0:
+                    sampled_token_ids_list = torch.cat(decode_sampled_token_ids + prefill_sampled_token_ids).tolist()
                 sampled_token_requests = \
                     decode_sampled_requests + prefill_sampled_requests
                 max_req_index = max(self.input_batch.req_id_to_index.values())


### PR DESCRIPTION
This is to fix SW-243767. When there is no prefill or decode tokens, which happens in the beginning of a run when max_num_batched_tokens < input length, torch.cat can return an error. 