### PR TITLE
POC of RowParallelLinear

### DIFF
--- a/tests/test_llama_70b_2layer_tp4.py
+++ b/tests/test_llama_70b_2layer_tp4.py
@@ -1,0 +1,131 @@
+"""Test Llama 70B-like inference with only 2 layers using TP4 and BF16."""
+import os
+import tempfile
+import shutil
+import argparse
+import torch
+from transformers import LlamaConfig, AutoTokenizer
+from vllm import LLM, SamplingParams
+
+# Import habana_frameworks to ensure HPU is available
+try:
+    import habana_frameworks.torch as htorch
+    HPU_AVAILABLE = True
+except ImportError:
+    HPU_AVAILABLE = False
+    print("WARNING: habana_frameworks not available, HPU may not be used")
+
+
+def test_llama_70b_2layer_tp4_bf16(
+    max_tokens: int = 16, warmup: bool = True, prompt_len: int = 8192, profile: bool = False
+):
+    """
+    Test inference with Llama 70B configuration but only 2 layers.
+    Creates a config with 70B dimensions but only 2 layers, copies tokenizer from real model.
+    
+    Args:
+        max_tokens: Number of tokens to generate
+        warmup: Whether to run warmup with same prompt length
+        prompt_len: Approximate prompt length in tokens (default 8192)
+    """
+    # Set environment variable for chunking before LLM initialization
+    if "VLLM_ROW_PARALLEL_CHUNKS" not in os.environ:
+        os.environ["VLLM_ROW_PARALLEL_CHUNKS"] = "4"
+        print(f"Set VLLM_ROW_PARALLEL_CHUNKS={os.environ['VLLM_ROW_PARALLEL_CHUNKS']}")
+    else:
+        print(f"VLLM_ROW_PARALLEL_CHUNKS already set to {os.environ['VLLM_ROW_PARALLEL_CHUNKS']}")
+    
+    # Create temp directory
+    temp_dir = tempfile.mkdtemp(prefix="llama_2layer_test_")
+    
+    # Verify HPU is available
+    if HPU_AVAILABLE:
+        print(f"HPU available: {torch.hpu.is_available()}")
+        if torch.hpu.is_available():
+            print(f"HPU device count: {torch.hpu.device_count()}")
+    
+    try:
+        # Create Llama 70B config with only 2 layers
+        config = LlamaConfig(
+            vocab_size=128256,  # Llama 3.3 vocab size
+            hidden_size=8192,
+            intermediate_size=28672,
+            num_hidden_layers=4,  # Only 4 layers
+            num_attention_heads=64,
+            num_key_value_heads=8,
+            max_position_embeddings=131072,
+            rms_norm_eps=1e-5,
+            torch_dtype="bfloat16",
+        )
+        config.save_pretrained(temp_dir)
+        
+        # Copy tokenizer from real model
+        tokenizer_path = "/mnt/weka/data/pytorch/llama3.3/Meta-Llama-3.3-70B-Instruct/"
+        tokenizer = AutoTokenizer.from_pretrained(tokenizer_path)
+        tokenizer.save_pretrained(temp_dir)
+        
+        # Initialize LLM with TP4 and BF16, using dummy weights
+        # Set max_num_batched_tokens higher than prompt+decode to handle chunking
+        # Set num_gpu_blocks_override slightly larger than max decode to prevent
+        # scheduler from forcing KV cache movement causing recompilations
+        llm = LLM(
+            model=temp_dir,
+            enable_prefix_caching=False,
+            tensor_parallel_size=4,
+            dtype="bfloat16",
+            trust_remote_code=True,
+            enforce_eager=True,
+            load_format="dummy",  # Initialize with random weights, no checkpoint needed
+            max_num_batched_tokens=prompt_len + max_tokens + 1024,  # Extra buffer for chunking
+            num_gpu_blocks_override=((prompt_len + max_tokens + 1024)//128 + 10),  # Slightly larger than max decode to avoid recompilations. This is used because defrag=True fails so we avoid defragmentation limiting kv cache
+        )
+        
+    
+        # Create prompt with approximately prompt_len tokens
+        # "Hello, how are you?" is ~5 tokens, so repeat it prompt_len/5 times
+        repeat_count = prompt_len // 5
+        prompt_text = "Hello, how are you?" * repeat_count
+        prompts = [prompt_text]
+        sampling_params = SamplingParams(temperature=0.0, max_tokens=max_tokens)
+        
+        # Warmup: Run with same prompt length to warm up the correct buckets
+        if warmup:
+            print(f"Running warmup with ~{prompt_len} token prompt...")
+            llm.generate(prompts, sampling_params)
+            print("Warmup complete.")
+        
+        # Run actual inference
+        
+        print(f"Running inference with max_tokens={max_tokens}...")
+        prompts = [prompt_text+'xxxx']
+        outputs = llm.generate(prompts, sampling_params)
+        prompts = [prompt_text+'xxxxxxxxxxxxx']
+        if profile:
+            llm.start_profile()
+        outputs = llm.generate(prompts, sampling_params)
+        if profile:
+            llm.stop_profile()
+        # Verify output
+        assert len(outputs) == 1
+        assert len(outputs[0].outputs) > 0
+        print(f"Generated {len(outputs[0].outputs[0].token_ids)} tokens")
+        print(f"Output: {outputs[0].outputs[0].text[:100]}...")
+        print("Test passed!")
+    
+    finally:
+        # Cleanup
+        
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--max-tokens", type=int, default=2, help="Number of tokens to generate")
+    parser.add_argument("--prompt-len", type=int, default=8192, help="Approximate prompt length in tokens")
+    parser.add_argument("--no-warmup", action="store_true", help="Skip warmup phase")
+    parser.add_argument("--profile", action="store_true", help="Enable profiling")
+    args = parser.parse_args()
+    
+    test_llama_70b_2layer_tp4_bf16(
+        max_tokens=args.max_tokens, warmup=not args.no_warmup, prompt_len=args.prompt_len, profile=args.profile
+    )

--- a/vllm_gaudi/__init__.py
+++ b/vllm_gaudi/__init__.py
@@ -21,6 +21,7 @@ def register_ops():
     import vllm_gaudi.ops.hpu_awq  # noqa: F401
     import vllm_gaudi.ops.hpu_multihead_attn  # noqa: F401
     import vllm_gaudi.ops.hpu_conv  # noqa: F401
+    import vllm_gaudi.ops.hpu_row_parallel_linear  # noqa: F401
 
 
 def register_models():

--- a/vllm_gaudi/extension/defragmentation.py
+++ b/vllm_gaudi/extension/defragmentation.py
@@ -36,6 +36,7 @@ class CacheSwapUtils(torch.nn.Module):
             prev_srcs = cache.index_select(0, srcs)
             # using apc we need to swap free blocks back as they can contain cached data
             if self.enable_prefix_caching:
+                print(f'here')
                 prev_dsts = cache.index_select(0, dsts)
                 cache.index_copy_(0, srcs, prev_dsts)
                 prev_dsts = None

--- a/vllm_gaudi/ops/hpu_row_parallel_linear.py
+++ b/vllm_gaudi/ops/hpu_row_parallel_linear.py
@@ -1,0 +1,188 @@
+from typing import Union
+import os
+import torch
+from torch.nn.parameter import Parameter
+from vllm.model_executor.layers.linear import RowParallelLinear
+from vllm.distributed import (
+    split_tensor_along_last_dim,
+    tensor_model_parallel_all_reduce,
+)
+import logging
+
+logger = logging.getLogger(__name__)
+
+@RowParallelLinear.register_oot
+class HPURowParallelLinear(RowParallelLinear):
+    """HPU-optimized RowParallelLinear implementation.
+    
+    This implementation provides chunked computation for overlapping
+    compute and communication on HPU devices.
+    """
+
+    def __init__(self, *args, **kwargs):
+        """Initialize HPURowParallelLinear with chunking support.
+        
+        The number of chunks can be configured via the VLLM_ROW_PARALLEL_CHUNKS
+        environment variable. Default is 4 chunks.
+        """
+        super().__init__(*args, **kwargs)
+        # Check for chunking configuration via environment variable
+        self.num_chunks = int(os.environ.get("VLLM_ROW_PARALLEL_CHUNKS", "4"))
+        logger.info(f"HPURowParallelLinear initialized with num_chunks={self.num_chunks}, "
+                   f"tp_size={self.tp_size}, reduce_results={self.reduce_results}")
+
+    def forward_oot(
+        self,
+        input_,
+    ) -> Union[torch.Tensor, tuple[torch.Tensor, Parameter]]:
+        """Forward pass with HPU-specific optimizations.
+        
+        Args:
+            input_: Input tensor to process
+            
+        Returns:
+            Output tensor, or tuple of (output, bias) if skip_bias_add is True
+        """
+        logger.info(f"HPURowParallelLinear.forward_oot called with input shape={input_.shape}, "
+                   f"num_chunks={self.num_chunks}, tp_size={self.tp_size}, "
+                   f"reduce_results={self.reduce_results}")
+        
+        if self.input_is_parallel:
+            input_parallel = input_
+        else:
+            splitted_input = split_tensor_along_last_dim(
+                input_, num_partitions=self.tp_size
+            )
+            input_parallel = splitted_input[self.tp_rank].contiguous()
+
+        assert self.quant_method is not None
+        
+        # Log the shape and chunking decision criteria
+        input_shape = input_parallel.shape
+        # Check if we should use chunking
+        # For 2D input [tokens, hidden], check if tokens > 1
+        # For 3D input [batch, seq, hidden], check if seq > 1
+        should_chunk = (self.num_chunks > 1 and 
+                       self.reduce_results and 
+                       self.tp_size > 1)
+        
+        # Additional check: for 2D input, shape is [tokens, hidden], check tokens
+        # For 3D input, shape is [batch, seq, hidden], check seq
+        if should_chunk and len(input_shape) >= 2:
+            if len(input_shape) == 2:
+                should_chunk = input_shape[0] > 1  # tokens dimension
+            else:  # 3D
+                should_chunk = input_shape[1] > 1  # sequence dimension
+        else:
+            should_chunk = False
+            
+        logger.info(f"Chunking decision: num_chunks={self.num_chunks}, "
+                   f"reduce_results={self.reduce_results}, tp_size={self.tp_size}, "
+                   f"input_shape={input_shape}, should_chunk={should_chunk}")
+        
+        # Chunked computation for overlapping compute and communication
+        if should_chunk:
+            logger.info(f"Using chunked computation with {self.num_chunks} chunks")
+            torch._dynamo.graph_break()
+            
+            # Determine if input is 3D [batch, seq, hidden] or 2D [batch*seq, hidden]
+            is_3d = input_parallel.ndim == 3
+            
+            if is_3d:
+                # Input is [batch, seq, hidden], chunk along sequence dimension
+                batch_size, seq_len, hidden_dim = input_parallel.shape
+                chunk_dim = 1  # sequence dimension
+                total_tokens = seq_len
+            else:
+                # Input is [batch*seq, hidden], chunk along batch dimension
+                total_tokens, hidden_dim = input_parallel.shape
+                chunk_dim = 0
+            
+            chunk_size = (total_tokens + self.num_chunks - 1) // self.num_chunks
+            
+            # Lists to store chunks and handles
+            output_chunks = []
+            handles = []
+            chunk_ranges = []
+            
+            # Phase 1: Compute all chunks and start all-reduces
+            for i in range(self.num_chunks):
+                torch._dynamo.graph_break()
+                start_idx = i * chunk_size
+                end_idx = min((i + 1) * chunk_size, total_tokens)
+                
+                # Skip empty chunks
+                if start_idx >= end_idx:
+                    continue
+                
+                # Slice input along the appropriate dimension
+                if is_3d:
+                    input_chunk = input_parallel[:, start_idx:end_idx, :]
+                else:
+                    input_chunk = input_parallel[start_idx:end_idx]
+                
+                # Compute on chunk (bias only on first chunk for rank 0)
+                bias_ = self.bias if (i == 0 and self.tp_rank == 0 and not self.skip_bias_add) else None
+                output_chunk = self.quant_method.apply(self, input_chunk, bias_)
+                torch._dynamo.graph_break()
+                
+                # Start async all-reduce for this chunk
+                handle = torch.distributed.all_reduce(
+                    output_chunk, group=torch.distributed.group.WORLD, async_op=True
+                )
+                
+                # Store chunk, handle, and range info
+                output_chunks.append(output_chunk)
+                handles.append(handle)
+                chunk_ranges.append((start_idx, end_idx))
+            
+            # Phase 2: Wait for all handles and combine outputs
+            for handle in handles:
+                handle.wait()
+            
+            torch._dynamo.graph_break()
+            
+            # Pre-allocate output buffer matching input shape
+            if is_3d:
+                output = torch.empty(
+                    batch_size,
+                    seq_len,
+                    self.output_size_per_partition, 
+                    dtype=input_parallel.dtype,
+                    device=input_parallel.device
+                )
+            else:
+                output = torch.empty(
+                    total_tokens, 
+                    self.output_size_per_partition, 
+                    dtype=input_parallel.dtype,
+                    device=input_parallel.device
+                )
+            
+            # Copy all chunks to output
+            for chunk, (start_idx, end_idx) in zip(output_chunks, chunk_ranges):
+                if is_3d:
+                    output[:, start_idx:end_idx, :] = chunk
+                else:
+                    output[start_idx:end_idx] = chunk
+            
+            torch._dynamo.graph_break()
+        else:
+            # Original single-shot computation
+            bias_ = None if (self.tp_rank > 0 or self.skip_bias_add) else self.bias
+            output_parallel = self.quant_method.apply(self, input_parallel, bias_)
+
+            if self.reduce_results and self.tp_size > 1:
+                output = tensor_model_parallel_all_reduce(output_parallel)
+            else:
+                output = output_parallel
+
+        output_bias = self.bias if self.skip_bias_add else None
+
+        if not self.return_bias:
+            return output
+        return output, output_bias
+
+
+# Log registration
+logger.info("HPURowParallelLinear registered as OOT custom op for RowParallelLinear")


### PR DESCRIPTION
Added as a PR to 0.13.0 for easier development. Once it's ready I'll create a commit for main branch. For it to work it's needed to change in vllm def forward() to:
    def forward_native(
        self,
        input_,
    ) -> torch.Tensor | tuple[torch.Tensor, Parameter | None]:
        """Native PyTorch implementation - delegates to CUDA version."""
        return self.forward_cuda(input_)

    def forward_cuda("
   in 
/vllm/vllm/model_executor/layers/linear.py 1938

You can change number of chunks by using: export VLLM_ROW_PARALLEL_CHUNKS=X where 4 is the default.

The goal is to pipeline NIC operations with MME calls in down_proj and o_proj.
Current flow:
<img width="1125" height="245" alt="image" src="https://github.com/user-attachments/assets/e9187a1c-a34f-48a3-bc78-cf4f7e842171" />
After the change:
<img width="1463" height="573" alt="image" src="https://github.com/user-attachments/assets/f0e17ef5-9187-408b-b01d-a5a2024ea8d0" />

