### PR TITLE
Fixed empty output_token_ids for penalties

### DIFF
--- a/tests/unit_tests/worker/test_hpu_model_runner.py
+++ b/tests/unit_tests/worker/test_hpu_model_runner.py
@@ -646,3 +646,98 @@ def test_model_torch_regional_compilation(default_vllm_config: None, dist_init, 
     assert_compilation(model, "lm_head", VocabParallelEmbedding)
     assert_compilation(model, "model.decoder.final_layer_norm", LayerNorm)
     assert_compilation(model, "model.decoder.embed_tokens", VocabParallelEmbedding)
+
+
+def test_update_async_output_token_ids_populates_tokens(model_runner, dist_init):
+    """Verify _update_async_output_token_ids transfers previous-step sampled
+    tokens into each request's output_token_ids (GAUDISW-245824)."""
+    req_ids = ("req_0", "req_1")
+    scheduler_output = _schedule_new_request(*req_ids)
+    model_runner._update_states(scheduler_output)
+
+    # Enable async scheduling on the runner
+    model_runner.use_async_scheduling = True
+
+    # Simulate previous step: sampled token 42 for req_0 (idx 0),
+    # token 99 for req_1 (idx 1)
+    model_runner.input_batch.prev_sampled_token_ids = torch.tensor([42, 99], dtype=torch.int32, device="cpu")
+    model_runner.input_batch.prev_req_id_to_index = {
+        "req_0": 0,
+        "req_1": 1,
+    }
+
+    # Precondition: output_token_ids should be empty
+    assert model_runner.requests["req_0"].output_token_ids == []
+    assert model_runner.requests["req_1"].output_token_ids == []
+
+    model_runner._update_async_output_token_ids()
+
+    assert model_runner.requests["req_0"].output_token_ids == [42]
+    assert model_runner.requests["req_1"].output_token_ids == [99]
+
+
+def test_update_async_output_token_ids_accumulates(model_runner, dist_init):
+    """Verify repeated calls accumulate tokens across steps."""
+    req_ids = ("req_0", )
+    scheduler_output = _schedule_new_request(*req_ids)
+    model_runner._update_states(scheduler_output)
+    model_runner.use_async_scheduling = True
+
+    # Step 1
+    model_runner.input_batch.prev_sampled_token_ids = torch.tensor([10], dtype=torch.int32, device="cpu")
+    model_runner.input_batch.prev_req_id_to_index = {"req_0": 0}
+    model_runner._update_async_output_token_ids()
+
+    # Step 2
+    model_runner.input_batch.prev_sampled_token_ids = torch.tensor([20], dtype=torch.int32, device="cpu")
+    model_runner._update_async_output_token_ids()
+
+    assert model_runner.requests["req_0"].output_token_ids == [10, 20]
+
+
+def test_update_async_output_token_ids_noop_sync_mode(model_runner, dist_init):
+    """When async scheduling is off, calling the method is a no-op."""
+    req_ids = ("req_0", )
+    scheduler_output = _schedule_new_request(*req_ids)
+    model_runner._update_states(scheduler_output)
+    model_runner.use_async_scheduling = False
+
+    model_runner.input_batch.prev_sampled_token_ids = torch.tensor([42], dtype=torch.int32, device="cpu")
+    model_runner.input_batch.prev_req_id_to_index = {"req_0": 0}
+
+    model_runner._update_async_output_token_ids()
+
+    assert model_runner.requests["req_0"].output_token_ids == []
+
+
+def test_update_async_output_token_ids_noop_no_prev(model_runner, dist_init):
+    """When there are no previous tokens, calling the method is a no-op."""
+    req_ids = ("req_0", )
+    scheduler_output = _schedule_new_request(*req_ids)
+    model_runner._update_states(scheduler_output)
+    model_runner.use_async_scheduling = True
+
+    # prev_sampled_token_ids defaults to None
+    model_runner._update_async_output_token_ids()
+
+    assert model_runner.requests["req_0"].output_token_ids == []
+
+
+def test_update_async_output_token_ids_skips_finished_req(model_runner, dist_init):
+    """If a request in prev_req_id_to_index was already finished, skip it."""
+    req_ids = ("req_0", )
+    scheduler_output = _schedule_new_request(*req_ids)
+    model_runner._update_states(scheduler_output)
+    model_runner.use_async_scheduling = True
+
+    model_runner.input_batch.prev_sampled_token_ids = torch.tensor([42, 99], dtype=torch.int32, device="cpu")
+    # req_1 was in previous batch but has since been removed
+    model_runner.input_batch.prev_req_id_to_index = {
+        "req_0": 0,
+        "req_1": 1,
+    }
+
+    model_runner._update_async_output_token_ids()
+
+    assert model_runner.requests["req_0"].output_token_ids == [42]
+    assert "req_1" not in model_runner.requests

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -1754,6 +1754,30 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
 
         return PromptDecodeInfo(prompt_req_ids, decode_req_ids, prompt_scheduled_tokens)
 
+    def _update_async_output_token_ids(self):
+        """Update output_token_ids with tokens from the previous async step.
+
+        In async scheduling mode, postprocessed_sampled_token_ids is not
+        populated (tokens stay on HPU), so output_token_ids never gets
+        updated. This method syncs the previous step's sampled tokens
+        from HPU to CPU and appends them to each request's
+        output_token_ids, enabling correct penalty computation during
+        sampling.
+        """
+        if not self.use_async_scheduling:
+            return
+        prev_sampled = self.input_batch.prev_sampled_token_ids
+        if prev_sampled is None:
+            return
+        prev_req_id_to_index = self.input_batch.prev_req_id_to_index
+        if prev_req_id_to_index is None:
+            return
+        prev_tokens_cpu = prev_sampled.cpu().tolist()
+        for req_id, prev_idx in prev_req_id_to_index.items():
+            req_state = self.requests.get(req_id)
+            if req_state is not None and prev_idx < len(prev_tokens_cpu):
+                req_state.output_token_ids.append(prev_tokens_cpu[prev_idx])
+
     def _generate_req_id_output_token_ids_lst(self,
                                               request_ids: Optional[list[str]] = None,
                                               pad_to: Optional[int] = None,
@@ -3810,6 +3834,10 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
         warmup_mode = self.warmup_mode
         self.scheduler_output = None
         self.warmup_mode = False
+
+        # Update output_token_ids with tokens from previous async step
+        # so that sampling penalties are correctly applied.
+        self._update_async_output_token_ids()
 
         if self.unified_attn:
             return self.unified_execute_model(scheduler_output, warmup_mode=warmup_mode)


### PR DESCRIPTION
This pull request introduces and tests a new mechanism for updating `output_token_ids` during asynchronous scheduling in the HPU model runner. The main purpose is to ensure that sampled tokens from previous steps are properly transferred to each request, enabling correct penalty computation during sampling. Several unit tests are added to verify the new behavior under various scenarios.

Async output token tracking improvements:

* Added the `_update_async_output_token_ids` method to `hpu_model_runner.py`, which syncs sampled tokens from previous async steps to each request's `output_token_ids` for correct penalty computation.
* Integrated `_update_async_output_token_ids` into the `sample_tokens` method to ensure output tokens are updated before sampling penalties are applied.

Testing enhancements:

* Added multiple unit tests in `test_hpu_model_runner.py` to verify the new async output token update logic, including tests for token transfer, accumulation across steps, no-op behavior in sync mode or when no previous tokens exist, and skipping finished requests.