### PR TITLE
Fix Llama4 shape mismatch for 32k+ context window

### DIFF
--- a/vllm_gaudi/ops/hpu_fused_moe.py
+++ b/vllm_gaudi/ops/hpu_fused_moe.py
@@ -90,7 +90,7 @@ class HPUUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
             activation=layer.activation,
         )
         if layer.dp_size > 1:
-            output.view(*(output.size(0), *input_shape[1:]))
+            return output.view(*(output.size(0), *input_shape[1:]))
         else:
             return output.view(*input_shape)
 


### PR DESCRIPTION
Llama4 for `max_model_len > 32k` enable temperature adjustment https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/models/llama4.py#L719. Enabled adjustment causes tensor `q` shape modification from 2D to 3D: https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/models/llama4.py#L307. This tensor is passing to `UnqnatizedFusedMoEMetod -> forward`: https://github.com/vllm-project/vllm-gaudi/blob/main/vllm_gaudi/ops/hpu_fused_moe.py#L163 causing invalid reshaping - we trying to return a 3D `output.view` based on 2D output tensor.

Found that following PR introduced the bug: #680 and #684 