### PR TITLE
Trigger CI tests for nixl libfabric VLLM

### DIFF
--- a/tests/full_tests/ci_gsm8k_tests.sh
+++ b/tests/full_tests/ci_gsm8k_tests.sh
@@ -257,6 +257,7 @@ run_embedding_model_test() {
 
 # pd_disaggregate_nixl_libfabric
 run_pd_disaggregate_nixl_libfabric_test() {
+    echo ""[CI TEST] This is a test for CI!"	
     echo "➡️ Testing PD disaggregate through NIXL libfabric."
     git clone https://github.com/intel-staging/nixl.git -b v0.6.0_OFI
     cp -r nixl /tmp/nixl_source


### PR DESCRIPTION
This pull request introduces a minor update to the `run_pd_disaggregate_nixl_libfabric_test()` function in `tests/full_tests/ci_gsm8k_tests.sh`. The change adds a new log message to indicate the start of a CI test.

* Logging improvement:
  * Added an informational echo statement to clarify that the test is being run for CI purposes in the `run_pd_disaggregate_nixl_libfabric_test()` function.