### PR TITLE
Fix dummy_mm_item TypeError when warmup MM model 

### DIFF
--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -4577,23 +4577,32 @@ class HPUModelRunner(KVConnectorModelRunnerMixin):
             #    height=h  # Custom height in pixels
             #)
             batch = img_count
-        '''
 
         processor = self.mm_registry.create_processor(model_config=self.model_config, cache=self.mm_budget.cache)
-        '''dummy_data = processor.dummy_inputs.get_decoder_dummy_data(processor,
+        dummy_data = processor.dummy_inputs.get_decoder_dummy_data(processor,
                                                                    seq_len=4096,
                                                                    mm_counts={"image": img_count},
                                                                    mm_options={"image": image_options}),
 
-        '''
         dummy_mm_data = processor.dummy_inputs.get_dummy_processor_inputs(
             seq_len=4096,
             mm_counts={"image": img_count},
         )
+        '''
 
         assert modality == 'image'
         # Result in the maximum GPU consumption of the model
-        dummy_mm_item = dummy_mm_data['image'][0]
+        dummy_mm_inputs = self.mm_registry.get_dummy_mm_inputs(
+            self.model_config,
+            mm_counts={modality: 1},
+            cache=self.mm_budget.cache,
+        )
+
+        dummy_mm_item = dummy_mm_inputs["mm_kwargs"][modality][0]
+        # We use the cache so that the item is saved to the cache,
+        # but not read from the cache
+        assert dummy_mm_item is not None, "Item should not already be cached"
+
         dummy_mm_items = [dummy_mm_item] * batch
 
         return next(mm_kwargs_group for _, _, mm_kwargs_group in group_mm_kwargs_by_modality(


### PR DESCRIPTION
Failed in multimodal model init because `dummy_mm_data['image'][0] ` need be `MultiModalKwargsItem `


vllm serve Qwen/Qwen2.5-VL-7B-Instruct --trust-remote-code

```shell
(EngineCore_DP0 pid=743478) ERROR 01-15 06:22:21 [core.py:936]   File "/mnt/ceph1/youzhi/vllm-gaudi/vllm_gaudi/v1/worker/hpu_model_runner.py", line 4750, in warmup_model
(EngineCore_DP0 pid=743478) ERROR 01-15 06:22:21 [core.py:936]     self.warmup_multimodal_graphs(self.get_model().vision_bucket_manager.multimodal_buckets)
(EngineCore_DP0 pid=743478) ERROR 01-15 06:22:21 [core.py:936]   File "/mnt/ceph1/youzhi/vllm-gaudi/vllm_gaudi/v1/worker/hpu_model_runner.py", line 4633, in warmup_multimodal_graphs
(EngineCore_DP0 pid=743478) ERROR 01-15 06:22:21 [core.py:936]     batched_dummy_mm_inputs = self._get_mm_dummy_batch(modality, img_arg, ratio_w, ratio_h)
(EngineCore_DP0 pid=743478) ERROR 01-15 06:22:21 [core.py:936]   File "/mnt/ceph1/youzhi/vllm-gaudi/vllm_gaudi/v1/worker/hpu_model_runner.py", line 4596, in _get_mm_dummy_batch
(EngineCore_DP0 pid=743478) ERROR 01-15 06:22:21 [core.py:936]     dummy_mm_item = dummy_mm_data['image'][0]
(EngineCore_DP0 pid=743478) ERROR 01-15 06:22:21 [core.py:936] TypeError: 'ProcessorInputs' object is not subscriptable
```
@iboiko-habana could you review or give some help? thx
