### PR TITLE
Allow building vllm-plugin docker for ubuntu with upstream torch

### DIFF
--- a/.cd/Dockerfile.ubuntu.pytorch.vllm
+++ b/.cd/Dockerfile.ubuntu.pytorch.vllm
@@ -8,8 +8,9 @@ ARG BASE_NAME=ubuntu24.04
 ARG PT_VERSION=2.9.0
 ARG REVISION=latest
 ARG REPO_TYPE=habanalabs
+ARG TORCH_TYPE_SUFFIX
 
-FROM ${DOCKER_URL}/${VERSION}/${BASE_NAME}/${REPO_TYPE}/pytorch-installer-${PT_VERSION}:${REVISION}
+FROM ${DOCKER_URL}/${VERSION}/${BASE_NAME}/${REPO_TYPE}/pytorch-${TORCH_TYPE_SUFFIX}installer-${PT_VERSION}:${REVISION}
 
 # Parameterize commit/branch for vllm-project & vllm-gaudi checkout
 ARG VLLM_GAUDI_COMMIT=v0.10.2_next


### PR DESCRIPTION
To create vllm-plugin docker for Ubuntu with torch package taken from upstream we need to modify 'FROM' directive - image should be based on pytorch-upstream-installer.

'TORCH_TYPE_SUFFIX' arg will have one of two values:
- empty string (default)
- 'upstream-'