### PR TITLE
Add vLLM UBI Dockerfile for Gaudi with RHEL 9.6 (#686)

### DIFF
--- a/.cd/Dockerfile.rhel.ubi.vllm
+++ b/.cd/Dockerfile.rhel.ubi.vllm
@@ -3,14 +3,14 @@
 
 # Global build arguments - declared before first FROM to be available in all stages
 ARG ARTIFACTORY_URL="vault.habana.ai"
-ARG SYNAPSE_VERSION=1.22.1
+ARG SYNAPSE_VERSION=1.23.0
 ARG SYNAPSE_REVISION=32
 ARG BASE_NAME=rhel9.6
-ARG PT_VERSION=2.7.1
+ARG PT_VERSION=2.9.0
 # can be upstream or fork
 ARG TORCH_TYPE=upstream
-ARG VLLM_GAUDI_COMMIT=main
-ARG VLLM_PROJECT_COMMIT=
+ARG VLLM_GAUDI_COMMIT=v0.12.0
+ARG VLLM_PROJECT_COMMIT=v0.12.0
 
 # ============================================================================
 # Stage 1: gaudi-base - Base system setup with Habana drivers


### PR DESCRIPTION
GAUDISW-242243

- Multi-stage build: gaudi-base → gaudi-pytorch → vllm-final

Build arguments:
- SYNAPSE_VERSION: Habana Synapse AI version (default: 1.22.1)
- PT_VERSION: PyTorch version (default: 2.7.1)
- VLLM_GAUDI_COMMIT: vllm-gaudi git commit/tag (default: main)
- VLLM_PROJECT_COMMIT: vllm upstream commit (auto-detected if empty)
- TORCH_TYPE: PyTorch type - 'upstream' or 'fork' (default: upstream)

Usage:
  docker build --build-arg SYNAPSE_VERSION=1.23.0 PT_VERSION=2.9.0 -t vllm-gaudi:1.23.0 .

---------