### PR TITLE
Fix type mismatch in DeepSeek with fp8_fused_sdpa for mla prefill

### DIFF
--- a/vllm_gaudi/extension/utils.py
+++ b/vllm_gaudi/extension/utils.py
@@ -190,14 +190,14 @@ class ModuleFP8FusedSDPA(torch.nn.Module):
         self.fp8_fused_sdpa = fusedSDPA
 
         # set the descale_amax and scale_amax 1.0 temporarily
-        self.descale_amax = torch.tensor(1.0)
-        self.scale_amax = torch.tensor(1.0)
-        self.scale_q = torch.tensor(1.0)
-        self.scale_k = torch.tensor(1.0)
-        self.scale_v = torch.tensor(1.0)
-        self.d_scale_q = torch.tensor(1.0)
-        self.d_scale_k = torch.tensor(1.0)
-        self.d_scale_v = torch.tensor(1.0)
+        self.descale_amax = torch.tensor(1.0, dtype=torch.float32)
+        self.scale_amax = torch.tensor(1.0, dtype=torch.float32)
+        self.scale_q = torch.tensor(1.0, dtype=torch.float32)
+        self.scale_k = torch.tensor(1.0, dtype=torch.float32)
+        self.scale_v = torch.tensor(1.0, dtype=torch.float32)
+        self.d_scale_q = torch.tensor(1.0, dtype=torch.float32)
+        self.d_scale_k = torch.tensor(1.0, dtype=torch.float32)
+        self.d_scale_v = torch.tensor(1.0, dtype=torch.float32)
 
     def quant_input(self, x, scale):
         return torch.ops.hpu.cast_to_fp8_v2(x, scale, False, False, torch.float8_e4m3fn)[0]


### PR DESCRIPTION
Initialize FP8 scales as fp32 to prevent type mismatch errors when using fp8_fused_sdpa in mla_prefill and FP8 KV cache https://github.com/vllm-project/vllm-gaudi/pull/909 Scales were defaulting to bf16. @lkk12014402 Please review.
