### PR TITLE
Fixing redundant transpose in HPUMambaMixer2 (#999)

### DIFF
--- a/vllm_gaudi/ops/hpu_mamba_utils.py
+++ b/vllm_gaudi/ops/hpu_mamba_utils.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.distributed import divide
+from vllm.model_executor.layers.mamba.mamba_utils import MambaStateShapeCalculator
+
+
+# Adapted from vllm.model_executor.layers.mamba.mamba_utils.MambaStateShapeCalculator.mamba2_state_shape
+# as we've modified the conv_state_shape
+def hpu_mamba2_state_shape(
+    tp_world_size: int,
+    intermediate_size: int,
+    n_groups: int,
+    num_heads: int,
+    head_dim: int,
+    state_size: int,
+    conv_kernel: int,
+) -> tuple[tuple[int, int], tuple[int, int, int]]:
+    # if n_groups is not divisible by world_size, need to extend the shards
+    # to ensure all groups needed by a head is sharded along with it
+    n_groups = n_groups + MambaStateShapeCalculator.extra_groups_for_head_shards(n_groups, tp_world_size)
+    # heads and n_groups are TP-ed
+    conv_dim = intermediate_size + 2 * n_groups * state_size
+
+    # contiguous along 'dim' axis
+    conv_state_shape = (divide(conv_dim, tp_world_size), conv_kernel - 1)
+
+    # These are not TP-ed as they depend on A, dt_bias, D
+    # - they are typically small
+    #   e.g., (h_heads, head_dim, state_size) = (128, 64, 128)
+    temporal_state_shape = (divide(num_heads, tp_world_size), head_dim, state_size)
+    return conv_state_shape, temporal_state_shape


### PR DESCRIPTION
We are noticing some MME transposes within the profiling, which are fixed by this change

---------

cherry-pick of https://github.com/vllm-project/vllm-gaudi/pull/999