### PR TITLE
Add missing quantization files (#639)

### DIFF
--- a/calibration/deepseek_gaudi2_converter.py
+++ b/calibration/deepseek_gaudi2_converter.py
@@ -1,0 +1,70 @@
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+from glob import glob
+import os
+
+import argparse
+
+
+def copy_other_files(input_path, output_path):
+    import shutil
+
+    for file in os.listdir(input_path):
+        if file.endswith(".json") or file.endswith(".py"):
+            print(f"copying {file} to {output_path}")
+            shutil.copyfile(
+                os.path.join(input_path, file),
+                os.path.join(output_path, file),
+            )
+
+
+def convert_files(input_path, output_path):
+    all_safetensors = glob(f"{input_path}/*.safetensors")
+    # sort by file name
+    all_safetensors.sort()
+    for safetensors_path in all_safetensors:
+        tensors = {}
+        print(f"processing {safetensors_path}")
+        with safe_open(safetensors_path, framework="pt", device="cpu") as tensor_file:
+            for k in tensor_file:
+                tensor = tensor_file.get_tensor(k)
+                if "proj" in k:
+                    if k.endswith("weight"):
+                        tensor = (tensor.float() * 0.5).to(torch.float8_e4m3fn)
+                    elif k.endswith("weight_scale_inv") or k.endswith("input_scale_inv"):
+                        # "scale_inv" in deepseek-r1 is actually "scale"
+                        tensor = tensor.float() * 2
+                    else:
+                        raise NotImplementedError(f"Cannot convert {k}")
+                else:
+                    print(f"skip {k}.")
+                tensors[k] = tensor
+        new_tensor_path = safetensors_path.replace(input_path, output_path)
+        print(f"saving to {new_tensor_path}")
+        save_file(tensors, new_tensor_path)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Convert tensors to float8fnuz format.")
+    parser.add_argument(
+        "-i",
+        "--input_path",
+        help="Path to the official model weights.",
+        required=True,
+    )
+    parser.add_argument(
+        "-o",
+        "--output_path",
+        help="Path to the output directory.",
+        required=True,
+    )
+    args = parser.parse_args()
+    input_path = args.input_path
+    output_path = args.output_path
+
+    # create output directory if it does not exist
+    if not os.path.exists(output_path):
+        os.makedirs(output_path)
+    copy_other_files(input_path, output_path)
+    convert_files(input_path, output_path)

--- a/calibration/quantization_config/README.md
+++ b/calibration/quantization_config/README.md
@@ -1,0 +1,57 @@
+# Supported JSON Config File Options
+
+The following table summarizes the options for the JSON config file:
+
+| Attribute            | Description | Values |
+|----------------------|-------------|--------|
+| **Mode**             | The mode to run INC with. | - **MEASURE** – Measure statistics of all modules and emit the results to `dump_stats_path`.<br>- **QUANTIZE** *(default)* – Quantize and run the model according to the provided measurements. |
+| **Observer**         | The observer to measure the statistics. | - **maxabs** *(default)*<br>- **save** – Saves all tensors to files. |
+| **Allowlist**        | List of `nn.Module` names or types to quantize. Empty list means all supported modules are quantized by default. See *supported-modules*. | Default: empty list |
+| **Blocklist**        | List of `nn.Module` names or types **not** to quantize. | Default: empty list |
+| **dump_stats_path**  | Path to save and load measurements. Directory structure is created up to the last `/`; the string after the last `/` is used as a prefix for measurement files. | Default: `stats` |
+| **scale_method**     | Method for calculating the scale from measurements. | - `unit_scale` *(default)* – Always use scale of 1.<br>- `maxabs_arbitrary` – Stretch/compress maxabs to full-scale of FP8.<br>- `maxabs_hw` – Stretch/compress maxabs to full-scale of FP8, then replace with HW-accelerated scale based on `device_for_scales`.<br>- `maxabs_pow2` – Same as above but rounded to power of 2.<br>- `maxabs_hw_opt_weight` – Weight scale chosen for minimal MSE among HW accelerated scales; activations use `maxabs_hw`.<br>- `act_maxabs_pow2_weights_pcs_opt_pow2` – Per-channel weights use `maxabs_hw_opt_weight`; activations use `maxabs_pow2`.<br>- `act_maxabs_hw_weights_pcs_maxabs_pow2` – Per-channel weights use `maxabs_pow2`; activations use `maxabs_hw`.<br>- `act_maxabs_pcs_pow2_weight_maxabs_pts_pow2_hw` – **Dynamic quant only**: per-tensor weights use `maxabs_hw`; activations use per-token `maxabs_pow2`. |
+| **measure_exclude**  | Tensor types to exclude from measurement. | - `NONE` – Measure all tensors.<br>- `OUTPUT` *(default)* – Skip output tensors. |
+| **scale_format**     | Format of scales passed to custom PyTorch ops. | - `const` – Scales passed as tensors.<br>- `scalar` *(default)* – Scales passed as scalar values for compile-time & throughput optimizations. |
+| **device_for_scales**| Exponent-bias values for converting FP32/BF16 to FP8-143. | - `GAUDI3` – Expanded exponent-bias range (0–63).<br>- `GAUDI2` – 4 possible exponent biases (3, 7, 11, 15), default is 7. |
+| **dynamic_quantization** | Enables dynamic FP8 quantization with per-token scales. Only supported with `act_maxabs_pcs_pow2_weight_maxabs_pts_pow2_hw`. | - `true` – Enable.<br>- `false` *(default)* – Disable. |
+
+---
+
+## Configuring Backoff Factors
+
+Maxabs-based scaling methods support backoff factors `input_backoff` and `weight_backoff` to leave margin when converting inputs and weights to FP8.
+
+For example, if an activation has a larger absolute value than observed in calibration, the maxabs value is scaled to:
+
+```
+input_backoff * FP8_143_FULLSCALE
+```
+
+Similarly, for weights:
+
+```
+weight_backoff * FP8_143_FULLSCALE
+```
+
+Defaults:
+- `input_backoff = 0.25`
+- `weight_backoff = 0.5`
+
+To change these values, add the following to the quantization configuration JSON file:
+
+```json
+"scale_params": {"input_backoff": <INPUT_BACKOFF>, "weight_backoff": <WEIGHT_BACKOFF>}
+```
+
+---
+
+## Compile Time and Throughput Optimization
+
+Setting `"scale_format": "scalar"` enables:
+
+- Faster compile time for FP8 inference by reducing the number of compiled recipes.
+- Less host-side overhead when launching FP8 ops, improving throughput in host-bound cases (e.g., small batch sizes).
+
+> **Note:**
+> - Compile time improvement depends on model properties such as recipe count and scale distribution.
+> - Not applicable to PCQ.

--- a/calibration/quantization_config/act_maxabs_pow2_weights_pcs_opt_pow2_quant.json
+++ b/calibration/quantization_config/act_maxabs_pow2_weights_pcs_opt_pow2_quant.json
@@ -1,0 +1,7 @@
+{
+    "method": "HOOKS",
+    "mode": "QUANTIZE",
+    "observer": "maxabs",
+    "scale_method": "ACT_MAXABS_POW2_WEIGHTS_PCS_OPT_POW2",
+    "dump_stats_path": "./hqt_output/measure"
+}

--- a/calibration/quantization_config/maxabs_measure.json
+++ b/calibration/quantization_config/maxabs_measure.json
@@ -1,0 +1,6 @@
+{
+    "method": "HOOKS",
+    "mode": "MEASURE",
+    "observer": "maxabs",
+    "dump_stats_path": "./hqt_output/measure"
+}

--- a/calibration/quantization_config/maxabs_measure_include_outputs.json
+++ b/calibration/quantization_config/maxabs_measure_include_outputs.json
@@ -1,0 +1,7 @@
+{
+    "method": "HOOKS",
+    "mode": "MEASURE",
+    "observer": "maxabs",
+    "measure_exclude": "NONE",
+    "dump_stats_path": "./hqt_output/measure"
+}

--- a/calibration/quantization_config/maxabs_quant.json
+++ b/calibration/quantization_config/maxabs_quant.json
@@ -1,0 +1,7 @@
+{
+    "method": "HOOKS",
+    "mode": "QUANTIZE",
+    "observer": "maxabs",
+    "scale_method": "maxabs_hw",
+    "dump_stats_path": "./hqt_output/measure"
+}

--- a/calibration/quantization_config/maxabs_quant_arbitrary.json
+++ b/calibration/quantization_config/maxabs_quant_arbitrary.json
@@ -1,0 +1,7 @@
+{
+    "method": "HOOKS",
+    "mode": "QUANTIZE",
+    "observer": "maxabs",
+    "scale_method": "maxabs_arbitrary",
+    "dump_stats_path": "./hqt_output/measure"
+}

--- a/calibration/quantization_config/maxabs_quant_dynamic_quantization.json
+++ b/calibration/quantization_config/maxabs_quant_dynamic_quantization.json
@@ -1,0 +1,8 @@
+{
+    "mode": "QUANTIZE",
+    "observer": "maxabs",
+    "scale_format": "CONST",
+    "scale_method": "act_maxabs_pcs_pow2_weight_maxabs_pts_pow2_hw",
+    "dynamic_quantization": true,
+    "dump_stats_path": ""
+}

--- a/calibration/quantization_config/maxabs_quant_gemma.json
+++ b/calibration/quantization_config/maxabs_quant_gemma.json
@@ -1,0 +1,10 @@
+{
+    "method": "HOOKS",
+    "mode": "QUANTIZE",
+    "observer": "maxabs",
+    "scale_method": "maxabs_hw",
+    "blocklist": {"types": [], "names":  [
+        "lm_head"
+    ]},
+    "dump_stats_path": "./hqt_output/measure"
+}

--- a/calibration/quantization_config/maxabs_quant_mixtral.json
+++ b/calibration/quantization_config/maxabs_quant_mixtral.json
@@ -1,0 +1,9 @@
+{
+    "method": "HOOKS",
+    "mode": "QUANTIZE",
+    "observer": "maxabs",
+    "scale_method": "maxabs_hw",
+    "allowlist": {"types": [], "names":  []},
+    "blocklist": {"types": [], "names":  ["self_attn"]},
+    "dump_stats_path": "./hqt_output/measure"
+}

--- a/calibration/quantization_config/maxabs_quant_phi.json
+++ b/calibration/quantization_config/maxabs_quant_phi.json
@@ -1,0 +1,12 @@
+{
+    "method": "HOOKS",
+    "mode": "QUANTIZE",
+    "observer": "maxabs",
+    "scale_method": "maxabs_hw",
+    "blocklist": {"types": [], "names":  [
+        "matmul_qk",
+        "matmul_av",
+        "lm_head"
+    ]},
+    "dump_stats_path": "./hqt_output/measure"
+}

--- a/calibration/quantization_config/maxabs_quant_qdq.json
+++ b/calibration/quantization_config/maxabs_quant_qdq.json
@@ -1,0 +1,9 @@
+{
+    "method": "HOOKS",
+    "mode": "QUANTIZE",
+    "observer": "maxabs",
+    "scale_method": "maxabs_hw",
+    "scale_format": "SCALAR",
+    "dump_stats_path": "./hqt_output/measure",
+    "use_qdq": "True"
+}

--- a/calibration/quantization_config/maxabs_quant_scalar_scales.json
+++ b/calibration/quantization_config/maxabs_quant_scalar_scales.json
@@ -1,0 +1,8 @@
+{
+    "method": "HOOKS",
+    "mode": "QUANTIZE",
+    "observer": "maxabs",
+    "scale_method": "maxabs_hw",
+    "dump_stats_path": "./hqt_output/measure",
+    "scale_format": "scalar"
+}

--- a/calibration/quantization_config/pow2_quant.json
+++ b/calibration/quantization_config/pow2_quant.json
@@ -1,0 +1,7 @@
+{
+    "method": "HOOKS",
+    "mode": "QUANTIZE",
+    "observer": "maxabs",
+    "scale_method": "maxabs_pow2",
+    "dump_stats_path": "./hqt_output/measure"
+}

--- a/calibration/quantization_config/unit_scale_quant.json
+++ b/calibration/quantization_config/unit_scale_quant.json
@@ -1,0 +1,7 @@
+{
+    "method": "HOOKS",
+    "mode": "QUANTIZE",
+    "observer": "maxabs",
+    "scale_method": "unit_scale",
+    "dump_stats_path": "./hqt_output/measure"
+}

--- a/calibration/quantization_config/weight_opt_quant.json
+++ b/calibration/quantization_config/weight_opt_quant.json
@@ -1,0 +1,7 @@
+{
+    "method": "HOOKS",
+    "mode": "QUANTIZE",
+    "observer": "maxabs",
+    "scale_method": "maxabs_hw_opt_weight",
+    "dump_stats_path": "./hqt_output/measure"
+}


### PR DESCRIPTION
Ported missing:
- `quantization_config` subdirectory
- `convert.py` script from https://github.com/HabanaAI/vllm-hpu-extension project to calibration subdirectory in plugin.

---------