### PR TITLE
Fix typo from PR#984

### DIFF
--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -2386,7 +2386,7 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
             padding_mask_flat = None
             query_start_loc_p = None
             blocks_caching_range = None
-            mamba_chunks_to_block_mappings = None
+            mamba_chunks_to_block_mapping = None
             seqlens_offsets_for_blocks = None
 
         query_lens = async_h2d_copy(query_lens, dtype=torch.int32)


### PR DESCRIPTION
Without this fix, running models other than mamba will crash on line 2415 with following message: 
 ```
File "/root/vllm-gaudi/vllm_gaudi/v1/worker/hpu_model_runner.py", line 2452, in _prepare_prefill_inputs
    all_batches = [self._form_prefill_batch(bc) for bc in all_batch_contents]
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/vllm-gaudi/vllm_gaudi/v1/worker/hpu_model_runner.py", line 2415, in _form_prefill_batch
    mamba_chunks_to_block_mapping=mamba_chunks_to_block_mapping,
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'mamba_chunks_to_block_mapping' where it is not associated with a value
```