### PR TITLE
Resolve issue with async scheduling when decode and prompt tokens are mixed

### DIFF
--- a/vllm_gaudi/extension/unified_batch.py
+++ b/vllm_gaudi/extension/unified_batch.py
@@ -688,7 +688,7 @@ def create_unified_batch(req_ids: list[str],
     # Async scheduling.
     invalid_req_indices = []
     if input_ids_hpu is not None:
-        # When decodes are not the first ones in the batch, need to copy them to the correct positions
+        # When decodes are not first in the batch, need to copy them to the correct positions
         if decode_index is not None:
             token_ids_device[decode_index] = input_ids_hpu[decode_index]
         else:

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -2389,7 +2389,9 @@ class HPUModelRunner(KVConnectorModelRunnerMixin):
         )
         return decode_input_data, None
 
-    def _prepare_input_ids(self, scheduler_output: "SchedulerOutput", return_index=False) -> Optional[torch.Tensor]:
+    def _prepare_input_ids(self,
+                           scheduler_output: "SchedulerOutput",
+                           return_index: bool = False) -> Optional[torch.Tensor]:
         """Prepare the input IDs for the current batch.
         
         Carefully handles the `prev_sampled_token_ids` which can be cached


### PR DESCRIPTION
When decode tokens are not strictly before prompt tokens, tokens from the previous batch cannot be copied using :num_decodes when using async scheduling. 