### PR TITLE
Fix missing unique attn image in the docs

### DIFF
--- a/docs/features/unified_attn.md
+++ b/docs/features/unified_attn.md
@@ -83,7 +83,7 @@ Since we know that each block is used by upmost one token, we can use two optimi
 
 The first optimization allows better handling of batches with large differences between sequence lengths. For example, if we have two samples in a batch, using [4, 12] context blocks respectively, instead of padding the `block_table` to the highest number of blocks, we can use flattened list of blocks. This way, the amount of compute we need scales with the sum of `blocks_used` instead of `bs * max(num_blocks)`. This simplified diagram presents how it works:
 
-![](../../docs/assets/unified_attn/unique.png)
+![](../assets/unified_attn/unique.png)
 
 The main difficulty in this approach is that several blocks may be used in a single query token, preventing direct softmax computation. However, we can use the same approach to calculate softmax in parts and then readjust.
 


### PR DESCRIPTION
Not sure if this is the root cause, but the other images are loading properly on the readthedocs, only Unique Attn was not, and the format for unique attn was going to the root dir, so I think it might be this reason.

This image shows the missing image in the readthedocs:

<img width="802" height="494" alt="image" src="https://github.com/user-attachments/assets/b62a2670-c5f8-486b-8990-7d8ffa873310" />

Source: https://docs.vllm.ai/projects/gaudi/en/latest/features/unified_attn.html#unique-attention 