### PR TITLE
Update nixl Dockerfile to use v1.22.2 and parameterize vllm-project

### DIFF
--- a/.cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest
+++ b/.cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest
@@ -51,7 +51,7 @@ RUN \
     cd $VLLM_PATH && \
     git remote add upstream https://github.com/vllm-project/vllm.git && \
     git fetch upstream --tags || true && \
-    git checkout ${VLLM_COMMIT_HASH} && \
+    git checkout ${VLLM_PROJECT_COMMIT} && \
     # Install vllm-project/vllm
     pip install -r <(sed '/^torch/d' requirements/build.txt) && \
     VLLM_TARGET_DEVICE=empty pip install --no-build-isolation . && \


### PR DESCRIPTION
Updates needed to make the dockerfile flexible for upcoming releases.