### PR TITLE
Documentation: Fix missing back navigation arrow on mobile devices

### DIFF
--- a/docs/styles/custom.css
+++ b/docs/styles/custom.css
@@ -10,8 +10,14 @@
     margin-block-end: 0.5em;
 }
 
-.md-nav--primary .md-nav__title {
-    display: none;
+@media screen and (min-width: 76.25em) {
+    .md-nav--primary .md-nav__title {
+        display: none;
+    }
+}
+
+.md-nav__item--section > .md-nav {
+    margin-block-start: 0;
 }
 
 .md-sidebar--primary {


### PR DESCRIPTION
This change fixes an issue on mobile devices where the back navigation arrow was hidden, preventing users from navigating to higher-level documents. The rule responsible for this behavior is now applied only to desktop viewports, ensuring the arrow displays correctly in the menu bar on narrow screens.
Before:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/869e4be7-2d95-4034-be5a-bd2ae893ed80" />
After:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/4d06e119-901d-4adb-895b-14448e302857" />
