### PR TITLE
Add smoke test for aice branch

### DIFF
--- a/scripts/QA/smoke_test.sh
+++ b/scripts/QA/smoke_test.sh
@@ -138,7 +138,6 @@ test_model() {
     http_code=$(echo "$response" | grep "HTTP_CODE:" | cut -d':' -f2)
     response=$(echo "$response" | sed '/HTTP_CODE:/d')
 
-
     if command -v jq > /dev/null 2>&1; then
         response=$(echo "$response" | jq -r '.choices[0].message.content' 2>/dev/null)
     fi


### PR DESCRIPTION
This smoke test will do a quick test on below models:
- DeepSeek-R1-Distill-Qwen-7B on one card
- Qwen3-32B on one card
- Qwen3-30B-A3B on two cards

The key idea is to make sure any changes on the PR do not break the basic features.