### PR TITLE
Added torchaudio installation to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,8 @@
 import logging
 import os
+import re
+import subprocess
+import sys
 
 from setuptools import setup, find_packages
 from setuptools_scm import get_version
@@ -40,6 +43,11 @@ def get_requirements() -> list[str]:
         requirements = _read_requirements("requirements.txt")
     except ValueError:
         print("Failed to read requirements.txt in vllm_gaudi.")
+
+    # Exclude torchaudio from install_requires — it needs --no-deps to
+    # avoid pulling CUDA torch, which install_requires cannot express.
+    requirements = [r for r in requirements if not r.strip().startswith("torchaudio")]
+
     return requirements
 
 
@@ -71,3 +79,28 @@ setup(
         ],
     },
 )
+
+# Install torchaudio with --no-deps to avoid pulling CUDA torch.
+# Skipped during metadata generation (dist_info / egg_info).
+if "dist_info" not in sys.argv and "egg_info" not in sys.argv:
+    try:
+        import torch
+    except ImportError:
+        raise RuntimeError(
+            "torch is not importable - this is needed for torchaudio installation.\n\n"
+            "********************************************************************************\n"
+            "Make sure torch is installed before installing vllm-gaudi\n"
+            "and add --no-build-isolation to pip install\n"
+            "********************************************************************************\n") from None
+    # Extract stable x.y.z from versions like 2.10.0a0+git...
+    ver = re.match(r"(\d+\.\d+\.\d+)", torch.__version__).group(1)
+    subprocess.check_call([
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "--no-deps",
+        "--extra-index-url",
+        "https://download.pytorch.org/whl/cpu",
+        f"torchaudio=={ver}",
+    ])

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ import re
 import subprocess
 import sys
 
+from packaging.requirements import InvalidRequirement, Requirement
 from setuptools import setup, find_packages
 from setuptools_scm import get_version
 
@@ -26,6 +27,13 @@ def get_path(*filepath) -> str:
 def get_requirements() -> list[str]:
     """Get Python package dependencies from requirements.txt."""
 
+    def _req_name(line: str) -> str:
+        """Extract normalized project name from a PEP 508 requirement line."""
+        try:
+            return Requirement(line).name.lower()
+        except InvalidRequirement:
+            return ""
+
     def _read_requirements(filename: str) -> list[str]:
         with open(get_path(filename)) as f:
             requirements = f.read().strip().split("\n")
@@ -35,6 +43,9 @@ def get_requirements() -> list[str]:
                 resolved_requirements += _read_requirements(line.split()[1])
             elif line.startswith("--"):
                 continue
+            elif _req_name(line) == "torchaudio":
+                raise RuntimeError("To ensure proper installation, torchaudio is handled in setup.py\n"
+                                   "Please remove it from requirements.txt")
             else:
                 resolved_requirements.append(line)
         return resolved_requirements
@@ -43,10 +54,6 @@ def get_requirements() -> list[str]:
         requirements = _read_requirements("requirements.txt")
     except ValueError:
         print("Failed to read requirements.txt in vllm_gaudi.")
-
-    # Exclude torchaudio from install_requires — it needs --no-deps to
-    # avoid pulling CUDA torch, which install_requires cannot express.
-    requirements = [r for r in requirements if not r.strip().startswith("torchaudio")]
 
     return requirements
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import logging
 import os
+
 import re
 import subprocess
 import sys
@@ -88,8 +89,9 @@ setup(
 )
 
 # Install torchaudio with --no-deps to avoid pulling CUDA torch.
-# Skipped during metadata generation (dist_info / egg_info).
-if "dist_info" not in sys.argv and "egg_info" not in sys.argv:
+# Only run during actual install/develop – skip metadata, wheel, and sdist builds.
+_PACKAGING_COMMANDS = {"dist_info", "egg_info", "bdist_wheel", "sdist", "build"}
+if not _PACKAGING_COMMANDS.intersection(sys.argv):
     try:
         import torch
     except ImportError:


### PR DESCRIPTION
This pull request introduces changes to the `setup.py` installation logic, specifically addressing the handling of the `torchaudio` dependency to avoid inadvertently installing CUDA-enabled PyTorch when only CPU support is desired. The changes ensure a safer and more predictable installation process for users.

Dependency management improvements:

* Excluded `torchaudio` from `install_requires` in `setup.py`, as its installation requires special handling to avoid pulling CUDA torch dependencies.
* Added logic to install `torchaudio` separately using `pip install --no-deps` with the correct version matching the installed `torch`, and only if not running in metadata generation mode (`dist_info` or `egg_info`).

We need torchaudio because it's imported from upstream vllm as a result of this PR:
https://github.com/vllm-project/vllm/pull/33247