### PR TITLE
Set fail-fast to true for pre-merge github actions

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -1,9 +1,9 @@
-name: Basic HPU test suite 
+name: Basic HPU test suite
 
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
-    branches: 
+    branches:
       - main
       - releases/**
 
@@ -15,7 +15,7 @@ permissions:
   # This line allows it to read the status of checks like DCO
   checks: read
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
@@ -54,7 +54,7 @@ jobs:
           # Fetch just the latest commit from the base branch for comparison
           git fetch origin ${{ github.event.pull_request.base.ref }} --depth=1
           behind_count=$(git rev-list --count HEAD..origin/${{ github.event.pull_request.base.ref }})
-          
+
           if_pr_is_behind="false"
           if [[ $behind_count -gt 0 ]]; then
             echo "PR is behind by ${behind_count} commit(s)."
@@ -221,20 +221,20 @@ jobs:
           if [ -z "$COMMIT_HASH" ]; then
             TARGET_BRANCH="vllm/last-good-commit-for-vllm-gaudi"
             echo "➡️ Fallback: Attempting to read '$TARGET_FILE' from branch '$TARGET_BRANCH'..."
-            
+
             git fetch origin "$TARGET_BRANCH" --no-tags --depth=1 || true
-            
+
             # Read file from the remote branch; suppress errors if not found
             COMMIT_HASH=$(git show "origin/$TARGET_BRANCH:$TARGET_FILE" 2>/dev/null) || COMMIT_HASH=""
             COMMIT_HASH=$(echo "$COMMIT_HASH" | tr -d '[:space:]')
-            
+
             if [ -n "$COMMIT_HASH" ]; then
               echo "✅ Found stable commit in fallback branch: $COMMIT_HASH"
             else
               echo "::error:: Fallback failed. Could not find a valid commit hash in either location."
             fi
           fi
-          
+
           # 3. Export the final result
           echo "VLLM_STABLE_COMMIT=$COMMIT_HASH" >> "$GITHUB_ENV"
       - name: Determine Target Commit Based on PR Title
@@ -249,7 +249,7 @@ jobs:
           PR_TITLE="$PR_TITLE_ENV"
 
           echo "Pull Request Title: \"${PR_TITLE}\""
-          
+
           # Check if the title contains the special flag
           if [[ "$PR_TITLE" == *"[FIX_FOR_VLLM_LATEST]"* ]]; then
             echo "✅ Flag '[FIX_FOR_VLLM_LATEST]' found in title."
@@ -262,7 +262,7 @@ jobs:
           else
             echo "Using stable commit: ${FINAL_TARGET}"
           fi
-          
+
           # Export the result to an environment variable for subsequent steps
           echo "TARGET_COMMIT=${FINAL_TARGET}" >> "$GITHUB_ENV"
           echo "commit_ref=${FINAL_TARGET}" >> "$GITHUB_OUTPUT"
@@ -358,7 +358,7 @@ jobs:
             -v /mnt/hf_cache:/workspace/hf_cache \
             hpu-plugin-v1-test-env-pre-merge-${{ github.event.pull_request.head.sha }} \
             /bin/bash -c "pytest -vvv --timeout=300 --durations=10 --durations-min=1.0 /workspace/vllm-gaudi/tests/unit_tests"
-          
+
           EXITCODE=$?
           echo "Test script exited with code: $EXITCODE"
   hpu_pd_tests:
@@ -413,7 +413,7 @@ jobs:
             -v /mnt/hf_cache:/workspace/hf_cache \
             hpu-plugin-v1-test-env-pre-merge-${{ github.event.pull_request.head.sha }} \
             /bin/bash "/workspace/vllm-gaudi/tests/full_tests/ci_perf_tests.sh"
-          
+
           EXITCODE=$?
           echo "Test script exited with code: $EXITCODE"
   hpu_dp_tests:
@@ -449,7 +449,6 @@ jobs:
     # --- UPDATED: Run on the specific node ---
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
     strategy:
-      fail-fast: false
       matrix:
         # The list of test functions is dynamically populated from the output of the 'discover_tests' job.
         test_function: ${{ fromJson(needs.discover_tests.outputs.matrix) }}
@@ -476,7 +475,7 @@ jobs:
 
           EXITCODE=$?
           echo "Test script exited with code: $EXITCODE"
-  
+
   pre_merge_hpu_test:
     # --- UPDATED: Add discover_runner dependency ---
     needs: [hpu_unit_tests, e2e, hpu_perf_tests, discover_runner]
@@ -485,7 +484,7 @@ jobs:
     # This job is required to pass for pre-merge CI. By itself it does nothing, and will only pass if all jobs specified in "needs" list pass.
     steps:
       - name: Succeeded if all previous jobs passed
-        run: echo "All previous jobs passed." 
+        run: echo "All previous jobs passed."
   # This is a new job, at the same level as hpu-test-suite
   post-comment:
     name: Post PR Comment


### PR DESCRIPTION
Due to ci being overloaded, I want to suggest setting fail-fast to true, as it would kill remaining jobs after first one fails. This would partially revert theoritically possible behaviour of running all e2e tests at once introduced in #261 
We have ~41 e2e tests, and each pr creation or update starts all of them, and finishes all of them, while single one failing will block the merge and require re-run of all. 
The obvious drawback of this change would be that ci would only give us info about one (first) test failing, but I believe that it would speed up our ci considerably.
One more important thing to note: even though e2e tests can be run all at once in parralel, most of the time they are ran one-by-one due to worker shortage; Because of that, setting fail-fast to true would be preventing new jobs from starting in most cases, instead of killing already running tests;