### PR TITLE
Allow building vllm-plugin docker for ubuntu with upstream torch

### DIFF
--- a/.cd/Dockerfile.ubuntu.pytorch.vllm
+++ b/.cd/Dockerfile.ubuntu.pytorch.vllm
@@ -8,8 +8,9 @@ ARG BASE_NAME=ubuntu24.04
 ARG PT_VERSION=2.7.1
 ARG REVISION=latest
 ARG REPO_TYPE=habanalabs
+ARG TORCH_TYPE_SUFFIX
 
-FROM ${DOCKER_URL}/${VERSION}/${BASE_NAME}/${REPO_TYPE}/pytorch-installer-${PT_VERSION}:${REVISION}
+FROM ${DOCKER_URL}/${VERSION}/${BASE_NAME}/${REPO_TYPE}/pytorch-${TORCH_TYPE_SUFFIX}installer-${PT_VERSION}:${REVISION}
 
 # Parameterize commit/branch for vllm-project & vllm-gaudi checkout
 ARG VLLM_GAUDI_COMMIT=main

--- a/.cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest
+++ b/.cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest
@@ -8,8 +8,9 @@ ARG BASE_NAME=ubuntu22.04
 ARG PT_VERSION=2.7.1
 ARG REVISION=latest
 ARG REPO_TYPE=habanalabs
+ARG TORCH_TYPE_SUFFIX
 
-FROM ${DOCKER_URL}/${VERSION}/${BASE_NAME}/${REPO_TYPE}/pytorch-installer-${PT_VERSION}:${REVISION}
+FROM ${DOCKER_URL}/${VERSION}/${BASE_NAME}/${REPO_TYPE}/pytorch-${TORCH_TYPE_SUFFIX}installer-${PT_VERSION}:${REVISION}
 
 # Parameterize commit/branch for vllm-project & vllm-gaudi checkout
 ARG VLLM_PROJECT_COMMIT=v0.10.2


### PR DESCRIPTION
To create vllm-plugin docker for Ubuntu with torch package taken from upstream we need to modify 'FROM' directive - image should be based on pytorch-upstream-installer.

'TORCH_TYPE_SUFFIX' arg will have one of two values:
- empty string (default)
- 'upstream-'

It's the same change as https://github.com/vllm-project/vllm-gaudi/pull/155 but this time for Ubuntu instead of RHEL.