### PR TITLE
fix param mismatch for compute_nixl_compatibility_hash()

### DIFF
--- a/vllm_gaudi/distributed/kv_transfer/kv_connector/v1/hetero_hpu_nixl_connector.py
+++ b/vllm_gaudi/distributed/kv_transfer/kv_connector/v1/hetero_hpu_nixl_connector.py
@@ -591,7 +591,8 @@ def NixlConnectorWorker_init_(self, vllm_config: VllmConfig, engine_id: str):
         total_num_kv_heads=self.model_config.get_total_num_kv_heads(),
         attn_backend=backend,
     )
-    self.compat_hash = compute_nixl_compatibility_hash(self.vllm_config, self.backend_name, self.kv_topo.cross_layers_blocks)
+    self.compat_hash = compute_nixl_compatibility_hash(self.vllm_config, self.backend_name,
+                                                       self.kv_topo.cross_layers_blocks)
     self._physical_blocks_per_logical_kv_block = 1
 
 


### PR DESCRIPTION
with the new baseline for v0.16.0, compute_nixl_compatibility_hash() is missing a 3rd parameter causing a mismatch error.