### PR TITLE
Fix import error when running MM models

### DIFF
--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -5283,7 +5283,7 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
     def warmup_multimodal_graphs(self, buckets):
 
         phase = 'Graph/Multimodal'
-        from vllm.multimodal.budget import MultiModalBudget
+        from vllm.multimodal.encoder_budget import MultiModalBudget
         self.mm_budget = MultiModalBudget(
             self.vllm_config,
             self.mm_registry,


### PR DESCRIPTION
To fix below import error when running Qwen3-VL-8B-Instruct model on aice branch.
`
(EngineCore_DP0 pid=357189) ERROR 03-02 06:41:51 [core.py:1006]   File "/root/code/plugin/vllm-gaudi/vllm_gaudi/v1/worker/hpu_model_runner.py", line 5286, in warmup_multimodal_graphs
(EngineCore_DP0 pid=357189) ERROR 03-02 06:41:51 [core.py:1006]     from vllm.multimodal.budget import MultiModalBudget
(EngineCore_DP0 pid=357189) ERROR 03-02 06:41:51 [core.py:1006] ModuleNotFoundError: No module named 'vllm.multimodal.budget'
`