### PR TITLE
Fix sampler & TP>1 recompilations

### DIFF
--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -4355,7 +4355,7 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
                 # Clear previous sampling state
                 self.input_batch.top_p_reqs = set()
                 self.input_batch.top_k_reqs = set()
-                
+
                 for i, req_id in enumerate(dummy_req_ids):
                     self.requests[req_id].sampling_params = SamplingParams(
                         temperature=temp,


### PR DESCRIPTION
In sampler we've been warming up bs 0 and at the same time due to > 1 and providing 1.0 parameter we've skipped some cases.

In tp>1 vocab is split between workers and we've been warming up using the same range, which corresponds to tp=1. This caused in warmup for rank > 1 users to warmup non-local vocab access path vs local access path we see in runtime where each rank uses correct vocab.