### PR TITLE
[FIX_FOR_VLLM_LATEST] Fix for hourly KeyError: <PlatformEnum.OOT: 6>

### DIFF
--- a/tests/full_tests/ci_gsm8k_tests.sh
+++ b/tests/full_tests/ci_gsm8k_tests.sh
@@ -120,7 +120,7 @@ run_qwen3_moe_compressed_tensor_static_scaling_test() {
 # RedHatAI/Meta-Llama-3-8B-Instruct-FP8 Per-tensor F8 static scales
 run_llama3_per_tensor_scaling_test() {
     echo "➡️ Testing RedHatAI/Meta-Llama-3-8B-Instruct-FP8 + per tensor scaling..."
-    #HABANA_VISIBLE_DEVICES=all VLLM_CONTIGUOUS_PA=False VLLM_SKIP_WARMUP=true PT_HPU_LAZY_MODE=1 python -u "${VLLM_GAUDI_PREFIX}/tests/full_tests/generate.py" --model RedHatAI/Meta-Llama-3-8B-Instruct-FP8 --trust-remote-code
+    HABANA_VISIBLE_DEVICES=all VLLM_CONTIGUOUS_PA=False VLLM_SKIP_WARMUP=true PT_HPU_LAZY_MODE=1 python -u "${VLLM_GAUDI_PREFIX}/tests/full_tests/generate.py" --model RedHatAI/Meta-Llama-3-8B-Instruct-FP8 --trust-remote-code
     echo "✅ Test with RedHatAI/Meta-Llama-3-8B-Instruct-FP8 + per tensor scaling successful."
 }
 


### PR DESCRIPTION
This pull request introduces support for Habana Gaudi (HPU) devices in the FP8 scaled matrix multiplication (scaled_mm) kernels by registering new HPU-specific kernel classes. It also enables a previously commented-out test for per-tensor scaling with the RedHatAI/Meta-Llama-3-8B-Instruct-FP8 model.

**Habana Gaudi FP8 kernel support:**
- Added `HPUPerTensorTorchFP8ScaledMMLinearKernel` and `HPUChannelWiseTorchFP8ScaledMMLinearKernel` classes that extend the existing PyTorch FP8 kernel classes and always report as supported, enabling FP8 scaled matrix multiplication on HPU devices.
- Registered these new HPU-specific kernels with the `scaled_mm` kernel registry for the `PlatformEnum.OOT` platform, ensuring that the system uses the correct kernels on HPU hardware.

**Testing improvements:**
- Enabled the per-tensor scaling test for the RedHatAI/Meta-Llama-3-8B-Instruct-FP8 model by uncommenting and activating the test invocation in `ci_gsm8k_tests.sh`.