### PR TITLE
Fix for Llama4 Maverick performance drop

### DIFF
--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -367,20 +367,6 @@ def is_mm_optimized(model):
         'Gemma3ForConditionalGeneration' in str(type(model))
 
 
-def maybe_set_chunked_attention_layers(model_runner):
-    if hasattr(model_runner.model.config, 'text_config') and \
-        hasattr(model_runner.model.config.text_config, 'attention_chunk_size') and \
-        model_runner.model.config.text_config.attention_chunk_size:
-        model_runner.model_has_chunked_attention = True
-        try:
-            for layer in model_runner.model.language_model.model.layers:
-                if "ChunkedLocalAttention" in layer.self_attn.attn.get_attn_backend().__name__:
-                    layer.self_attn.attn.impl.is_chunked_attention = True
-        except Exception:
-            # add explicit warning
-            pass
-
-
 def patch_llama4_get_attn_scale(model):
 
     config = getattr(model, "config", None)
@@ -404,6 +390,21 @@ def patch_llama4_get_attn_scale(model):
             return attn_scale.unsqueeze(-1)
 
         attn._get_attn_scale = types.MethodType(_get_attn_scale_for_hpu, attn)
+
+
+def maybe_set_chunked_attention_layers(model_runner):
+    if hasattr(model_runner.model.config, 'text_config') and \
+        hasattr(model_runner.model.config.text_config, 'attention_chunk_size') and \
+        model_runner.model.config.text_config.attention_chunk_size:
+        model_runner.model_has_chunked_attention = True
+        try:
+            for layer in model_runner.model.language_model.model.layers:
+                if "ChunkedLocalAttention" in layer.self_attn.attn.get_attn_backend().__name__:
+                    layer.self_attn.attn.impl.is_chunked_attention = True
+        except Exception:
+            # add explicit warning
+            pass
+
 
 def maybe_set_mamba_kv_cache_groups_ids(model, kv_cache_config: KVCacheConfig):
     if isinstance(model, HpuModelAdapter):


### PR DESCRIPTION
This is a fix for Maverick performance drop - t.compile does not handle functions with methods as inputs, so to avoid recompilations we need to declare a scale function directly.