### PR TITLE
removed lens calculation for qwen2_5

### DIFF
--- a/vllm_gaudi/models/qwen2_5_vl.py
+++ b/vllm_gaudi/models/qwen2_5_vl.py
@@ -83,8 +83,6 @@ class HPU_Attention:
             else:
                 return AttentionLongSequence.forward(q, k, v, mask, q_block_size, cls.softmax_mode)
         else:
-            if cu_seqlens is None:
-                return FusedSDPA.apply(q, k, v, None, 0.0, False, None, cls.softmax_mode)
             lens = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
             if len(lens) == 1:
                 return FusedSDPA.apply(q, k, v, None, 0.0, False, None, cls.softmax_mode)


### PR DESCRIPTION
Remove the lens = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist() computation from the Qwen2.5 path.

This calculation is not required for Qwen2.5 and was causing a performance regression after PR #884. Removing it restores the previous performance without changing model behavior.