### PR TITLE
Added installation script for proper handling of torchaudio

### DIFF
--- a/.cd/Dockerfile.rhel.tenc.pytorch.vllm
+++ b/.cd/Dockerfile.rhel.tenc.pytorch.vllm
@@ -67,7 +67,7 @@ RUN \
     # Install vllm-gaudi plugin
     cd $VLLM_PATH2 && \
     git checkout ${VLLM_GAUDI_COMMIT} && \
-    VLLM_TARGET_DEVICE=hpu pip install -v . --no-build-isolation
+    VLLM_TARGET_DEVICE=hpu bash -c "./install.sh -v --no-build-isolation"
 # --- END: COMBINED RUN COMMAND ---
 
 # to be verified later PWolsza

--- a/.cd/Dockerfile.rhel.ubi.vllm
+++ b/.cd/Dockerfile.rhel.ubi.vllm
@@ -209,7 +209,7 @@ RUN set -e && \
     VLLM_TARGET_DEVICE=empty pip install --no-cache-dir --no-build-isolation . && \
     cd $VLLM_PATH2 && \
     git checkout ${VLLM_GAUDI_COMMIT} && \
-    VLLM_TARGET_DEVICE=hpu pip install --no-cache-dir -v . --no-build-isolation && \
+    VLLM_TARGET_DEVICE=hpu bash -c "./install.sh --no-cache-dir -v --no-build-isolation" && \
     pip check
 
 # The scripts below are used for benchmarks testing and autocalc:

--- a/.cd/Dockerfile.ubuntu.pytorch.vllm
+++ b/.cd/Dockerfile.ubuntu.pytorch.vllm
@@ -58,7 +58,7 @@ RUN \
     # Install vllm-gaudi plugin
     cd $VLLM_PATH2 && \
     git checkout ${VLLM_GAUDI_COMMIT} && \
-    VLLM_TARGET_DEVICE=hpu pip install -v . --no-build-isolation
+    VLLM_TARGET_DEVICE=hpu bash -c "./install.sh -v --no-build-isolation"
 # --- END: COMBINED RUN COMMAND ---
 
 # Install additional Python packages

--- a/.cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest
+++ b/.cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest
@@ -59,7 +59,7 @@ RUN \
     # Install vllm-gaudi plugin
     cd $VLLM_PATH2 && \
     git checkout ${VLLM_GAUDI_COMMIT} && \
-    VLLM_TARGET_DEVICE=hpu pip install -v . --no-build-isolation && \
+    VLLM_TARGET_DEVICE=hpu bash -c "./install.sh -v --no-build-isolation" && \
     python install_nixl.py
 # --- END: COMBINED RUN COMMAND ---
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The vLLM Hardware Plugin for Intel® Gaudi® integrates [Intel® Gaudi® AI acce
 
     ```bash
     cd vllm-gaudi
-    pip install -e .
+    ./install.sh -e
     cd ..
     ```
 

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -129,7 +129,7 @@ There are two ways to install vLLM Hardware Plugin for Intel Gaudi from source: 
 5. Install vLLM Hardware Plugin for Intel Gaudi from source.
   
         cd vllm-gaudi
-        pip install -e .
+        ./install.sh -e
         cd ..
   
 To achieve the best performance on HPU, please follow the methods outlined in the
@@ -180,7 +180,7 @@ To install vLLM Hardware Plugin for Intel Gaudi and NIXL using a Dockerfile:
 3. Install vLLM Hardware Plugin for Intel Gaudi from source.
 
         cd vllm-gaudi
-        pip install -e .
+        ./install.sh -e
   
 4. Build NIXL.
   

--- a/install.sh
+++ b/install.sh
@@ -2,8 +2,11 @@
 # Install vllm-gaudi and its dependencies for HPU environments.
 #
 # Usage:
-#   ./install.sh        # regular install
-#   ./install.sh -e     # editable (development) install
+#   ./install.sh                       # regular install
+#   ./install.sh -e                    # editable (development) install
+#   ./install.sh -e -v                 # editable + verbose
+#   ./install.sh --no-build-isolation  # skip pip build isolation
+#   ./install.sh --no-cache-dir        # disable pip cache
 #
 # Prerequisites:
 #   - torch must already be installed (HPU build)
@@ -12,17 +15,23 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EDITABLE=""
+VERBOSE=""
+NO_BUILD_ISOLATION=""
+NO_CACHE_DIR=""
 
 for arg in "$@"; do
     case "$arg" in
         -e) EDITABLE="-e" ;;
+        -v) VERBOSE="-v" ;;
+        --no-build-isolation) NO_BUILD_ISOLATION="--no-build-isolation" ;;
+        --no-cache-dir) NO_CACHE_DIR="--no-cache-dir" ;;
         *) echo "Unknown option: $arg"; exit 1 ;;
     esac
 done
 
 # --- Install vllm-gaudi ---
 echo "*** Installing vllm-gaudi ***"
-python3 -m pip install $EDITABLE "$SCRIPT_DIR"
+python3 -m pip install $EDITABLE $VERBOSE $NO_BUILD_ISOLATION $NO_CACHE_DIR "$SCRIPT_DIR"
 
 # --- Install torchaudio with --no-deps to avoid pulling CUDA torch ---
 # Extract stable x.y.z from torch version (e.g. 2.10.0a0+git... -> 2.10.0)
@@ -36,7 +45,7 @@ except ImportError:
 print(re.match(r'(\d+\.\d+\.\d+)', torch.__version__).group(1))
 ")
 echo "*** Installing torchaudio==${TORCH_VER} (--no-deps) ***"
-python3 -m pip install --no-deps \
+python3 -m pip install --no-deps $NO_CACHE_DIR \
     --extra-index-url https://download.pytorch.org/whl/cpu \
     "torchaudio==${TORCH_VER}"
 

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 # Install vllm-gaudi and its dependencies for HPU environments.
 #
 # Usage:
@@ -41,7 +41,11 @@ try:
 except ImportError:
     print('Error: torch is not installed', file=sys.stderr)
     sys.exit(1)
-print(re.match(r'(\d+\.\d+\.\d+)', torch.__version__).group(1))
+match = re.match(r'(\d+\.\d+\.\d+)', torch.__version__)
+if not match:
+    print(f\"Error: unexpected torch.__version__ format: {torch.__version__!r}\", file=sys.stderr)
+    sys.exit(1)
+print(match.group(1))
 ")
 echo "*** Installing torchaudio==${TORCH_VER} (--no-deps) ***"
 python3 -m pip install --no-deps $NO_CACHE_DIR \

--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,6 @@
 #
 # Prerequisites:
 #   - torch must already be installed (HPU build)
-#   - vllm must already be installed
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Install vllm-gaudi and its dependencies for HPU environments.
+#
+# Usage:
+#   ./install.sh        # regular install
+#   ./install.sh -e     # editable (development) install
+#
+# Prerequisites:
+#   - torch must already be installed (HPU build)
+#   - vllm must already be installed
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EDITABLE=""
+
+for arg in "$@"; do
+    case "$arg" in
+        -e) EDITABLE="-e" ;;
+        *) echo "Unknown option: $arg"; exit 1 ;;
+    esac
+done
+
+# --- Install vllm-gaudi ---
+echo "*** Installing vllm-gaudi ***"
+python3 -m pip install $EDITABLE "$SCRIPT_DIR"
+
+# --- Install torchaudio with --no-deps to avoid pulling CUDA torch ---
+# Extract stable x.y.z from torch version (e.g. 2.10.0a0+git... -> 2.10.0)
+TORCH_VER=$(python3 -c "
+import re, sys
+try:
+    import torch
+except ImportError:
+    print('Error: torch is not installed', file=sys.stderr)
+    sys.exit(1)
+print(re.match(r'(\d+\.\d+\.\d+)', torch.__version__).group(1))
+")
+echo "*** Installing torchaudio==${TORCH_VER} (--no-deps) ***"
+python3 -m pip install --no-deps \
+    --extra-index-url https://download.pytorch.org/whl/cpu \
+    "torchaudio==${TORCH_VER}"
+
+echo "*** Done ***"


### PR DESCRIPTION
This pull request adds a new installation script, `install.sh`, to streamline the process of installing `vllm-gaudi` and its dependencies in HPU (Habana Processing Unit) environments.

**Installation automation:**

* Added `install.sh` script to automate the installation of `vllm-gaudi` and compatible `torchaudio` for HPU environments, supporting both regular and editable installs.
* Automatically detects the installed `torch` version to ensure the correct `torchaudio` version is installed, improving reliability and compatibility.