### PR TITLE
Fixing _compile_region for nested attributes (#956)

### DIFF
--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -3,6 +3,7 @@ import itertools
 import pytest
 
 from vllm_gaudi.extension.utils import align_and_pad
+from vllm_gaudi.utils import getattr_nested, setattr_nested
 
 
 @pytest.fixture
@@ -74,3 +75,112 @@ class TestAlignAndPad:
         assert out_materialized[-1] == expected_last
         for row in out_materialized:
             assert len(row) == target_len
+
+
+# ---------------------------------------------------------------------------
+# Helpers for nested-attr tests
+# ---------------------------------------------------------------------------
+
+
+class _Inner:
+    """Leaf object used in nested attribute tests."""
+
+    def __init__(self, value=None):
+        self.value = value
+
+
+class _Middle:
+    """Intermediate object used in nested attribute tests."""
+
+    def __init__(self):
+        self.inner = _Inner(42)
+
+
+class _Root:
+    """Top-level object used in nested attribute tests."""
+
+    def __init__(self):
+        self.middle = _Middle()
+        self.flat = "flat_value"
+
+
+# ---------------------------------------------------------------------------
+# getattr_nested
+# ---------------------------------------------------------------------------
+
+
+class TestGetattrNested:
+
+    def test_single_level(self):
+        root = _Root()
+        assert getattr_nested(root, "flat") == "flat_value"
+
+    def test_two_levels(self):
+        root = _Root()
+        assert getattr_nested(root, "middle.inner") is root.middle.inner
+
+    def test_three_levels(self):
+        root = _Root()
+        assert getattr_nested(root, "middle.inner.value") == 42
+
+    def test_missing_attr_raises(self):
+        root = _Root()
+        with pytest.raises(AttributeError):
+            getattr_nested(root, "no_such_attr")
+
+    def test_missing_nested_attr_raises(self):
+        root = _Root()
+        with pytest.raises(AttributeError):
+            getattr_nested(root, "middle.no_such_attr")
+
+    def test_missing_attr_with_default(self):
+        root = _Root()
+        assert getattr_nested(root, "no_such_attr", None) is None
+
+    def test_missing_nested_attr_with_default(self):
+        root = _Root()
+        assert getattr_nested(root, "middle.inner.missing", "fallback") == "fallback"
+
+    def test_default_can_be_any_value(self):
+        root = _Root()
+        sentinel = object()
+        assert getattr_nested(root, "x.y.z", sentinel) is sentinel
+
+    def test_too_many_defaults_raises_type_error(self):
+        root = _Root()
+        with pytest.raises(TypeError):
+            getattr_nested(root, "flat", 1, 2)
+
+
+# ---------------------------------------------------------------------------
+# setattr_nested
+# ---------------------------------------------------------------------------
+
+
+class TestSetattrNested:
+
+    def test_single_level(self):
+        root = _Root()
+        setattr_nested(root, "flat", "new_value")
+        assert root.flat == "new_value"
+
+    def test_two_levels(self):
+        root = _Root()
+        new_inner = _Inner(99)
+        setattr_nested(root, "middle.inner", new_inner)
+        assert root.middle.inner is new_inner
+
+    def test_three_levels(self):
+        root = _Root()
+        setattr_nested(root, "middle.inner.value", 100)
+        assert root.middle.inner.value == 100
+
+    def test_creates_new_leaf_attr(self):
+        root = _Root()
+        setattr_nested(root, "middle.inner.new_field", "hello")
+        assert root.middle.inner.new_field == "hello"  # type: ignore[attr-defined]
+
+    def test_missing_intermediate_raises(self):
+        root = _Root()
+        with pytest.raises(AttributeError):
+            setattr_nested(root, "no_such.attr.value", 1)

--- a/vllm_gaudi/utils.py
+++ b/vllm_gaudi/utils.py
@@ -76,6 +76,59 @@ def async_h2d_update(source: torch.Tensor, dest: torch.Tensor, indices: list[int
     dest[indices] = source[indices].to(device, non_blocking=True)
 
 
+def getattr_nested(obj: Any, name: str, *default: Any) -> Any:
+    """Like built-in getattr but supports dot-separated nested attributes.
+
+    Examples:
+        getattr_nested(obj, 'a.b.c')  is equivalent to  obj.a.b.c
+        getattr_nested(obj, 'a.b', None)  returns None when any
+            intermediate or final attribute is missing.
+
+    Args:
+        obj: Root object.
+        name: Dot-separated attribute path.
+        *default: Optional default returned when the attribute is missing.
+            At most one default value may be provided (same contract as
+            built-in ``getattr``).
+
+    Raises:
+        TypeError: If more than one default value is provided.
+        AttributeError: If the attribute is missing and no default was given.
+    """
+    if len(default) > 1:
+        raise TypeError(f"getattr_nested expected at most 3 arguments, got {2 + len(default)}")
+    parts = name.split(".")
+    try:
+        for part in parts:
+            obj = getattr(obj, part)
+        return obj
+    except AttributeError:
+        if default:
+            return default[0]
+        raise
+
+
+def setattr_nested(obj: Any, name: str, value: Any) -> None:
+    """Like built-in setattr but supports dot-separated nested attributes.
+
+    Examples:
+        setattr_nested(obj, 'a.b.c', val)  is equivalent to  obj.a.b.c = val
+
+    Args:
+        obj: Root object.
+        name: Dot-separated attribute path.  All parts except the last
+            must already exist as attributes.
+        value: Value to assign to the final attribute.
+
+    Raises:
+        AttributeError: If any intermediate attribute does not exist.
+    """
+    parts = name.split(".")
+    for part in parts[:-1]:
+        obj = getattr(obj, part)
+    setattr(obj, parts[-1], value)
+
+
 def make_ndarray_with_pad_align(
     x: list[list[T]],
     pad: T,

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -64,7 +64,7 @@ from vllm.utils.platform_utils import is_pin_memory_available
 from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE, get_dtype_size
 from vllm.utils.import_utils import LazyLoader
 from vllm.utils.jsontree import json_map_leaves
-from vllm_gaudi.utils import (HPUCompileConfig, is_fake_hpu, async_h2d_copy)
+from vllm_gaudi.utils import (HPUCompileConfig, is_fake_hpu, async_h2d_copy, getattr_nested, setattr_nested)
 from vllm_gaudi.v1.attention.backends.hpu_attn import HPUAttentionMetadataV1
 from vllm.v1.attention.backends.utils import create_fast_prefill_custom_backend
 from vllm.v1.kv_cache_interface import (
@@ -4136,7 +4136,7 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
         """
         compiled_methods = ['metadata_processor.process_metadata', '_rotary_prepare_cos_sin']
         for method_name in compiled_methods:
-            method = getattr(self.model, method_name, None)
+            method = getattr_nested(self.model, method_name, None)
             if method is not None:
                 self._compile_region(self.model, method_name, method)
 
@@ -4162,7 +4162,7 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
 
     def _compile_region(self, model, name, module):
         module = self._compile(module)
-        setattr(model, name, module)
+        setattr_nested(model, name, module)
 
     def _compile(self, module):
         return torch.compile(module, **self.compile_config.get_compile_args())


### PR DESCRIPTION
Introduced mainly because we did not have `metadata_processor.process_metadata` compiled - due to the fact we passed this attribute name as a nested string with dot notation, which is not supported neither by native `setattr` nor `getattr` methods.

With this change applied I've noticed a significant reduction in number of graphs produced by a `torch.compile` execution.

---------

cherry-pick of https://github.com/vllm-project/vllm-gaudi/pull/956