### PR TITLE
Fix INC patch for new version

### DIFF
--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -5650,17 +5650,13 @@ class HPUAttentionMetadataProcessor:
 
 def _apply_inc_patch():
     try:
-        import neural_compressor
-        from packaging import version
+        from neural_compressor.torch.algorithms.fp8_quant._quant_common.quant_config import (
+            supported_dynamic_ops as inc_supported_dynamic_ops, )
+        from neural_compressor.torch.algorithms.fp8_quant._quant_common import quant_config as inc_quant_config
 
-        inc_version = version.parse(neural_compressor.__version__)
-        if inc_version <= version.parse("3.5"):
-            # Apply it only when INC version is <= 3.5
-            from neural_compressor.torch.algorithms.fp8_quant._quant_common.quant_config import (
-                supported_dynamic_ops as inc_supported_dynamic_ops, )
-            from neural_compressor.torch.algorithms.fp8_quant._quant_common import quant_config as inc_quant_config
-
-            fixed_dynamic_ops = inc_supported_dynamic_ops + ["MoeMatmul"]
-            inc_quant_config.supported_dynamic_ops = fixed_dynamic_ops
+        fixed_dynamic_ops = inc_supported_dynamic_ops + ["MoeMatmul"]
+        inc_quant_config.supported_dynamic_ops = fixed_dynamic_ops
+        logger.warning_once(f"Applied INC patch for FP8 dynamic quantization support for MoE. "
+                            f"Fixed supported_dynamic_ops: {fixed_dynamic_ops}")
     except (ImportError, AttributeError):
         pass


### PR DESCRIPTION
The issue was fixed in synpase 1.24(INC 3.6), and the `supported_dynamic_ops ` was removed.