### PR TITLE
Add the padding-aware bucketing strategy

### DIFF
--- a/docs/configuration/env_variables.md
+++ b/docs/configuration/env_variables.md
@@ -21,11 +21,14 @@ This document lists the supported diagnostic and profiling, as well as performan
 | ---------------------------- | ------------------------------------------------------------- | ------------- |
 | `VLLM_GRAPH_RESERVED_MEM`    | Percentage of memory dedicated to HPUGraph capture.           | `0.1`         |
 | `VLLM_BUCKETING_STRATEGY`    | Selects the bucketing strategy: `exp`, `lin`, or `pad`.      | `exp`         |
+| `VLLM_EXPONENTIAL_BUCKETING` | Deprecated compatibility flag. If set, it overrides `VLLM_BUCKETING_STRATEGY`: `true` forces `exp`, `false` forces `lin`. It cannot select `pad` and will be removed in a future release. | `None`        |
 | `VLLM_BUCKETING_FROM_FILE`   | Enables reading bucket configuration from file.              | `None`        |
 | `VLLM_ROW_PARALLEL_CHUNKS`   | Number of chunks to split input into for pipelining matmul with all-reduce in RowParallelLinear layers. Setting to a value greater than 1 enables chunking. See [Row-Parallel Chunking](../features/row_parallel_chunking.md). | `1` (disabled) |
 | `VLLM_ROW_PARALLEL_CHUNK_THRESHOLD` | Minimum number of tokens required to activate row-parallel chunking. Inputs below this threshold use the standard non-chunked path. | `8192` |
 
 Use `VLLM_BUCKETING_STRATEGY=exp` for the default exponential warm-up, `VLLM_BUCKETING_STRATEGY=lin` for explicitly configured linear ranges, or `VLLM_BUCKETING_STRATEGY=pad` for padding-aware ranges with absolute and relative padding limits.
+
+Leave `VLLM_EXPONENTIAL_BUCKETING` unset when using `VLLM_BUCKETING_STRATEGY`. The legacy flag is checked for backward compatibility and still overrides the selected strategy when present.
 
 ## Developer Mode Parameters
 

--- a/docs/configuration/env_variables.md
+++ b/docs/configuration/env_variables.md
@@ -20,10 +20,12 @@ This document lists the supported diagnostic and profiling, as well as performan
 | Parameter name               | Description                                                   | Default value |
 | ---------------------------- | ------------------------------------------------------------- | ------------- |
 | `VLLM_GRAPH_RESERVED_MEM`    | Percentage of memory dedicated to HPUGraph capture.           | `0.1`         |
-| `VLLM_EXPONENTIAL_BUCKETING` | Enables exponential bucket spacing instead of linear spacing. | `true`        |
-| `VLLM_BUCKETING_FROM_FILE`   | Enables reading bucket configuration from file | `None`        |
+| `VLLM_BUCKETING_STRATEGY`    | Selects the bucketing strategy: `exp`, `lin`, or `pad`.      | `exp`         |
+| `VLLM_BUCKETING_FROM_FILE`   | Enables reading bucket configuration from file.              | `None`        |
 | `VLLM_ROW_PARALLEL_CHUNKS`   | Number of chunks to split input into for pipelining matmul with all-reduce in RowParallelLinear layers. Setting to a value greater than 1 enables chunking. See [Row-Parallel Chunking](../features/row_parallel_chunking.md). | `1` (disabled) |
 | `VLLM_ROW_PARALLEL_CHUNK_THRESHOLD` | Minimum number of tokens required to activate row-parallel chunking. Inputs below this threshold use the standard non-chunked path. | `8192` |
+
+Use `VLLM_BUCKETING_STRATEGY=exp` for the default exponential warm-up, `VLLM_BUCKETING_STRATEGY=lin` for explicitly configured linear ranges, or `VLLM_BUCKETING_STRATEGY=pad` for padding-aware ranges with absolute and relative padding limits.
 
 ## Developer Mode Parameters
 
@@ -50,33 +52,48 @@ HPU PyTorch bridge environment variables impacting vLLM execution:
 | `VLLM_PROMPT_USE_FLEX_ATTENTION`   | Enabled only for the Llama model, allowing usage of `torch.nn.attention.flex_attention` instead of FusedSDPA. Requires `VLLM_PROMPT_USE_FUSEDSDPA=0`. | `false`                                          |
 | `RUNTIME_SCALE_PATCHING`           | Enables the runtime scale patching feature, which applies only to FP8 execution and is ignored for BF16.                                              | `true` (Torch Compile mode), `false` (Lazy mode) |
 
-## Additional Performance Tuning Parameters for Linear Bucketing Strategy
+## Additional Performance Tuning Parameters for Bucketing Strategies
 
-`VLLM_{phase}_{dim}_BUCKET_{param}` is a collection of environment variables configuring ranges of linear bucketing mechanism, where:
+`VLLM_{phase}_{dim}_BUCKET_{param}` is a collection of environment variables configuring user-defined bucket ranges, where:
 
-- `{phase}` is either `PROMPT` or `DECODE`
-- `{dim}` is either `BS`, `SEQ` or `BLOCK`
-- `{param}` is either `MIN`, `STEP` or `MAX`
+- `{phase}` is in `['PROMPT', 'DECODE']`.
+- `{dim}` is in `['BS', 'QUERY', 'CTX']` for `PROMPT` phase or in `['BS', 'BLOCK']` for `DECODE` phase.
+- `{param}` is in `['MIN', 'STEP', 'MAX']` for the `lin` strategy.
+- `{param}` is in `['MIN', 'STEP', 'MAX', 'PAD_MAX', 'PAD_PERCENT']` for the `pad` strategy.
 
-The following table lists the available variables with their default values:
+The following table lists the available variables with their default values. `PAD_MAX` and `PAD_PERCENT` are used only when `VLLM_BUCKETING_STRATEGY=pad`.
 
-| Phase  | Variable name                                     | Default value                                |
-| ------ | ------------------------------------------------- | -------------------------------------------- |
-| Prompt | batch size min (`VLLM_PROMPT_BS_BUCKET_MIN`)      | `1`                                          |
-| Prompt | batch size step (`VLLM_PROMPT_BS_BUCKET_STEP`)    | `1`                                          |
-| Prompt | batch size max (`VLLM_PROMPT_BS_BUCKET_MAX`)      | `max_num_prefill_seqs`                       |
-| Prompt | query length min (`VLLM_PROMPT_SEQ_BUCKET_MIN`)   | `block_size`                                 |
-| Prompt | query length step (`VLLM_PROMPT_SEQ_BUCKET_STEP`) | `block_size`                                 |
-| Prompt | query length max (`VLLM_PROMPT_SEQ_BUCKET_MAX`)   | `max_num_batched_tokens`                     |
-| Prompt | sequence ctx min (`VLLM_PROMPT_CTX_BUCKET_MIN`)   | `0`                                          |
-| Prompt | sequence ctx step (`VLLM_PROMPT_CTX_BUCKET_STEP`) | `1`                                          |
-| Prompt | sequence ctx max (`VLLM_PROMPT_CTX_BUCKET_MAX`)   | `(max_model_len - block_size) // block_size` |
-| Decode | batch size min (`VLLM_DECODE_BS_BUCKET_MIN`)      | `1`                                          |
-| Decode | batch size step (`VLLM_DECODE_BS_BUCKET_STEP`)    | `32`                                         |
-| Decode | batch size max (`VLLM_DECODE_BS_BUCKET_MAX`)      | `max_num_seqs`                               |
-| Decode | block size min (`VLLM_DECODE_BLOCK_BUCKET_MIN`)   | `1`                                 |
-| Decode | block size step (`VLLM_DECODE_BLOCK_BUCKET_STEP`) | `block_size`                                 |
-| Decode | block size max (`VLLM_DECODE_BLOCK_BUCKET_MAX`)   | `max_model_len * max_num_seqs // block_size` <br> by default or `max_blocks` <br> if `VLLM_CONTIGUOUS_PA = True` |
+| Phase  | Variable name                                                            | Default value                                                                                                       |
+|--------|--------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
+| Prompt | batch size min (`VLLM_PROMPT_BS_BUCKET_MIN`)                             | `1`                                                                                                                 |
+| Prompt | batch size step (`VLLM_PROMPT_BS_BUCKET_STEP`)                           | `1`                                                                                                                 |
+| Prompt | batch size max (`VLLM_PROMPT_BS_BUCKET_MAX`)                             | `max_num_prefill_seqs`                                                                                              |
+| Prompt | batch size max abs padding (`VLLM_PROMPT_BS_BUCKET_PAD_MAX`)             | `ceil(max_num_prefill_seqs / 4)`                                                                                    |
+| Prompt | batch size max padding percent (`VLLM_PROMPT_BS_BUCKET_PAD_PERCENT`)     | `25`                                                                                                                |
+| Prompt | query length min (`VLLM_PROMPT_QUERY_BUCKET_MIN`)                        | `block_size`                                                                                                        |
+| Prompt | query length step (`VLLM_PROMPT_QUERY_BUCKET_STEP`)                      | `block_size`                                                                                                        |
+| Prompt | query length max (`VLLM_PROMPT_QUERY_BUCKET_MAX`)                        | `max_num_batched_tokens`                                                                                            |
+| Prompt | query length max abs padding (`VLLM_PROMPT_QUERY_BUCKET_PAD_MAX`)        | `ceil(max_num_batched_tokens / 4)`                                                                                  |
+| Prompt | query length max padding percent (`VLLM_PROMPT_QUERY_BUCKET_PAD_PERCENT`)| `25`                                                                                                                |
+| Prompt | sequence ctx min (`VLLM_PROMPT_CTX_BUCKET_MIN`)                          | `0`                                                                                                                 |
+| Prompt | sequence ctx step (`VLLM_PROMPT_CTX_BUCKET_STEP`)                        | `2`                                                                                                                 |
+| Prompt | sequence ctx max (`VLLM_PROMPT_CTX_BUCKET_MAX`)                          | `ceil((max_model_len - VLLM_PROMPT_QUERY_BUCKET_MIN) / block_size)`                                                 |
+| Prompt | sequence ctx max abs padding (`VLLM_PROMPT_CTX_BUCKET_PAD_MAX`)          | `ceil(max_num_batched_tokens / block_size)`                                                                         |
+| Prompt | sequence ctx max padding percent (`VLLM_PROMPT_CTX_BUCKET_PAD_PERCENT`)  | `25`                                                                                                                |
+| Decode | batch size min (`VLLM_DECODE_BS_BUCKET_MIN`)                             | `1`                                                                                                                 |
+| Decode | batch size step (`VLLM_DECODE_BS_BUCKET_STEP`)                           | `2`                                                                                                                 |
+| Decode | batch size max (`VLLM_DECODE_BS_BUCKET_MAX`)                             | `max_num_seqs`                                                                                                      |
+| Decode | batch size max abs padding (`VLLM_DECODE_BS_BUCKET_PAD_MAX`)             | `ceil(max_num_seqs / 4)`                                                                                            |
+| Decode | batch size max padding percent (`VLLM_DECODE_BS_BUCKET_PAD_PERCENT`)     | `25`                                                                                                                |
+| Decode | num blocks min (`VLLM_DECODE_BLOCK_BUCKET_MIN`)                          | `block_size`                                                                                                        |
+| Decode | num blocks step (`VLLM_DECODE_BLOCK_BUCKET_STEP`)                        | `block_size`                                                                                                        |
+| Decode | num blocks max (`VLLM_DECODE_BLOCK_BUCKET_MAX`)                          | `ceil(max_model_len * max_num_seqs / block_size)` <br>by default or `max_blocks` <br>if `VLLM_CONTIGUOUS_PA = True` |
+| Decode | num blocks max abs padding (`VLLM_DECODE_BLOCK_BUCKET_PAD_MAX`)          | `ceil(VLLM_DECODE_BLOCK_BUCKET_MAX / 4)`                                                                            |
+| Decode | num blocks max padding percent (`VLLM_DECODE_BLOCK_BUCKET_PAD_PERCENT`)  | `25`                                                                                                                |
+
+The default value of `25` for `VLLM_*_BUCKET_PAD_PERCENT` is a balance of warmup duration and runtime performance. Using smaller value like `10` introduce more buckets and reduces the padding to get better runtime performance. Setting to `0` to fall back to the original linear bucketing with minimum padding. And setting to `50` is close to the exponential bucketing except for the corresponding  `VLLM_*_BUCKET_MIN` is not `0` nor `1`.
+
+Legacy `VLLM_PROMPT_SEQ_BUCKET_*` variables are still accepted as a fallback for prompt query settings when `VLLM_PROMPT_QUERY_BUCKET_*` is not set, but this compatibility path is deprecated and will be removed in a future release.
 
 When a deployed workload does not use the full context a model can handle, we
 recommend you to limit the maximum values upfront, based on the expected input
@@ -90,7 +107,7 @@ unnecessary and you can limit the values upfront. It reduces the startup time
 and warm-up. Recommended settings for this case are:
 
 - `--max_model_len`: `3072`, which is the sum of input and output sequences (1+2)*1024.  
-- `VLLM_PROMPT_SEQ_BUCKET_MAX`: `1024`, which is the maximum input token size that you expect to handle.
+- `VLLM_PROMPT_QUERY_BUCKET_MAX`: `1024`, which is the maximum input token size that you expect to handle.
 
 !!! note
     If the model config specifies a high `max_model_len`, set it to the sum of `input_tokens` and `output_tokens`, rounded up to a multiple of `block_size` according to actual requirements.

--- a/docs/configuration/long_context.md
+++ b/docs/configuration/long_context.md
@@ -20,17 +20,19 @@ Set the following environment variables to avoid OOM/functional issues.  Additio
 
 ## Warm-up Buckets Preparation
 
-Exponential bucketing mechanism automatically prepares buckets for long context. Linear bucketing mechanism requires manual flags settings. The following table presents 32K context length flags examples for linear warm-up:
+With `VLLM_BUCKETING_STRATEGY=exp`, long-context buckets are prepared automatically. The `lin` and `pad` strategies usually require manual bucket tuning for long-context workloads. The following table presents 32K context-length examples for manual warm-up tuning:
 
 | Flag | Suggested value | Notes |
 |------|-----------------|-------|
 | `VLLM_GRAPH_RESERVED_MEM` | `0.02` or `0.1` | It depends on the model and context length settings. Set to `0.02` for Llama3.1-8B or `0.1` for Llama3.1-70B. |
-| `VLLM_PROMPT_SEQ_BUCKET_MIN` | `24576` | The value depends on the warm-up results. |
-| `VLLM_PROMPT_SEQ_BUCKET_STEP` | `2048` | The value depends on the warm-up results. We recommend increasing it to a higher value for faster warm-up. for Intel Gaudi 3, we suggest setting it to `16384`. |
-| `VLLM_PROMPT_SEQ_BUCKET_MAX` | `32768` | The value for context length is 32K; use 16384 for 16K. |
+| `VLLM_PROMPT_QUERY_BUCKET_MIN` | `24576` | The value depends on the warm-up results. |
+| `VLLM_PROMPT_QUERY_BUCKET_STEP` | `2048` | The value depends on the warm-up results. We recommend increasing it to a higher value for faster warm-up. For Intel Gaudi 3, we suggest setting it to `16384`. |
+| `VLLM_PROMPT_QUERY_BUCKET_MAX` | `32768` | The value for context length is 32K; use 16384 for 16K. |
 | `VLLM_DECODE_BLOCK_BUCKET_MIN` | `1024` | The value depends on the warm-up results. |
 | `VLLM_DECODE_BLOCK_BUCKET_STEP` | `1024` | The value depends on the warm-up results. |
 | `VLLM_DECODE_BLOCK_BUCKET_MAX` | `33792` | Calculate the value of `max_num_seqs * max_decode_seq // self.block_size`, where `max_decode_seq` represents the sum of input and output sequences. For example: `128 *((32 + 1)* 1024) / 128` and `32 *((32 + 1)* 1024) / 128`. |
+
+Legacy `VLLM_PROMPT_SEQ_BUCKET_*` aliases are still accepted for prompt query tuning, but `VLLM_PROMPT_QUERY_BUCKET_*` is the preferred naming.
 
 ## Batch Size Settings
 

--- a/docs/configuration/warm-up/managing_warm-up.md
+++ b/docs/configuration/warm-up/managing_warm-up.md
@@ -50,7 +50,7 @@ VLLM_PROMPT_BS_BUCKET_MAX=256 \
 VLLM_DECODE_BS_BUCKET_MIN=128 \
 VLLM_DECODE_BS_BUCKET_STEP=128 \
 VLLM_DECODE_BS_BUCKET_MAX=128 \
-VLLM_PROMPT_SEQ_BUCKET_MAX=1024 \
+VLLM_PROMPT_QUERY_BUCKET_MAX=1024 \
 VLLM_DECODE_BLOCK_BUCKET_MAX=1024 \
 PT_HPU_WEIGHT_SHARING=0 PT_HPU_MAX_COMPOUND_OP_SIZE=30 PT_HPU_LAZY_MODE=1 PT_HPU_ENABLE_LAZY_COLLECTIVES=true vllm serve meta-llama/Llama-3.1-8B-instruct -tp 1 --weights-load-device cpu --max-model-len 8192
 ```
@@ -74,6 +74,6 @@ No changes are required in the Dockerfile as recipe cache is specific to the mod
 
 vLLM warm-up time is determined by the number of HPU graphs that must be compiled to support dynamic shapes. These shapes are influenced by the `batch_size`, `query_length`, and `num_context_blocks`. Setting them according to `max_num_batched_tokens` ensures that additional graphs are not compiled at runtime.
 
-## Exponential Bucketing
+## Bucketing Strategy Selection
 
-The `VLLM_EXPONENTIAL_BUCKETING=True` flag, enabled by default starting with the vLLM `1.21.0-post1` release, switches the bucketing strategy from linear to exponential. This can reduce the number of buckets and warm-up time by up to 80%, while generally maintaining comparable inference performance. In some configurations, however, it may lead to a slight performance drop due to increased padding. This setting is particularly effective for BF16 and FP8 models. To use linear bucketing instead, set `VLLM_EXPONENTIAL_BUCKETING=False`.
+Use `VLLM_BUCKETING_STRATEGY` to select how warm-up buckets are generated. The default `exp` strategy reduces the number of buckets and warm-up time, typically with more padding between prepared shapes. Use `lin` when you want explicit control over `MIN`, `STEP`, and `MAX` ranges, or `pad` when you want that same control plus `PAD_MAX` and `PAD_PERCENT` to bound padding overhead more tightly. For BF16 and FP8 workloads, `exp` is often the fastest warm-up option, while `lin` and `pad` are better suited to workload-specific tuning.

--- a/docs/dev_guide/profiling/e2e-profiling.md
+++ b/docs/dev_guide/profiling/e2e-profiling.md
@@ -39,7 +39,7 @@ To execute E2E profiling, use one of the following procedures.
 4. Start the vLLM server. The following example uses the `facebook/opt-125m` model, `TP=1`, and the maximum batch size of `128`.
 
     ```bash
-    VLLM_PROMPT_SEQ_BUCKET_MAX=128 VLLM_PROMPT_SEQ_BUCKET_MIN=128 \
+    VLLM_PROMPT_QUERY_BUCKET_MAX=128 VLLM_PROMPT_QUERY_BUCKET_MIN=128 \
     python3 -m vllm.entrypoints.openai.api_server --port 8080 \
     --model "facebook/opt-125m" --tensor-parallel-size 1 \
     --max-num-seqs 128 --dtype bfloat16 \
@@ -95,7 +95,7 @@ To execute E2E profiling, use one of the following procedures.
 4. Start the vLLM server. The following example uses the `facebook/opt-125m` model, `TP=1`, and the maximum batch size of `128`.
 
     ```bash
-    VLLM_PROMPT_SEQ_BUCKET_MAX=128 VLLM_PROMPT_SEQ_BUCKET_MIN=128 \
+    VLLM_PROMPT_QUERY_BUCKET_MAX=128 VLLM_PROMPT_QUERY_BUCKET_MIN=128 \
     python3 -m vllm.entrypoints.openai.api_server --port 8080 \
     --model "facebook/opt-125m" --tensor-parallel-size 1 \
     --max-num-seqs 128 --dtype bfloat16 \

--- a/docs/dev_guide/profiling/pytorch-profiling-async.md
+++ b/docs/dev_guide/profiling/pytorch-profiling-async.md
@@ -24,7 +24,7 @@ While you can collect hardware traces, we do not recommend doing so during profi
 3. Start the vLLM server. The following example uses the `facebook/opt-125m` model, `TP=1`, and the maximum batch size `128`.
 
     ```bash
-    VLLM_PROMPT_SEQ_BUCKET_MAX=128 VLLM_PROMPT_SEQ_BUCKET_MIN=128 \
+    VLLM_PROMPT_QUERY_BUCKET_MAX=128 VLLM_PROMPT_QUERY_BUCKET_MIN=128 \
     python3 -m vllm.entrypoints.openai.api_server --port 8080 \
         --model "facebook/opt-125m" --tensor-parallel-size 1 \
         --max-num-seqs 128 --dtype bfloat16 \
@@ -73,7 +73,7 @@ While you can collect hardware traces, we do not recommend doing so during profi
 3. Start the vLLM server. The following example uses the `facebook/opt-125m` model, `TP=1`, and the maximum batch size `128`.
 
     ```bash
-    VLLM_PROMPT_SEQ_BUCKET_MAX=128 VLLM_PROMPT_SEQ_BUCKET_MIN=128 \
+    VLLM_PROMPT_QUERY_BUCKET_MAX=128 VLLM_PROMPT_QUERY_BUCKET_MIN=128 \
     python3 -m vllm.entrypoints.openai.api_server --port 8080 \
         --model "facebook/opt-125m" --tensor-parallel-size 1 \
         --max-num-seqs 128 --dtype bfloat16 \

--- a/docs/features/bucketing_mechanism.md
+++ b/docs/features/bucketing_mechanism.md
@@ -52,6 +52,9 @@ Bucketing is transparent to the user – padding in the sequence length dimensio
 
 There are three generated bucketing strategies, selected with `VLLM_BUCKETING_STRATEGY`: exponential (`exp`, default), linear (`lin`), and padding-aware (`pad`).
 
+!!! note
+    `VLLM_EXPONENTIAL_BUCKETING` is deprecated, but it is still honored for backward compatibility. If it is set, it overrides `VLLM_BUCKETING_STRATEGY`: `true` forces exponential bucketing and `false` forces linear bucketing. It cannot select padding-aware bucketing, so leave it unset when using `VLLM_BUCKETING_STRATEGY=pad`.
+
 ### Exponential Strategy
 
 The exponential strategy is the default warm-up mechanism. Enable it with `VLLM_BUCKETING_STRATEGY=exp`. It is based on 4 parameters that are not configurable by the user:

--- a/docs/features/bucketing_mechanism.md
+++ b/docs/features/bucketing_mechanism.md
@@ -20,7 +20,13 @@ Bucketing is focused on three dimensions:
 - `query lenght`: The sequence length without context tokens.
 - `num blocks`: The context length counted in blocks.
 
-Bucketing ranges are generated based on 4 parameters - `min`, `step`, `max`, and `limit` - applied separately for the prompt and decode phases, as well as for batch size, query length, and context block dimensions. These parameters are logged and can be observed during vLLM startup:
+Bucketing ranges are generated separately for the prompt and decode phases, as well as for batch size, query length, and context block dimensions. The parameters depend on the selected strategy:
+
+- Exponential uses `min`, `step`, `max`, and `limit`.
+- Linear uses `min`, `step`, and `max`.
+- Padding-aware uses `min`, `step`, `max`, `pad_max`, and `pad_percent`.
+
+These parameters are logged and can be observed during vLLM startup:
 
 ```{.}
 INFO 07-07 19:27:37 [exponential.py:36] Prompt bucket config (min, step, max_warmup, limit) bs:[1, 1, 1, 1], seq:[128, 128, 1024, 11]
@@ -44,11 +50,11 @@ After the prefill stage, it will be executed as a `(4, 1, 512)` decode bucket, w
 
 Bucketing is transparent to the user – padding in the sequence length dimension is never returned, and padding in the batch dimension does not create new requests.
 
-There are two bucketing strategies: exponential (default) and linear.
+There are three generated bucketing strategies, selected with `VLLM_BUCKETING_STRATEGY`: exponential (`exp`, default), linear (`lin`), and padding-aware (`pad`).
 
 ### Exponential Strategy
 
-The exponential strategy is the default warm-up mechanism. It is based on 4 parameters that are not configurable by the user:
+The exponential strategy is the default warm-up mechanism. Enable it with `VLLM_BUCKETING_STRATEGY=exp`. It is based on 4 parameters that are not configurable by the user:
 
 - `min`: The minimum value
 - `step`: The rounding value for bucket boundaries
@@ -70,7 +76,7 @@ This strategy creates more buckets with smaller values closer to `min`. As the v
 ### Linear Strategy
 
 !!! note
-    Starting from v1.22.0 Intel Gaudi Software release, Linear strategy is no longer the default warm-up mechanism.
+    Starting from v1.22.0 Intel Gaudi Software release, Linear strategy is no longer the default warm-up mechanism. Set `VLLM_BUCKETING_STRATEGY=lin` to use the linear strategy.
 
 The linear strategy is determined with 3 parameters: `min`, `step` and `max`, where:
 
@@ -94,6 +100,62 @@ These parameters can be configured separately by the user for the prompt and dec
     => stable = (128, 256, 384, 512)
     => buckets = ramp_up + stable => (128, 256, 384, 512)
     ```
+
+### Padding-Aware Strategy
+
+Set `VLLM_BUCKETING_STRATEGY=pad` to use the padding-aware strategy.
+
+Padding-aware bucketing extends the linear ramp-up with two additional controls:
+
+- `pad_max`: Maximum absolute padding tolerated before a denser bucket is kept.
+- `pad_percent`: Maximum relative padding tolerated before a denser bucket is kept.
+
+This strategy is useful when you want more direct control over the warm-up versus runtime-padding tradeoff. Lower `pad_percent` values produce more buckets and less runtime padding. Setting `pad_percent=0` approaches dense linear coverage, while larger values (up to 50) reduce warm-up cost and move closer to exponential spacing.
+
+The following examples use the configuration tuple `(min, step, max, pad_max, pad_percent)` and show how the generated warm-up buckets change as the padding limits change.
+
+Dense linear-like coverage:
+
+```{.}
+config = (0, 8, 64, 64, 0)
+=> ramp_up = (0, 1, 2, 4, 8)
+=> stable = (16, 24, 32, 40, 48, 56, 64)
+=> buckets = (0, 1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64)
+```
+
+With `pad_percent=0`, every linear bucket after the ramp-up is kept, so the result stays close to dense linear coverage.
+
+Ratio-limited spacing:
+
+```{.}
+config = (0, 8, 64, 64, 50)
+=> ramp_up = (0, 1, 2, 4, 8)
+=> stable = (16, 32, 64)
+=> buckets = (0, 1, 2, 4, 8, 16, 32, 64)
+```
+
+A larger `pad_percent` allows wider spacing, so several intermediate buckets are skipped and the result moves closer to exponential bucketing.
+
+Absolute pad cap:
+
+```{.}
+config = (0, 8, 64, 16, 50)
+=> ramp_up = (0, 1, 2, 4, 8)
+=> stable = (16, 32, 48, 64)
+=> buckets = (0, 1, 2, 4, 8, 16, 32, 48, 64)
+```
+
+Reducing `pad_max` forces the strategy to keep extra intermediate buckets, even when `pad_percent` would otherwise allow a sparser range.
+
+No ramp-up phase:
+
+```{.}
+config = (16, 16, 128, 32, 25)
+=> stable = (16, 32, 48, 64, 80, 96, 128)
+=> buckets = (16, 32, 48, 64, 80, 96, 128)
+```
+
+When `min` already matches `step`, the strategy skips the ramp-up phase and starts directly with the stable region.
 
 ### Specifying Buckets in a File
 

--- a/docs/features/supported_features.md
+++ b/docs/features/supported_features.md
@@ -28,7 +28,7 @@ This document summarizes the features currently supported by the vLLM Hardware P
 | Multiprocessing backend   | The default distributed runtime in vLLM.   | [Documentation](https://docs.vllm.ai/en/v0.10.0/serving/distributed_serving.html)  |
 | Multimodal   | Supports inference for multi-modal models. It is not fully supported with the `t.compile` execution mode. |  [Documentation](https://docs.vllm.ai/en/latest/features/multimodal_inputs.html) |
 | Guided decode   | Supports a guided decoding backend for generating structured outputs.   | [Documentation](https://docs.vllm.ai/en/latest/features/structured_outputs.html)  |
-| Exponential bucketing | Supports exponential bucketing spacing instead of linear spacing, automating the configuration of the bucketing mechanism. This feature is enabled by default and can be disabled via `VLLM_EXPONENTIAL_BUCKETING=false` environment variable.   | N/A |
+| Configurable bucketing strategies | Supports exponential (`exp`), linear (`lin`), and padding-aware (`pad`) bucketing strategies, selected with `VLLM_BUCKETING_STRATEGY`. The default is `exp`.   | [Bucketing Mechanism](bucketing_mechanism.md) |
 | Data Parallel support | Replicates model weights across multiple instances or GPUs to process independent request batches. | [Documentation](https://docs.vllm.ai/en/stable/serving/data_parallel_deployment.html), [Example](https://docs.vllm.ai/en/latest/examples/offline_inference/data_parallel.html)  |
 | Row-Parallel Chunking | Overlaps computation with communication in RowParallelLinear layers by splitting input into chunks and launching async all-reduce operations. Improves throughput for tensor-parallel inference with long prefills. Configured via `VLLM_ROW_PARALLEL_CHUNKS` and `VLLM_ROW_PARALLEL_CHUNK_THRESHOLD` environment variables. | [Documentation](row_parallel_chunking.md) |
 
@@ -42,7 +42,7 @@ compilations triggered by varying constant scale values in quantized model layer
 You can reduce the FP8 warm-up time by setting the `RUNTIME_SCALE_PATCHING=1` environment variable and
 selecting a hardware-aligned per-tensor `scale_method` provided by the `INC JSON config <json-options>`.
 This feature is recommended for larger models, such as 70B and 405B. When combined with
-`VLLM_EXPONENTIAL_BUCKETING` for FP8 models, it can reduce warm-up time by up to 90%.
+`VLLM_BUCKETING_STRATEGY=exp` for FP8 models, it can reduce warm-up time by up to 90%.
 
 !!!note
     This feature reduces FP8 warm-up time but may lower model throughput by 5-20%. Future releases will improve performance and extend support to more options. Currently, the feature is supported with Lazy mode (`PT_HPU_LAZY_MODE=1`) and `torch.compile`. It supports Llama workloads using FP8 execution of Linear and FSDPA layers, and casting ops between BF16 and FP8. MoE and Convolution options are not yet supported.

--- a/docs/getting_started/quickstart/quickstart_configuration.md
+++ b/docs/getting_started/quickstart/quickstart_configuration.md
@@ -24,11 +24,11 @@ The following table lists the available variables:
 | `MAX_MODEL_LEN`                 | Sets the maximum supported sequence length for the model.                                 |
 | `MAX_NUM_SEQS`                  | Specifies the maximum number of sequences processed concurrently.                         |
 | `TENSOR_PARALLEL_SIZE`          | Defines the degree of tensor parallelism.                                                 |
-| `VLLM_EXPONENTIAL_BUCKETING`    | Enables or disables exponential bucketing for warm-up strategy.                            |
+| `VLLM_BUCKETING_STRATEGY`       | Selects the bucketing strategy used for warm-up: `exp`, `lin`, or `pad`.                  |
 | `VLLM_DECODE_BLOCK_BUCKET_STEP` | Configures the step size for decode block allocation, affecting memory granularity.       |
 | `VLLM_DECODE_BS_BUCKET_STEP`    | Sets the batch size step for decode operations, impacting how decode batches are grouped. |
 | `VLLM_PROMPT_BS_BUCKET_STEP`    | Adjusts the batch size step for prompt processing.                                        |
-| `VLLM_PROMPT_SEQ_BUCKET_STEP`   | Controls the step size for prompt sequence allocation.                                    |
+| `VLLM_PROMPT_QUERY_BUCKET_STEP` | Controls the step size for prompt query-length allocation.                                |
 | `EXTRA_ARGS`                    | Additional vLLM serve args for the server bringup e.g., " --served-model-name model_name" |
 
 Set the preferred variable when running the vLLM server using Docker Compose, as presented in the following example:

--- a/tests/unit_tests/test_bucketing.py
+++ b/tests/unit_tests/test_bucketing.py
@@ -621,6 +621,51 @@ def test_padding_aware_prompt_cfgs_defaults():
     assert ctx_cfg == [0, 2, 31, 16, 25]
 
 
+@patch('vllm_gaudi.extension.bucketing.padding_aware.logger')
+@patch('vllm_gaudi.extension.bucketing.padding_aware.get_config')
+def test_padding_aware_prompt_cfgs_merged_prefill_overrides_defaults(mock_get_config, mock_logger):
+    mock_get_config.return_value = _MockConfig(merged_prefill=True)
+    strategy = PaddingAwareBucketingStrategy()
+
+    bs_cfg, query_cfg, ctx_cfg = strategy.get_prompt_cfgs(max_num_prefill_seqs=16,
+                                                          block_size=128,
+                                                          max_num_batched_tokens=2048,
+                                                          max_model_len=4096)
+
+    assert bs_cfg == (1, 1, 1, 4, 25)
+    assert query_cfg == (128, 512, 2048, 512, 25)
+    assert ctx_cfg == [0, 4, 496, 16, 25]
+
+    info_messages = [call.args[0] for call in mock_logger.return_value.info.call_args_list]
+    assert any('Merged prefill is enabled!' in message for message in info_messages)
+    assert any('prompt bs cfg: (1, 1, 16, 4, 25) -> (1, 1, 1, 4, 25)' in message for message in info_messages)
+    assert any('prompt query cfg: (128, 128, 2048, 512, 25) -> (128, 512, 2048, 512, 25)' in message
+               for message in info_messages)
+    assert any('prompt ctx cfg: (0, 2, 31, 16, 25) -> [0, 4, 496, 16, 25]' in message for message in info_messages)
+
+
+@patch('vllm_gaudi.extension.bucketing.padding_aware.get_config')
+def test_padding_aware_prompt_cfgs_merged_prefill_preserves_user_padding_limits(mock_get_config, monkeypatch):
+    mock_get_config.return_value = _MockConfig(merged_prefill=True)
+    monkeypatch.setenv("VLLM_PROMPT_BS_BUCKET_PAD_MAX", "8")
+    monkeypatch.setenv("VLLM_PROMPT_BS_BUCKET_PAD_PERCENT", "10")
+    monkeypatch.setenv("VLLM_PROMPT_QUERY_BUCKET_STEP", "256")
+    monkeypatch.setenv("VLLM_PROMPT_QUERY_BUCKET_PAD_MAX", "640")
+    monkeypatch.setenv("VLLM_PROMPT_QUERY_BUCKET_PAD_PERCENT", "15")
+    monkeypatch.setenv("VLLM_PROMPT_CTX_BUCKET_PAD_MAX", "32")
+    monkeypatch.setenv("VLLM_PROMPT_CTX_BUCKET_PAD_PERCENT", "5")
+
+    strategy = PaddingAwareBucketingStrategy()
+    bs_cfg, query_cfg, ctx_cfg = strategy.get_prompt_cfgs(max_num_prefill_seqs=16,
+                                                          block_size=128,
+                                                          max_num_batched_tokens=2048,
+                                                          max_model_len=4096)
+
+    assert bs_cfg == (1, 1, 1, 8, 10)
+    assert query_cfg == (128, 1024, 2048, 640, 15)
+    assert ctx_cfg == [0, 4, 496, 32, 5]
+
+
 @patch('vllm_gaudi.extension.bucketing.padding_aware.get_config')
 def test_padding_aware_decode_cfgs_contiguous_pa_clamps_block_range(mock_get_config, monkeypatch):
     mock_get_config.return_value = _MockConfig(use_contiguous_pa=True)

--- a/tests/unit_tests/test_bucketing.py
+++ b/tests/unit_tests/test_bucketing.py
@@ -43,6 +43,66 @@ def test_get_bucketing_strategy_selected_by_env(monkeypatch, env_value, expected
     assert isinstance(strategy, expected_type)
 
 
+def test_get_bucketing_strategy_default_when_env_not_set(monkeypatch):
+    monkeypatch.delenv("VLLM_BUCKETING_STRATEGY", raising=False)
+    clear_config()
+
+    manager = HPUBucketingManager.__new__(HPUBucketingManager)
+    strategy = manager.get_bucketing_strategy()
+
+    assert isinstance(strategy, ExponentialBucketingStrategy)
+
+
+@patch('vllm_gaudi.extension.bucketing.common.logger')
+def test_get_bucketing_strategy_deprecated_env_overrides_to_exponential(mock_logger, monkeypatch):
+    monkeypatch.setenv("VLLM_BUCKETING_STRATEGY", "lin")
+    monkeypatch.setenv("VLLM_EXPONENTIAL_BUCKETING", "true")
+    clear_config()
+
+    manager = HPUBucketingManager.__new__(HPUBucketingManager)
+    strategy = manager.get_bucketing_strategy()
+
+    assert isinstance(strategy, ExponentialBucketingStrategy)
+
+    warnings = [call.args[0] for call in mock_logger.return_value.warning.call_args_list]
+    assert any("deprecated" in message for message in warnings)
+    assert any("Overriding bucketing strategy LinearBucketingStrategy with ExponentialBucketingStrategy" in message
+               for message in warnings)
+
+
+@patch('vllm_gaudi.extension.bucketing.common.logger')
+def test_get_bucketing_strategy_deprecated_env_overrides_to_linear(mock_logger, monkeypatch):
+    monkeypatch.setenv("VLLM_BUCKETING_STRATEGY", "pad")
+    monkeypatch.setenv("VLLM_EXPONENTIAL_BUCKETING", "false")
+    clear_config()
+
+    manager = HPUBucketingManager.__new__(HPUBucketingManager)
+    strategy = manager.get_bucketing_strategy()
+
+    assert isinstance(strategy, LinearBucketingStrategy)
+
+    warnings = [call.args[0] for call in mock_logger.return_value.warning.call_args_list]
+    assert any("deprecated" in message for message in warnings)
+    assert any("Overriding bucketing strategy PaddingAwareBucketingStrategy with LinearBucketingStrategy" in message
+               for message in warnings)
+
+
+@patch('vllm_gaudi.extension.bucketing.common.logger')
+def test_get_bucketing_strategy_deprecated_env_without_override_logs_only_deprecation(mock_logger, monkeypatch):
+    monkeypatch.setenv("VLLM_BUCKETING_STRATEGY", "exp")
+    monkeypatch.setenv("VLLM_EXPONENTIAL_BUCKETING", "true")
+    clear_config()
+
+    manager = HPUBucketingManager.__new__(HPUBucketingManager)
+    strategy = manager.get_bucketing_strategy()
+
+    assert isinstance(strategy, ExponentialBucketingStrategy)
+
+    warnings = [call.args[0] for call in mock_logger.return_value.warning.call_args_list]
+    assert any("deprecated" in message for message in warnings)
+    assert not any("Overriding bucketing strategy" in message for message in warnings)
+
+
 def test_read_bucket_settings(monkeypatch):
     monkeypatch.setenv("VLLM_PROMPT_BS_BUCKET_MIN", "1")
     monkeypatch.setenv("VLLM_PROMPT_BS_BUCKET_STEP", "16")

--- a/tests/unit_tests/test_bucketing.py
+++ b/tests/unit_tests/test_bucketing.py
@@ -9,8 +9,11 @@ import pytest
 from unittest.mock import patch
 
 import vllm_gaudi.extension.bucketing.linear as linear
-from vllm_gaudi.extension.bucketing.common import generate_buckets, calc_fallback_value
+import vllm_gaudi.extension.bucketing.padding_aware as padding_aware
+from vllm_gaudi.extension.bucketing.common import HPUBucketingManager, generate_buckets, calc_fallback_value
 from vllm_gaudi.extension.bucketing.exponential import (ExponentialBucketingStrategy, warmup_range_with_limit)
+from vllm_gaudi.extension.bucketing.linear import LinearBucketingStrategy
+from vllm_gaudi.extension.bucketing.padding_aware import PaddingAwareBucketingStrategy
 from vllm_gaudi.extension.runtime import get_config, clear_config
 
 
@@ -20,6 +23,24 @@ def default_config():
     get_config()
     yield
     clear_config()
+
+
+@pytest.mark.parametrize(
+    ("env_value", "expected_type"),
+    [
+        ("exp", ExponentialBucketingStrategy),
+        ("lin", LinearBucketingStrategy),
+        ("pad", PaddingAwareBucketingStrategy),
+    ],
+)
+def test_get_bucketing_strategy_selected_by_env(monkeypatch, env_value, expected_type):
+    monkeypatch.setenv("VLLM_BUCKETING_STRATEGY", env_value)
+    clear_config()
+
+    manager = HPUBucketingManager.__new__(HPUBucketingManager)
+    strategy = manager.get_bucketing_strategy()
+
+    assert isinstance(strategy, expected_type)
 
 
 def test_read_bucket_settings(monkeypatch):
@@ -491,3 +512,67 @@ def test_exponential_decode_block_limit_cap(monkeypatch):
     # the uncapped ~126.
     total = len(bs_range) * len(block_range)
     assert total <= 50
+
+
+# --- Padding-aware bucketing tests ---
+
+
+def test_padding_aware_read_bucket_settings_query_seq_fallback(monkeypatch):
+    monkeypatch.setenv("VLLM_PROMPT_SEQ_BUCKET_MIN", "64")
+    monkeypatch.setenv("VLLM_PROMPT_SEQ_BUCKET_STEP", "128")
+    monkeypatch.setenv("VLLM_PROMPT_SEQ_BUCKET_MAX", "1024")
+    monkeypatch.setenv("VLLM_PROMPT_SEQ_BUCKET_PAD_MAX", "256")
+    monkeypatch.setenv("VLLM_PROMPT_SEQ_BUCKET_PAD_PERCENT", "10")
+
+    config = padding_aware.read_bucket_settings("prompt",
+                                                "query",
+                                                min=32,
+                                                step=32,
+                                                max=2048,
+                                                pad_max=512,
+                                                pad_percent=25)
+
+    assert config == [64, 128, 1024, 256, 10]
+
+
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        ((0, 8, 64, 64, 0), [0, 1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64]),
+        ((0, 8, 64, 64, 50), [0, 1, 2, 4, 8, 16, 32, 64]),
+        ((0, 8, 64, 16, 50), [0, 1, 2, 4, 8, 16, 32, 48, 64]),
+        ((16, 16, 128, 32, 25), [16, 32, 48, 64, 80, 96, 128]),
+    ],
+)
+def test_padding_aware_warmup_range_with_limits_examples(config, expected):
+    assert padding_aware.warmup_range_with_limits(config) == expected
+
+
+def test_padding_aware_prompt_cfgs_defaults():
+    strategy = PaddingAwareBucketingStrategy()
+
+    bs_cfg, query_cfg, ctx_cfg = strategy.get_prompt_cfgs(max_num_prefill_seqs=16,
+                                                          block_size=128,
+                                                          max_num_batched_tokens=2048,
+                                                          max_model_len=4096)
+
+    assert bs_cfg == [1, 1, 16, 4, 25]
+    assert query_cfg == [128, 128, 2048, 512, 25]
+    assert ctx_cfg == [0, 2, 31, 16, 25]
+
+
+@patch('vllm_gaudi.extension.bucketing.padding_aware.get_config')
+def test_padding_aware_decode_cfgs_contiguous_pa_clamps_block_range(mock_get_config, monkeypatch):
+    mock_get_config.return_value = _MockConfig(use_contiguous_pa=True)
+    monkeypatch.setenv("VLLM_DECODE_BLOCK_BUCKET_MIN", "4096")
+    monkeypatch.setenv("VLLM_DECODE_BLOCK_BUCKET_STEP", "128")
+    monkeypatch.setenv("VLLM_DECODE_BLOCK_BUCKET_MAX", "8192")
+
+    strategy = PaddingAwareBucketingStrategy()
+    _, _, block_cfg = strategy.get_decode_cfgs(max_num_seqs=64,
+                                               block_size=128,
+                                               max_num_batched_tokens=2048,
+                                               max_model_len=4096,
+                                               max_blocks=3593)
+
+    assert block_cfg == [3465, 128, 3593, 899, 25]

--- a/vllm_gaudi/extension/bucketing/common.py
+++ b/vllm_gaudi/extension/bucketing/common.py
@@ -8,6 +8,11 @@ from typing import List, Tuple
 
 from vllm_gaudi.extension.logger import logger as logger
 from vllm_gaudi.extension.runtime import get_config
+from vllm_gaudi.extension.config import boolean
+from vllm_gaudi.extension.bucketing.exponential import ExponentialBucketingStrategy
+from vllm_gaudi.extension.bucketing.linear import LinearBucketingStrategy
+from vllm_gaudi.extension.bucketing.padding_aware import PaddingAwareBucketingStrategy
+from vllm_gaudi.extension.bucketing.file_strategy import FileBucketingStrategy
 
 LONG_CTX_THRESHOLD = 8192
 
@@ -93,7 +98,6 @@ class HPUBucketingManager():
 
     def read_from_file(self, is_prompt):
         file_name = get_config().VLLM_BUCKETING_FROM_FILE
-        from vllm_gaudi.extension.bucketing.file_strategy import (FileBucketingStrategy)
         strategy = FileBucketingStrategy()
         return strategy.get_buckets(file_name, is_prompt)
 
@@ -101,17 +105,31 @@ class HPUBucketingManager():
         # TODO - we can use different strategies for decode and prompt
         bucketing_strategy = get_config().bucketing_strategy
         if bucketing_strategy == 'exp':
-            from vllm_gaudi.extension.bucketing.exponential import (ExponentialBucketingStrategy)
             strategy = ExponentialBucketingStrategy()
         elif bucketing_strategy == 'lin':
-            from vllm_gaudi.extension.bucketing.linear import LinearBucketingStrategy
             strategy = LinearBucketingStrategy()
         elif bucketing_strategy == 'pad':
-            from vllm_gaudi.extension.bucketing.padding_aware import PaddingAwareBucketingStrategy
             strategy = PaddingAwareBucketingStrategy()
         else:
             raise ValueError(
                 f"Invalid bucketing strategy: {bucketing_strategy}, please choose from ['exp', 'lin', 'pad']")
+
+        # for backward compatibility - if VLLM_EXPONENTIAL_BUCKETING is set, it will override the bucketing strategy
+        exp_bucketing_env = os.getenv('VLLM_EXPONENTIAL_BUCKETING', None)
+        if exp_bucketing_env is not None:
+            logger().warning(
+                "VLLM_EXPONENTIAL_BUCKETING is deprecated and will be removed in a future release. Use VLLM_BUCKETING_STRATEGY='exp'|'lin'|'pad' instead."
+            )
+            use_exp_bucketing = boolean(exp_bucketing_env)
+            if use_exp_bucketing:
+                override_strategy = ExponentialBucketingStrategy()
+            else:
+                override_strategy = LinearBucketingStrategy()
+            if override_strategy.__class__ != strategy.__class__:
+                logger().warning(
+                    f"Overriding bucketing strategy {strategy.__class__.__name__} with {override_strategy.__class__.__name__} due to VLLM_EXPONENTIAL_BUCKETING={exp_bucketing_env}"
+                )
+                strategy = override_strategy
         return strategy
 
     def generate_prompt_buckets(self):

--- a/vllm_gaudi/extension/bucketing/common.py
+++ b/vllm_gaudi/extension/bucketing/common.py
@@ -98,18 +98,20 @@ class HPUBucketingManager():
         return strategy.get_buckets(file_name, is_prompt)
 
     def get_bucketing_strategy(self):
-        strategy = None
         # TODO - we can use different strategies for decode and prompt
-        use_exponential_bucketing = True if \
-                get_config().VLLM_EXPONENTIAL_BUCKETING == None else \
-                get_config().VLLM_EXPONENTIAL_BUCKETING
-
-        if use_exponential_bucketing:
+        bucketing_strategy = get_config().bucketing_strategy
+        if bucketing_strategy == 'exp':
             from vllm_gaudi.extension.bucketing.exponential import (ExponentialBucketingStrategy)
             strategy = ExponentialBucketingStrategy()
-        else:
+        elif bucketing_strategy == 'lin':
             from vllm_gaudi.extension.bucketing.linear import LinearBucketingStrategy
             strategy = LinearBucketingStrategy()
+        elif bucketing_strategy == 'pad':
+            from vllm_gaudi.extension.bucketing.padding_aware import PaddingAwareBucketingStrategy
+            strategy = PaddingAwareBucketingStrategy()
+        else:
+            raise ValueError(
+                f"Invalid bucketing strategy: {bucketing_strategy}, please choose from ['exp', 'lin', 'pad']")
         return strategy
 
     def generate_prompt_buckets(self):
@@ -132,6 +134,9 @@ class HPUBucketingManager():
                 bs_range = strategy.get_range(bs_cfg)
                 query_range = strategy.get_range(query_cfg)
                 ctx_range = strategy.get_range(ctx_cfg)
+                logger().debug(f"Prompt BS range: {bs_range}")
+                logger().debug(f"Prompt query range: {query_range}")
+                logger().debug(f"Prompt context range: {ctx_range}")
 
             self.prompt_buckets = generate_buckets(bs_range, query_range, ctx_range, True, self.max_model_len,
                                                    self.max_num_seqs, self.max_num_prefill_seqs,
@@ -175,6 +180,10 @@ class HPUBucketingManager():
 
                 if get_config().use_contiguous_pa and ctx_range[-1] < self.num_hpu_blocks:
                     ctx_range.append(self.num_hpu_blocks)
+
+                logger().debug(f"Decode BS range: {bs_range}")
+                logger().debug(f"Decode query range: {query_range}")
+                logger().debug(f"Decode context range: {ctx_range}")
 
             self.decode_buckets = generate_buckets(bs_range, query_range, ctx_range, False, self.max_model_len,
                                                    self.max_num_seqs, self.max_num_prefill_seqs,
@@ -458,10 +467,8 @@ def generate_buckets(bs_range,
         phase = 'prompt' if is_prompt else 'decode'
         for bucket in omitted_buckets:
             logger().error(bucket)
-        raise RuntimeError(
-            "Generated 0 " + phase +
-            " buckets. Please use default exponential bucketing, VLLM_EXPONENTIAL_BUCKETING=true or generate linear warmup flags according to README"
-        )
+        raise RuntimeError("Generated 0 " + phase +
+                           " buckets. Please adjust the bucketing configuration according to README")
 
     return sorted(buckets)
 

--- a/vllm_gaudi/extension/bucketing/padding_aware.py
+++ b/vllm_gaudi/extension/bucketing/padding_aware.py
@@ -1,0 +1,180 @@
+import os
+import math
+from typing import List, Tuple
+
+from vllm_gaudi.extension.logger import logger as logger
+from vllm_gaudi.extension.runtime import get_config
+
+
+class PaddingAwareBucketingStrategy:
+
+    def get_prompt_cfgs(self, max_num_prefill_seqs, block_size, max_num_batched_tokens, max_model_len):
+        prompt_bs_bucket_cfg = read_bucket_settings('prompt',
+                                                    'bs',
+                                                    min=1,
+                                                    step=1,
+                                                    max=max_num_prefill_seqs,
+                                                    pad_max=math.ceil(max_num_prefill_seqs / 4),
+                                                    pad_percent=25)
+        prompt_query_bucket_cfg = read_bucket_settings('prompt',
+                                                       'query',
+                                                       min=block_size,
+                                                       step=block_size,
+                                                       max=max_num_batched_tokens,
+                                                       pad_max=math.ceil(max_num_batched_tokens / 4),
+                                                       pad_percent=25)
+        max_ctx = math.ceil((max_model_len - prompt_query_bucket_cfg[0]) / block_size)
+        prompt_ctx_bucket_cfg = read_bucket_settings('prompt',
+                                                     'ctx',
+                                                     min=0,
+                                                     step=2,
+                                                     max=max_ctx,
+                                                     pad_max=math.ceil(max_num_batched_tokens / block_size),
+                                                     pad_percent=25)
+
+        msg = ("Prompt bucket config (min, step, max_warmup, pad_max, pad_percent) "
+               f"bs:{prompt_bs_bucket_cfg}, "
+               f"query:{prompt_query_bucket_cfg}, "
+               f"blocks:{prompt_ctx_bucket_cfg}")
+        logger().info(msg)
+
+        return prompt_bs_bucket_cfg, prompt_query_bucket_cfg, prompt_ctx_bucket_cfg
+
+    def get_decode_cfgs(self, max_num_seqs, block_size, max_num_batched_tokens, max_model_len, max_blocks):
+        contiguous_pa = get_config().use_contiguous_pa
+
+        decode_bs_bucket_cfg = read_bucket_settings('decode',
+                                                    'bs',
+                                                    min=1,
+                                                    step=2,
+                                                    max=max_num_seqs,
+                                                    pad_max=math.ceil(max_num_seqs / 4),
+                                                    pad_percent=25)
+        decode_query_bucket_cfg = [1, 1, 1, 1, 1]
+        max_decode_blocks = max(math.ceil(max_model_len * max_num_seqs / block_size), block_size)
+        if contiguous_pa:
+            max_decode_blocks = max_blocks
+        decode_block_bucket_cfg = read_bucket_settings('decode',
+                                                       'block',
+                                                       min=block_size,
+                                                       step=block_size,
+                                                       max=max_decode_blocks,
+                                                       pad_max=math.ceil(max_decode_blocks / 4),
+                                                       pad_percent=25)
+        if contiguous_pa and decode_block_bucket_cfg[2] > max_blocks:
+            logger().info(
+                f'VLLM_DECODE_BLOCK_BUCKET_MAX={decode_block_bucket_cfg[2]} is higher than max_blocks={max_blocks}. Your configuration VLLM_DECODE_BLOCK_BUCKET_MAX={decode_block_bucket_cfg[2]} will be overwritten to VLLM_DECODE_BLOCK_BUCKET_MAX={max_blocks}'
+            )
+            decode_block_bucket_cfg[2] = max_blocks
+        if decode_block_bucket_cfg[0] > max_blocks:
+            decode_block_bucket_min = max(1, max_blocks - decode_block_bucket_cfg[1])
+            logger().info(
+                f'VLLM_DECODE_BLOCK_BUCKET_MIN={decode_block_bucket_cfg[0]} is higher than max_blocks={max_blocks}. Your configuration VLLM_DECODE_BLOCK_BUCKET_MIN={decode_block_bucket_cfg[0]} will be overwritten to VLLM_DECODE_BLOCK_BUCKET_MIN={decode_block_bucket_min}'
+            )
+            decode_block_bucket_cfg[0] = decode_block_bucket_min
+
+        msg = ("Decode bucket config (min, step, max_warmup, pad_max, pad_percent) "
+               f"bs:{decode_bs_bucket_cfg}, "
+               f"blocks:{decode_block_bucket_cfg}")
+        logger().info(msg)
+
+        return decode_bs_bucket_cfg, decode_query_bucket_cfg, decode_block_bucket_cfg
+
+    def get_range(self, cfg):
+        range_for_cfg = warmup_range_with_limits(cfg)
+        return sorted(range_for_cfg)
+
+
+def read_bucket_settings(phase: str, dim: str, **defaults):
+    """Read bucketing configuration from env variables.
+
+    phase is either 'prompt' or 'decode'
+    dim is either 'bs', 'query' or 'block'
+    param is either 'min', 'step', 'max', 'pad_max' or 'pad_percent'
+    example env variable: VLLM_DECODE_BS_BUCKET_STEP=128
+    """
+    params = ['min', 'step', 'max', 'pad_max', 'pad_percent']
+    env_vars = [f'VLLM_{phase}_{dim}_BUCKET_{p}'.upper() for p in params]
+    default_values = [defaults[p] for p in params]
+    values = []
+
+    for p, e, d in zip(params, env_vars, default_values):
+        val = os.environ.get(e)
+
+        if val is None and dim == 'query':
+            # Check if fallback 'seq' flag is set
+            fallback_env = f'VLLM_{phase}_SEQ_BUCKET_{p}'.upper()
+            fallback_val = os.environ.get(fallback_env)
+
+            if fallback_val is not None:
+                val = fallback_val
+                logger().warning(f"{e} not set, using {fallback_env} value ({fallback_val}) instead. "
+                                 "This fallback behavior is deprecated and will be removed in v0.12.0.")
+        resolved_val = int(val) if val is not None else d
+        logger().info(f'{e}={resolved_val} (default:{d})')
+        values.append(resolved_val)
+
+    return values
+
+
+def warmup_range_with_limits(config: Tuple[int, int, int, int, int]) -> List[int]:
+    """Generate a warmup range with absolute and relative padding limits.
+
+    1. Starts from `bucket_min` and multiply by 2 (or +1 for 0) till to `bucket_step`.
+    2. Add `bucket_step` to the values till to `bucket_max` and choose current bucket if:
+        a. the next bucket exceeds the absolute padding limit `pad_max`,
+        b. or the next bucket exceeds the padding ratio limit `pad_percent`,
+        c. or the current bucket is a multiple of `pad_max`.
+    3. Always include `bucket_max` as the last bucket.
+
+    Example:
+    1. for config = (0, 8, 64, 64, 0), fallback to linear bucketing without padding limits:
+        ramp_up = [0, 1, 2, 4, 8]
+        stable = [16, 24, 32, 40, 48, 56, 64]
+        return [0, 1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64]
+    2. for config = (0, 8, 64, 64, 50), fallback to exponential bucketing:
+        ramp_up = [0, 1, 2, 4, 8]
+        stable = [16, 32, 64]  # [24, 40, 48, 56] are skipped due to padding ratio limit
+        return [0, 1, 2, 4, 8, 16, 32, 64]
+    3. for config = (0, 8, 64, 16, 50)
+        ramp_up = [0, 1, 2, 4, 8]
+        stable = [16, 32, 48, 64]  # [24, 40, 56] are skipped due to absolute padding limit
+        return [0, 1, 2, 4, 8, 16, 32, 48, 64]
+    4. for config = (16, 16, 128, 32, 25)
+        stable = [16, 32, 48, 64, 80, 96, 128]  # no ramp up phase
+        return [16, 32, 48, 64, 80, 96, 128]
+    """
+    bucket_min, bucket_step, bucket_max, pad_max, pad_percent = config
+    if pad_max == 0:
+        pad_max = bucket_max
+    assert bucket_min <= bucket_max, ("bucket_min cannot be greater than bucket_max. "
+                                      "If you want to skip warmup, set VLLM_SKIP_WARMUP=true")
+    assert bucket_step > 0, f"bucket_step must be positive, got: ({bucket_step})"
+    assert 0 <= pad_percent <= 50, f"pad_percent must be between 0 and 50 percentage points, got: ({pad_percent})"
+
+    buckets = [bucket_min]
+    current_bucket = bucket_min
+    while current_bucket <= bucket_max:
+        last_bucket = buckets[-1]
+        if current_bucket <= bucket_step:
+            next_bucket = last_bucket * 2
+            if next_bucket == 0:
+                next_bucket += 1
+            if next_bucket <= bucket_max:
+                buckets.append(next_bucket)
+        else:
+            next_bucket = current_bucket + bucket_step
+            max_padding = next_bucket - last_bucket - 1
+            max_padding_ratio = max_padding / next_bucket
+            keep_bucket = (
+                max_padding_ratio > pad_percent / 100.0  # next bucket exceeds padding ratio limit
+                or max_padding > pad_max  # next bucket exceeds absolute padding limit
+                or current_bucket % pad_max == 0  # current bucket is a multiple of pad_max
+            )
+            if keep_bucket and current_bucket != last_bucket:
+                buckets.append(current_bucket)
+        current_bucket = next_bucket
+    if buckets[-1] != bucket_max:
+        buckets.append(bucket_max)
+
+    return buckets

--- a/vllm_gaudi/extension/bucketing/padding_aware.py
+++ b/vllm_gaudi/extension/bucketing/padding_aware.py
@@ -9,6 +9,7 @@ from vllm_gaudi.extension.runtime import get_config
 class PaddingAwareBucketingStrategy:
 
     def get_prompt_cfgs(self, max_num_prefill_seqs, block_size, max_num_batched_tokens, max_model_len):
+        use_merged_prefill = get_config().merged_prefill
         prompt_bs_bucket_cfg = read_bucket_settings('prompt',
                                                     'bs',
                                                     min=1,
@@ -31,6 +32,29 @@ class PaddingAwareBucketingStrategy:
                                                      max=max_ctx,
                                                      pad_max=math.ceil(max_num_batched_tokens / block_size),
                                                      pad_percent=25)
+        if use_merged_prefill:
+            prev_prompt_bs_bucket_cfg = tuple(prompt_bs_bucket_cfg)
+            prev_prompt_query_bucket_cfg = tuple(prompt_query_bucket_cfg)
+            prev_prompt_ctx_bucket_cfg = tuple(prompt_ctx_bucket_cfg)
+
+            prompt_bs_bucket_cfg = (1, 1, 1, prev_prompt_bs_bucket_cfg[-2], prev_prompt_bs_bucket_cfg[-1])
+            query_min, query_step, _, query_pad_max, query_pad_percent = prev_prompt_query_bucket_cfg
+            prompt_query_bucket_cfg = (query_min, query_step * 4, max_num_batched_tokens, query_pad_max,
+                                       query_pad_percent)
+            prompt_ctx_bucket_cfg = read_bucket_settings('prompt',
+                                                         'ctx',
+                                                         min=0,
+                                                         step=4,
+                                                         max=max_ctx * max_num_prefill_seqs,
+                                                         pad_max=math.ceil(max_num_batched_tokens / block_size),
+                                                         pad_percent=25)
+
+            msg = ('Merged prefill is enabled!\n'
+                   'Overriding prompt bucketing settings!\n'
+                   f'prompt bs cfg: {prev_prompt_bs_bucket_cfg} -> {prompt_bs_bucket_cfg}\n'
+                   f'prompt query cfg: {prev_prompt_query_bucket_cfg} -> {prompt_query_bucket_cfg}\n'
+                   f'prompt ctx cfg: {prev_prompt_ctx_bucket_cfg} -> {prompt_ctx_bucket_cfg}\n')
+            logger().info(msg)
 
         msg = ("Prompt bucket config (min, step, max_warmup, pad_max, pad_percent) "
                f"bs:{prompt_bs_bucket_cfg}, "
@@ -50,7 +74,9 @@ class PaddingAwareBucketingStrategy:
                                                     max=max_num_seqs,
                                                     pad_max=math.ceil(max_num_seqs / 4),
                                                     pad_percent=25)
-        decode_query_bucket_cfg = [1, 1, 1, 1, 1]
+        # Decode query is always 1 token (autoregressive), no bucketing needed
+        decode_query_bucket_cfg = [1, 1, 1, 1, 0]
+
         max_decode_blocks = max(math.ceil(max_model_len * max_num_seqs / block_size), block_size)
         if contiguous_pa:
             max_decode_blocks = max_blocks

--- a/vllm_gaudi/extension/features.py
+++ b/vllm_gaudi/extension/features.py
@@ -13,26 +13,37 @@ from vllm_gaudi.extension.validation import for_all, choice
 def get_user_flags():
     flags = [
         Env('VLLM_DEVELOPER_MODE', boolean),
-        Env('VLLM_EXPONENTIAL_BUCKETING', boolean),
         Env('VLLM_PROMPT_BS_BUCKET_MIN', int),
         Env('VLLM_PROMPT_BS_BUCKET_STEP', int),
         Env('VLLM_PROMPT_BS_BUCKET_MAX', int),
+        Env('VLLM_PROMPT_BS_BUCKET_PAD_MAX', int),
+        Env('VLLM_PROMPT_BS_BUCKET_PAD_PERCENT', int),
         Env('VLLM_PROMPT_QUERY_BUCKET_MIN', int),
         Env('VLLM_PROMPT_QUERY_BUCKET_STEP', int),
         Env('VLLM_PROMPT_QUERY_BUCKET_MAX', int),
+        Env('VLLM_PROMPT_QUERY_BUCKET_PAD_MAX', int),
+        Env('VLLM_PROMPT_QUERY_BUCKET_PAD_PERCENT', int),
         Env('VLLM_PROMPT_SEQ_BUCKET_MIN', int),
         Env('VLLM_PROMPT_SEQ_BUCKET_STEP', int),
         Env('VLLM_PROMPT_SEQ_BUCKET_MAX', int),
+        Env('VLLM_PROMPT_SEQ_BUCKET_PAD_MAX', int),
+        Env('VLLM_PROMPT_SEQ_BUCKET_PAD_PERCENT', int),
         Env('VLLM_PROMPT_CTX_BUCKET_MIN', int),
         Env('VLLM_PROMPT_CTX_BUCKET_STEP', int),
         Env('VLLM_PROMPT_CTX_BUCKET_MAX', int),
+        Env('VLLM_PROMPT_CTX_BUCKET_PAD_MAX', int),
+        Env('VLLM_PROMPT_CTX_BUCKET_PAD_PERCENT', int),
         Env('VLLM_DECODE_BS_BUCKET_MIN', int),
         Env('VLLM_DECODE_BS_BUCKET_STEP', int),
         Env('VLLM_DECODE_BS_BUCKET_MAX', int),
+        Env('VLLM_DECODE_BS_BUCKET_PAD_MAX', int),
+        Env('VLLM_DECODE_BS_BUCKET_PAD_PERCENT', int),
         Env('VLLM_DECODE_BLOCK_BUCKET_MIN', int),
         Env('VLLM_DECODE_BLOCK_BUCKET_STEP', int),
         Env('VLLM_DECODE_BLOCK_BUCKET_MAX', int),
-        Env('VLLM_DECODE_BLOCK_BUCKET_LIMIT', int),
+        Env('VLLM_DECODE_BLOCK_BUCKET_PAD_MAX', int),
+        Env('VLLM_DECODE_BLOCK_BUCKET_PAD_PERCENT', int),
+        Env('VLLM_BUCKETING_STRATEGY', str),
         Env('VLLM_BUCKETING_FROM_FILE', str),
 
         # Non-vllm flags that are also important to print
@@ -63,7 +74,6 @@ def get_experimental_flags():
 
 def get_features():
     supported_attn_impls = ['flex_impl', 'fsdpa_impl', 'naive_impl']
-    bucketing_strategies = ['exponential_bucketing', 'linear_bucketing']
     features = [
         Value('fp32_alibi_biases', True, env_var='VLLM_ALIBI_USE_FLOAT32_BIASES'),
         Value('fp32_softmax', Any(ModelType('qwen2'), ModelType('qwen2_5_vl'))),
@@ -80,9 +90,11 @@ def get_features():
         Value('merged_prefill', False),
         Value('use_contiguous_pa', Disabled('prefix_caching'), env_var='VLLM_CONTIGUOUS_PA'),
         Value('use_bucketing', True, env_var='VLLM_ENABLE_BUCKETING'),
-        Value('exponential_bucketing', True),
-        Value('linear_bucketing', True),
-        ValueFromList('bucketing_strategy', bucketing_strategies),
+        Value('bucketing_strategy',
+              'exp',
+              env_var='VLLM_BUCKETING_STRATEGY',
+              env_var_type=str,
+              check=choice('exp', 'lin', 'pad')),
         Value('defrag', False),
         Value('regional_compilation', True, env_var='VLLM_T_COMPILE_REGIONAL_COMPILATION', env_var_type=boolean),
         Value('dynamic_shapes_compilation', True, env_var='VLLM_T_COMPILE_DYNAMIC_SHAPES', env_var_type=boolean),

--- a/vllm_gaudi/extension/runtime.py
+++ b/vllm_gaudi/extension/runtime.py
@@ -15,7 +15,7 @@ USER_FLAGS = None
 EXPERIMENTAL_FLAGS = None
 ENVIRONMENT_VALUES = None
 FEATURE_VALUES = None
-HIDDEN_PARAMS = ['exponential_bucketing', 'linear_bucketing', 'flex_impl', 'fsdpa_impl', 'naive_impl']
+HIDDEN_PARAMS = ['flex_impl', 'fsdpa_impl', 'naive_impl']
 
 
 def filter_defined(config, keys):


### PR DESCRIPTION
Introduce the new `PaddingAwareBucketingStrategy` which could be enabled by setting `VLLM_BUCKETING_STRATEGY="pad"` and further tuning by setting the `VLLM_{phase}_{dim}_BUCKET_PAD_MAX` and `VLLM_{phase}_{dim}_BUCKET_PAD_PERCENT` for the max absolute and relative padding limits respectively.

## Motivation
The exponential bucketing is introduced to significantly reduce the number of buckets. For the example with `max_num_batched_tokens=8192`, `max_model_len=32768`, `max_num_seqs=256` and `# hpu blocks: 4127`. The exponential bucketing generates **120** prompt buckets and **81** decode buckets, and the linear bucketing generates **14368** prompt buckets and **4042** decode buckets. The exponential buckets are filtered combinations with the following ranges:
```
Prompt query range: [128, 256, 384, 512, 640, 1792, 2816, 3968, 4992, 6144, 7168, 8192]
Prompt context range: [0, 1, 3, 8, 22, 56, 90, 124, 158, 192]
Decode BS range: [1, 2, 4, 8, 14, 24, 42, 78, 140, 256]
Decode context range: [1, 256, 512, 768, 1024, 1280, 1536, 1792, 2304, 2816, 3584, 4352]
```
The max absolute padding (`max(bucket[i]-bucket[i-1]-1)`) is proportional to the bucket max without limitations, and the max relative padding (`(bucket[i]-bucket[i-1]-1)/bucket[i]`) towards **50%** for large bucket max. The large padding cause large overhead especially for the cases with long sequences.

We need a bucketing algorithm to **balance** the bucket number (warmup time) and the runtime performance (padding overhead).

## Changes
- Enhance the `warmup_range` in linear bucketing to `warmup_range_with_limits` to generate a range that ensure the absolute and relative padding not exceeds the specified limits.
- Introduce new ENVs named `VLLM_{phase}_{dim}_BUCKET_PAD_MAX` and `VLLM_{phase}_{dim}_BUCKET_PAD_PERCENT` to set the absolute and relative padding limits respectively.
- Introduce the new ENV named `VLLM_BUCKETING_STRATEGY` to selects the bucketing strategies from `exp`, `lin` and  `pad` for the default exponential, the linear and the padding-aware bucketing strategies respectively.

For the above example with default settings:
```
Prompt query range: [128, 256, 384, 512, 640, 768, 1024, 1280, 1664, 2176, 2816, 3712, 4864, 6400, 8192]
Prompt context range: [0, 1, 2, 4, 6, 8, 12, 16, 22, 30, 40, 54, 64, 86, 116, 128, 172, 192, 255]
Decode BS range: [1, 2, 4, 6, 8, 12, 16, 22, 30, 32, 44, 60, 64, 86, 96, 128, 160, 192, 224, 256]
Decode context range: [128, 256, 384, 512, 640, 768, 1024, 1280, 1664, 2176, 2816, 3712, 4127]
```
Which results in **284** prompt buckets and **222** decode buckets with much less padding.

## Benefits
- Could simulate the exponential bucketing by setting large `VLLM_{phase}_{dim}_BUCKET_PAD_MAX` and setting `VLLM_{phase}_{dim}_BUCKET_PAD_PERCENT=50`.
- Could fallback to the original linear bucketing by setting `VLLM_{phase}_{dim}_BUCKET_PAD_PERCENT=0`.
- Users could further tuning the absolute and relative padding limits to balance the warmup time and runtime performance.
- Setting `VLLM_{phase}_{dim}_BUCKET_PAD_MAX` to multiple of `PT_HPU_SDPA_BR_FACTOR` and `PT_HPU_SDPA_BC_FACTOR` could generate buckets that align with the slicing chunk size and give better performance.
