### PR TITLE
Optimize performance of static FP8 linear op

### DIFF
--- a/vllm_gaudi/ops/hpu_fp8.py
+++ b/vllm_gaudi/ops/hpu_fp8.py
@@ -69,12 +69,14 @@ class Fp8LinearMethod(OrigFp8LinearMethod):
 
         weight_scale = layer.weight_scale.transpose(0, 1) if layer.weight_scale.dim() > 1 else layer.weight_scale
         input_scale = getattr(layer, 'input_scale', None)
-        return hpu_ops.apply_fp8_linear_hpu(input=x,
-                                            weight=layer.weight,
-                                            weight_scale=weight_scale,
-                                            input_scale=input_scale,
-                                            bias=bias,
-                                            trans_B=False)
+        input_2d = x.view(-1, x.shape[-1])
+        output = hpu_ops.apply_fp8_linear_hpu(input=input_2d,
+                                              weight=layer.weight,
+                                              weight_scale=weight_scale,
+                                              input_scale=input_scale,
+                                              bias=bias,
+                                              trans_B=False)
+        return output.view(*x.shape[:-1], -1)
 
     def dequant_fp8_weight(self, layer) -> torch.Tensor:
         if hasattr(layer, "updated_fp8_weight") and layer.updated_fp8_weight:


### PR DESCRIPTION
Optimizes the performance of FP8 linear op similar to https://github.com/vllm-project/vllm-gaudi/blob/82937529b3535014e17b88aab7d8dc58e35176cc/vllm_gaudi/extension/ops.py#L687 and https://github.com/vllm-project/vllm/blob/2f32a68d75324299d13025c75f9cb5427e5c445d/vllm/model_executor/layers/quantization/utils/w8a8_utils.py#L454 