### PR TITLE
Spec decode: fix MTP function broken by using unified MTP method names

### DIFF
--- a/tests/full_tests/spec_decode.py
+++ b/tests/full_tests/spec_decode.py
@@ -243,6 +243,7 @@ def test_mtp_model(is_enable, args, prompts, sampling_params, task_key, result_q
                 enable_expert_parallel=True,
                 speculative_config={
                     "num_speculative_tokens": args.num_spec_tokens,
+                    "method": "mtp",
                 },
                 disable_log_stats=False,
                 trust_remote_code=True,
@@ -330,7 +331,7 @@ if __name__ == "__main__":
             task_queue['baseline_eaglemtp'] = {
                 'proc':
                 multiprocessing.Process(target=test_eaglemtp_model,
-                                        args=(False, args, prompts, sampling_params, 'baseline_mtp', result_queue))
+                                        args=(False, args, prompts, sampling_params, 'baseline_eaglemtp', result_queue))
             }
         task_queue['spec_eaglemtp'] = {
             'proc':

--- a/vllm_gaudi/v1/spec_decode/hpu_eagle.py
+++ b/vllm_gaudi/v1/spec_decode/hpu_eagle.py
@@ -45,7 +45,8 @@ class HpuEagleProposer(EagleProposer):
             attn_metadata=common_attn_metadata,
         )
 
-        if self.method in ("deepseek_mtp", "ernie_mtp"):
+        # All MTP related method names are now unified to "mtp"
+        if self.method == "mtp":
             last_hidden_states = ret_hidden_states
             hidden_states = last_hidden_states
         else:
@@ -63,7 +64,7 @@ class HpuEagleProposer(EagleProposer):
         target_positions = target_positions.view(-1)
         # [batch_size]
         positions = target_positions[last_token_indices]
-        if self.method in ("deepseek_mtp", "ernie_mtp", "longcat_flash_mtp"):
+        if self.method == "mtp":
             hidden_states = target_hidden_states.view(-1, target_hidden_states.shape[-1])
         else:
             hidden_states = hidden_states.view(-1, hidden_states.shape[-1])


### PR DESCRIPTION
vLLM PR (https://github.com/vllm-project/vllm/pull/25232) has consolidated speculative decode method name for MTP. We need to use "mtp" in the code instead of other names.