### PR TITLE
[warmup][multimodal] Fix import error for MultiModalBudget

### DIFF
--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -5283,7 +5283,7 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
     def warmup_multimodal_graphs(self, buckets):
 
         phase = 'Graph/Multimodal'
-        from vllm.multimodal.budget import MultiModalBudget
+        from vllm.multimodal.encoder_budget import MultiModalBudget
         self.mm_budget = MultiModalBudget(
             self.vllm_config,
             self.mm_registry,


### PR DESCRIPTION
This fix is needed to avoid runtime errors when doing warmup on multimodal models. It's also present in https://github.com/vllm-project/vllm-gaudi/pull/1060 but this may not merge into main or be cherry-picked into aice branch for a while.