### PR TITLE
fix empty buckets issue for enforce eager mode

### DIFF
--- a/vllm_gaudi/v1/worker/hpu_worker.py
+++ b/vllm_gaudi/v1/worker/hpu_worker.py
@@ -292,9 +292,8 @@ class HPUWorker(WorkerBase):
         self.compile_or_warm_up_model()
 
     def compile_or_warm_up_model(self) -> None:
-        # Don't run the warmup if in eager or if the model is already warmed up
-        if not self.model_config.enforce_eager \
-            and not getattr(self.model_runner, 'graphed_buckets', None):
+        # Don't run the warmup if the model is already warmed up
+        if not getattr(self.model_runner, 'graphed_buckets', None):
             self.model_runner.warmup_model()
         # Reset the seed to ensure that the random state is not affected by
         # the model initialization and profiling.


### PR DESCRIPTION
Current implementation skip calling `self.model_runner.warmup_model()` for `enforce_eager=True` leads to empty bucket lists in the bucket manager, and the following `find_bucket` calls will get fallback buckets.

The buckets are generated by the following calls in `self.model_runner.warmup_model()`.
https://github.com/vllm-project/vllm-gaudi/blob/cc37f1f221ecb2733d02f3c3f138cc697f0acaac/vllm_gaudi/v1/worker/hpu_model_runner.py#L4581-L4596

And the actual warmup will be skipped for `enforce_eager=True` according to
https://github.com/vllm-project/vllm-gaudi/blob/cc37f1f221ecb2733d02f3c3f138cc697f0acaac/vllm_gaudi/v1/worker/hpu_model_runner.py#L4670-L4695

So the `self.model_runner.warmup_model()` cannot be skipped when `enforce_eager=True` and no actual warmup in this case as expected.