### PR TITLE
Fix device detection when ENABLE_CONSOLE=true

### DIFF
--- a/calibration/calibrate_model.sh
+++ b/calibration/calibrate_model.sh
@@ -143,17 +143,16 @@ fi
 MODEL_NAME=$(extract_last_folder_name "$MODEL_PATH")
 model_name_lower=$(echo "$MODEL_NAME" | tr '[:upper:]' '[:lower:]')
 
-echo "Step 0 - detecting used device type [g2, g3]"
-DEVICE_TYPE=$(python3 step-0-detect-device.py) || (echo "Detecting device process failed" && exit 1)
-DEVICE_TYPE="g$DEVICE_TYPE"
-echo "Detected device type: $DEVICE_TYPE"
-echo "Step 0 done"
-
+echo "Step 0 - detecting used device type ${ALLOWED_DEVICES[*]}"
+python3 step-0-detect-device.py > /dev/null  || DEVICE_TYPE=$?
+DEVICE_TYPE="g${DEVICE_TYPE}"
 # Check if the provided device type is valid
 if [[ ! " ${ALLOWED_DEVICES[*]} " =~ " $DEVICE_TYPE " ]]; then
     echo "Invalid device type: $DEVICE_TYPE. Allowed devices: ${ALLOWED_DEVICES[*]}"
     exit 1
 fi
+echo "Detected device type: $DEVICE_TYPE"
+echo "Step 0 done"
 
 if [[ $TP_SIZE -gt 8 ]]; then
     MULTI_NODE_SETUP=true

--- a/calibration/step-0-detect-device.py
+++ b/calibration/step-0-detect-device.py
@@ -1,6 +1,8 @@
 ###############################################################################
 # Copyright (C) 2024 Habana Labs, Ltd. an Intel Company
 ###############################################################################
+import sys
+
 import habana_frameworks.torch.hpu as hthpu
 
 
@@ -9,4 +11,4 @@ def detect_hpu():
 
 
 if __name__ == "__main__":
-    print(detect_hpu())
+    sys.exit(int(detect_hpu()))

--- a/calibration/vlm-calibration/calibrate_model.sh
+++ b/calibration/vlm-calibration/calibrate_model.sh
@@ -149,18 +149,16 @@ fi
 MODEL_NAME=$(extract_last_folder_name "$MODEL_PATH")
 
 echo ""
-echo "Step 1/3 - detecting used device type [g2, g3]"
-DEVICE_TYPE=$(python3 ../step-0-detect-device.py) || (echo "Detecting device process failed" && exit 1)
+echo "Step 1/3 - detecting used device type ${ALLOWED_DEVICES[*]}"
+python3 step-0-detect-device.py > /dev/null  || DEVICE_TYPE=$?
 DEVICE_TYPE="g$DEVICE_TYPE"
-echo "Detected device type: $DEVICE_TYPE"
-echo "Step 1 done"
-
 # Check if the provided device type is valid
 if [[ ! " ${ALLOWED_DEVICES[*]} " =~ " $DEVICE_TYPE " ]]; then
     echo "Invalid device type: $DEVICE_TYPE. Allowed devices: ${ALLOWED_DEVICES[*]}"
     exit 1
 fi
-
+echo "Detected device type: $DEVICE_TYPE"
+echo "Step 1 done"
 
 create_measure_config $FP8_DIR $MODEL_NAME $DEVICE_TYPE
 create_quant_config $FP8_DIR $MODEL_NAME $DEVICE_TYPE


### PR DESCRIPTION
When `ENABLE_CONSOLE=true` we print a lot of additional logs using `habana_frameworks.torch.hpu.get_device_name()` function in `step-0-detect-device.py` script.

The PR fixing the problem directing all prints from the function to `/dev/null` focussing only on returned code, i.e. Gaudi version in our case.