### PR TITLE
Add VLLM_DEFRAG env to enable defrag without UA

### DIFF
--- a/vllm_gaudi/extension/features.py
+++ b/vllm_gaudi/extension/features.py
@@ -85,7 +85,7 @@ def get_features():
         Value('exponential_bucketing', True),
         Value('linear_bucketing', True),
         ValueFromList('bucketing_strategy', bucketing_strategies),
-        Value('defrag', Enabled('unified_attn')),
+        Value('defrag', Enabled('unified_attn'), env_var='VLLM_DEFRAG', env_var_type=boolean),
         Value('regional_compilation', True, env_var='VLLM_T_COMPILE_REGIONAL_COMPILATION', env_var_type=boolean),
         Value('dynamic_shapes_compilation', True, env_var='VLLM_T_COMPILE_DYNAMIC_SHAPES', env_var_type=boolean),
         Value('fullgraph_compilation', False, env_var='VLLM_T_COMPILE_FULLGRAPH', env_var_type=boolean),


### PR DESCRIPTION
We need to enable defrag with contiguous pa for deepseek r1. Add the env to enable defrag. 