### PR TITLE
Enable slicing for the FusedSDPA

### DIFF
--- a/docs/configuration/env_variables.md
+++ b/docs/configuration/env_variables.md
@@ -123,12 +123,12 @@ and warm-up. Recommended settings for this case are:
 
 FusedSDPA can be split into smaller chunks to improve performance while using the padding-aware bucketing strategy which guarantees the max absolute padding in the sequence and context dimensions.
 
-| Parameter name                           | Description                                                                                  | Default value                              |
-| ---------------------------------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| Parameter name                           | Description                                                                                  | Default value                               |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------- |
 | `VLLM_HPU_FSDPA_SLICE_ENABLED`           | Enable the slicing.                                                                          | `True` for padding-aware bucketing strategy |
-| `VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD`      | KV length threshold above which slicing is applied.                                          | `min(max_num_batched_tokens, 8192)`        |
-| `VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE`        | Chunk size for `q_len` and `kv_len` in each chunk. Rounded up to the next multiple of 1024.  | `VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD // 2`   |
-| `VLLM_HPU_FSDPA_SLICE_WITH_GRAPH_BREAKS` | Places each chunk in a separate graph to reduce compilation time.                            | `true` for lazy mode and `false` otherwise |
+| `VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD`      | KV length threshold above which slicing is applied.                                          | `min(max_num_batched_tokens, 8192)`         |
+| `VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE`        | Chunk size for `q_len` and `kv_len` in each chunk. Rounded up to the next multiple of 1024.  | `VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD // 2`    |
+| `VLLM_HPU_FSDPA_SLICE_WITH_GRAPH_BREAKS` | Places each chunk in a separate graph to reduce compilation time.                            | `true` for lazy mode and `false` otherwise  |
 
 !!! note
     These parameters are effective only with the padding-aware bucketing strategy set by `VLLM_BUCKETING_STRATEGY="pad"`.

--- a/docs/configuration/env_variables.md
+++ b/docs/configuration/env_variables.md
@@ -132,3 +132,10 @@ FusedSDPA can be split into smaller chunks to improve performance while using th
 
 !!! note
     These parameters are effective only with the padding-aware bucketing strategy set by `VLLM_BUCKETING_STRATEGY="pad"`.
+
+The slicing only activated if all the following additional conditions are satisfied:
+- The batch size should be 1.
+- The query length and KV length should be different, i.e. the normal causal prefill will route to the default dispatch for better performance.
+- It's causal attention model.
+- The padding side is 'right'.
+- no sliding window nor sinks.

--- a/docs/configuration/env_variables.md
+++ b/docs/configuration/env_variables.md
@@ -118,3 +118,17 @@ and warm-up. Recommended settings for this case are:
 
 !!! note
     If the model config specifies a high `max_model_len`, set it to the sum of `input_tokens` and `output_tokens`, rounded up to a multiple of `block_size` according to actual requirements.
+
+## Additional Performance Tuning Parameters for the FusedSDPA Kernel with Padding-Aware Bucketing
+
+FusedSDPA can be split into smaller chunks to improve performance while using the padding-aware bucketing strategy which guarantees the max absolute padding in the sequence and context dimensions.
+
+| Parameter name                           | Description                                                                                  | Default value                              |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| `VLLM_HPU_FSDPA_SLICE_ENABLED`           | Enable the slicing.                                                                          | `True` for padding-aware bucketing strategy |
+| `VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD`      | KV length threshold above which slicing is applied.                                          | `min(max_num_batched_tokens, 8192)`        |
+| `VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE`        | Chunk size for `q_len` and `kv_len` in each chunk. Rounded up to the next multiple of 1024.  | `VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD // 2`   |
+| `VLLM_HPU_FSDPA_SLICE_WITH_GRAPH_BREAKS` | Places each chunk in a separate graph to reduce compilation time.                            | `true` for lazy mode and `false` otherwise |
+
+!!! note
+    These parameters are effective only with the padding-aware bucketing strategy set by `VLLM_BUCKETING_STRATEGY="pad"`.

--- a/docs/configuration/env_variables.md
+++ b/docs/configuration/env_variables.md
@@ -125,7 +125,7 @@ FusedSDPA can be split into smaller chunks to improve performance while using th
 
 | Parameter name                           | Description                                                                                  | Default value                               |
 | ---------------------------------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------- |
-| `VLLM_HPU_FSDPA_SLICE_ENABLED`           | Enable the slicing.                                                                          | `True` for padding-aware bucketing strategy |
+| `VLLM_HPU_FSDPA_SLICE_ENABLED`           | Enable the slicing.                                                                          | `True` when using padding-aware bucketing strategy with bucketing enabled, merged prefill disabled, and FusedSDPA kernel available |
 | `VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD`      | KV length threshold above which slicing is applied.                                          | `min(max_num_batched_tokens, 8192)`         |
 | `VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE`        | Chunk size for `q_len` and `kv_len` in each chunk. Rounded up to the next multiple of 1024.  | `VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD // 2`    |
 | `VLLM_HPU_FSDPA_SLICE_WITH_GRAPH_BREAKS` | Places each chunk in a separate graph to reduce compilation time.                            | `true` for lazy mode and `false` otherwise  |
@@ -133,9 +133,9 @@ FusedSDPA can be split into smaller chunks to improve performance while using th
 !!! note
     These parameters are effective only with the padding-aware bucketing strategy set by `VLLM_BUCKETING_STRATEGY="pad"`.
 
-The slicing only activated if all the following additional conditions are satisfied:
+The slicing is only activated if all the following additional conditions are satisfied:
 - The batch size should be 1.
 - The query length and KV length should be different, i.e. the normal causal prefill will route to the default dispatch for better performance.
-- It's causal attention model.
+- It's a causal attention model.
 - The padding side is 'right'.
-- no sliding window nor sinks.
+- No sliding window nor sinks (BF16 only; FP8 does not support sinks).

--- a/tests/full_tests/ci_e2e_discoverable_tests.sh
+++ b/tests/full_tests/ci_e2e_discoverable_tests.sh
@@ -624,11 +624,8 @@ launch_all_tests() {
     run_longbench_qwen3_30b_fp8_static_test
     run_longbench_qwen3_30b_fp8_static_bf16_fsdpa_slicing_lazy_test
     run_longbench_qwen3_30b_fp8_static_fp8_fsdpa_slicing_lazy_test
-    # Compile-mode LongBench variants are intentionally excluded from launch_all_tests
-    # due to a known runtime error: RuntimeError("Not Implemented") in PT_HPU_LAZY_MODE=0.
-    # Keep these discoverable for manual/debug runs:
-    #   run_longbench_qwen3_30b_fp8_static_bf16_fsdpa_slicing_compile_test
-    #   run_longbench_qwen3_30b_fp8_static_fp8_fsdpa_slicing_compile_test
+    run_longbench_qwen3_30b_fp8_static_bf16_fsdpa_slicing_compile_test
+    run_longbench_qwen3_30b_fp8_static_fp8_fsdpa_slicing_compile_test
     run_preemption_test
     run_spec_decode_ngram_test
     run_spec_decode_eagle3_test

--- a/tests/full_tests/ci_e2e_discoverable_tests.sh
+++ b/tests/full_tests/ci_e2e_discoverable_tests.sh
@@ -342,6 +342,7 @@ run_longbench_qwen3_30b_fp8_static_test() {
     echo "➡️ Testing LongBench (longbench_qasper) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only..."
     pip install 'lm_eval[longbench]' --quiet
     VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=1 TP_SIZE=2 \
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=600 \
     pytest -v -s "${VLLM_GAUDI_PREFIX}/tests/models/language/generation/test_common.py" --model_card_path "${VLLM_GAUDI_PREFIX}/tests/full_tests/model_cards/Qwen3-30B-A3B-FP8-Static-longbench.yaml"
     echo "✅ LongBench test with Intel/Qwen3-30B-A3B-FP8-Static-Test-Only passed."
 }
@@ -355,6 +356,7 @@ run_longbench_qwen3_30b_fp8_static_fsdpa_slicing_test() {
     VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=1 TP_SIZE=2 \
     VLLM_BUCKETING_STRATEGY=pad VLLM_HPU_FSDPA_SLICE_ENABLED=true \
     VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD=4096 VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE=2048 \
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=600 \
     pytest -v -s "${VLLM_GAUDI_PREFIX}/tests/models/language/generation/test_common.py" --model_card_path "${VLLM_GAUDI_PREFIX}/tests/full_tests/model_cards/Qwen3-30B-A3B-FP8-Static-longbench.yaml"
     echo "✅ LongBench test with Intel/Qwen3-30B-A3B-FP8-Static-Test-Only + enable_fsdpa_slicing passed."
 }
@@ -367,6 +369,7 @@ run_longbench_qwen3_30b_fp8_static_fp8kv_test() {
     VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=1 TP_SIZE=2 KV_CACHE_DTYPE=fp8_inc \
     VLLM_BUCKETING_STRATEGY=pad VLLM_HPU_FSDPA_SLICE_ENABLED=true \
     VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD=4096 VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE=2048 \
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=600 \
     pytest -v -s "${VLLM_GAUDI_PREFIX}/tests/models/language/generation/test_common.py" --model_card_path "${VLLM_GAUDI_PREFIX}/tests/full_tests/model_cards/Qwen3-30B-A3B-FP8-Static-longbench.yaml"
     echo "✅ LongBench test with Intel/Qwen3-30B-A3B-FP8-Static-Test-Only + KV_CACHE_DTYPE=fp8_inc + enable_fsdpa_slicing passed."
 }
@@ -379,6 +382,7 @@ run_longbench_qwen3_30b_fp8_static_fsdpa_slicing_compile_test() {
     VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=0 TP_SIZE=2 \
     VLLM_BUCKETING_STRATEGY=pad VLLM_HPU_FSDPA_SLICE_ENABLED=true \
     VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD=4096 VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE=2048 \
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=600 \
     pytest -v -s "${VLLM_GAUDI_PREFIX}/tests/models/language/generation/test_common.py" --model_card_path "${VLLM_GAUDI_PREFIX}/tests/full_tests/model_cards/Qwen3-30B-A3B-FP8-Static-longbench.yaml"
     echo "✅ LongBench test with Intel/Qwen3-30B-A3B-FP8-Static-Test-Only + enable_fsdpa_slicing + PT_HPU_LAZY_MODE=0 passed."
 }
@@ -391,6 +395,7 @@ run_longbench_qwen3_30b_fp8_static_fp8kv_compile_test() {
     VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=0 TP_SIZE=2 KV_CACHE_DTYPE=fp8_inc \
     VLLM_BUCKETING_STRATEGY=pad VLLM_HPU_FSDPA_SLICE_ENABLED=true \
     VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD=4096 VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE=2048 \
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=600 \
     pytest -v -s "${VLLM_GAUDI_PREFIX}/tests/models/language/generation/test_common.py" --model_card_path "${VLLM_GAUDI_PREFIX}/tests/full_tests/model_cards/Qwen3-30B-A3B-FP8-Static-longbench.yaml"
     echo "✅ LongBench test with Intel/Qwen3-30B-A3B-FP8-Static-Test-Only + KV_CACHE_DTYPE=fp8_inc + enable_fsdpa_slicing + PT_HPU_LAZY_MODE=0 passed."
 }

--- a/tests/full_tests/ci_e2e_discoverable_tests.sh
+++ b/tests/full_tests/ci_e2e_discoverable_tests.sh
@@ -336,6 +336,126 @@ run_gsm8k_qwen3_30b_test() {
 }
 
 
+# LongBench on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only (baseline, no fsdpa_slicing)
+# Requires: pip install 'lm_eval[longbench]'
+run_longbench_qwen3_30b_fp8_static_test() {
+    echo "➡️ Testing LongBench (longbench_qasper) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only..."
+    pip install 'lm_eval[longbench]' --quiet
+    VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=1 TP_SIZE=2 \
+    pytest -v -s "${VLLM_GAUDI_PREFIX}/tests/models/language/generation/test_common.py" --model_card_path "${VLLM_GAUDI_PREFIX}/tests/full_tests/model_cards/Qwen3-30B-A3B-FP8-Static-longbench.yaml"
+    echo "✅ LongBench test with Intel/Qwen3-30B-A3B-FP8-Static-Test-Only passed."
+}
+
+# LongBench on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with enable_fsdpa_slicing
+# Validates accuracy of the new fsdpa_slicing feature for long-context inference
+# Requires: pip install 'lm_eval[longbench]'
+run_longbench_qwen3_30b_fp8_static_fsdpa_slicing_test() {
+    echo "➡️ Testing LongBench (longbench_qasper) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with enable_fsdpa_slicing..."
+    pip install 'lm_eval[longbench]' --quiet
+    VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=1 TP_SIZE=2 \
+    VLLM_BUCKETING_STRATEGY=pad VLLM_HPU_FSDPA_SLICE_ENABLED=true \
+    VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD=4096 VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE=2048 \
+    pytest -v -s "${VLLM_GAUDI_PREFIX}/tests/models/language/generation/test_common.py" --model_card_path "${VLLM_GAUDI_PREFIX}/tests/full_tests/model_cards/Qwen3-30B-A3B-FP8-Static-longbench.yaml"
+    echo "✅ LongBench test with Intel/Qwen3-30B-A3B-FP8-Static-Test-Only + enable_fsdpa_slicing passed."
+}
+
+# LongBench on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with fp8 KV cache and fsdpa slicing
+# Requires: pip install 'lm_eval[longbench]'
+run_longbench_qwen3_30b_fp8_static_fp8kv_test() {
+    echo "➡️ Testing LongBench (longbench_qasper) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with KV_CACHE_DTYPE=fp8_inc and enable_fsdpa_slicing..."
+    pip install 'lm_eval[longbench]' --quiet
+    VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=1 TP_SIZE=2 KV_CACHE_DTYPE=fp8_inc \
+    VLLM_BUCKETING_STRATEGY=pad VLLM_HPU_FSDPA_SLICE_ENABLED=true \
+    VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD=4096 VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE=2048 \
+    pytest -v -s "${VLLM_GAUDI_PREFIX}/tests/models/language/generation/test_common.py" --model_card_path "${VLLM_GAUDI_PREFIX}/tests/full_tests/model_cards/Qwen3-30B-A3B-FP8-Static-longbench.yaml"
+    echo "✅ LongBench test with Intel/Qwen3-30B-A3B-FP8-Static-Test-Only + KV_CACHE_DTYPE=fp8_inc + enable_fsdpa_slicing passed."
+}
+
+# LongBench on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with fsdpa slicing in torch.compile mode
+# Requires: pip install 'lm_eval[longbench]'
+run_longbench_qwen3_30b_fp8_static_fsdpa_slicing_compile_test() {
+    echo "➡️ Testing LongBench (longbench_qasper) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with enable_fsdpa_slicing and PT_HPU_LAZY_MODE=0..."
+    pip install 'lm_eval[longbench]' --quiet
+    VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=0 TP_SIZE=2 \
+    VLLM_BUCKETING_STRATEGY=pad VLLM_HPU_FSDPA_SLICE_ENABLED=true \
+    VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD=4096 VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE=2048 \
+    pytest -v -s "${VLLM_GAUDI_PREFIX}/tests/models/language/generation/test_common.py" --model_card_path "${VLLM_GAUDI_PREFIX}/tests/full_tests/model_cards/Qwen3-30B-A3B-FP8-Static-longbench.yaml"
+    echo "✅ LongBench test with Intel/Qwen3-30B-A3B-FP8-Static-Test-Only + enable_fsdpa_slicing + PT_HPU_LAZY_MODE=0 passed."
+}
+
+# LongBench on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with fp8 KV cache and fsdpa slicing in torch.compile mode
+# Requires: pip install 'lm_eval[longbench]'
+run_longbench_qwen3_30b_fp8_static_fp8kv_compile_test() {
+    echo "➡️ Testing LongBench (longbench_qasper) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with KV_CACHE_DTYPE=fp8_inc, enable_fsdpa_slicing, and PT_HPU_LAZY_MODE=0..."
+    pip install 'lm_eval[longbench]' --quiet
+    VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=0 TP_SIZE=2 KV_CACHE_DTYPE=fp8_inc \
+    VLLM_BUCKETING_STRATEGY=pad VLLM_HPU_FSDPA_SLICE_ENABLED=true \
+    VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD=4096 VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE=2048 \
+    pytest -v -s "${VLLM_GAUDI_PREFIX}/tests/models/language/generation/test_common.py" --model_card_path "${VLLM_GAUDI_PREFIX}/tests/full_tests/model_cards/Qwen3-30B-A3B-FP8-Static-longbench.yaml"
+    echo "✅ LongBench test with Intel/Qwen3-30B-A3B-FP8-Static-Test-Only + KV_CACHE_DTYPE=fp8_inc + enable_fsdpa_slicing + PT_HPU_LAZY_MODE=0 passed."
+}
+
+
+# LongBench on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only (baseline, no fsdpa_slicing)
+# Requires: pip install 'lm_eval[longbench]'
+run_longbench_qwen3_30b_fp8_static_test() {
+    echo "➡️ Testing LongBench (longbench_qasper) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only..."
+    pip install 'lm_eval[longbench]' --quiet
+    VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=1 TP_SIZE=2 \
+    pytest -v -s "${VLLM_GAUDI_PREFIX}/tests/models/language/generation/test_common.py" --model_card_path "${VLLM_GAUDI_PREFIX}/tests/full_tests/model_cards/Qwen3-30B-A3B-FP8-Static-longbench.yaml"
+    echo "✅ LongBench test with Intel/Qwen3-30B-A3B-FP8-Static-Test-Only passed."
+}
+
+# LongBench on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with enable_fsdpa_slicing
+# Validates accuracy of the new fsdpa_slicing feature for long-context inference
+# Requires: pip install 'lm_eval[longbench]'
+run_longbench_qwen3_30b_fp8_static_fsdpa_slicing_test() {
+    echo "➡️ Testing LongBench (longbench_qasper) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with enable_fsdpa_slicing..."
+    pip install 'lm_eval[longbench]' --quiet
+    VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=1 TP_SIZE=2 \
+    VLLM_BUCKETING_STRATEGY=pad VLLM_HPU_FSDPA_SLICE_ENABLED=true \
+    VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD=4096 VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE=2048 \
+    pytest -v -s "${VLLM_GAUDI_PREFIX}/tests/models/language/generation/test_common.py" --model_card_path "${VLLM_GAUDI_PREFIX}/tests/full_tests/model_cards/Qwen3-30B-A3B-FP8-Static-longbench.yaml"
+    echo "✅ LongBench test with Intel/Qwen3-30B-A3B-FP8-Static-Test-Only + enable_fsdpa_slicing passed."
+}
+
+# LongBench on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with fp8 KV cache and fsdpa slicing
+# Requires: pip install 'lm_eval[longbench]'
+run_longbench_qwen3_30b_fp8_static_fp8kv_test() {
+    echo "➡️ Testing LongBench (longbench_qasper) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with KV_CACHE_DTYPE=fp8_inc and enable_fsdpa_slicing..."
+    pip install 'lm_eval[longbench]' --quiet
+    VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=1 TP_SIZE=2 KV_CACHE_DTYPE=fp8_inc \
+    VLLM_BUCKETING_STRATEGY=pad VLLM_HPU_FSDPA_SLICE_ENABLED=true \
+    VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD=4096 VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE=2048 \
+    pytest -v -s "${VLLM_GAUDI_PREFIX}/tests/models/language/generation/test_common.py" --model_card_path "${VLLM_GAUDI_PREFIX}/tests/full_tests/model_cards/Qwen3-30B-A3B-FP8-Static-longbench.yaml"
+    echo "✅ LongBench test with Intel/Qwen3-30B-A3B-FP8-Static-Test-Only + KV_CACHE_DTYPE=fp8_inc + enable_fsdpa_slicing passed."
+}
+
+# LongBench on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with fsdpa slicing in torch.compile mode
+# Requires: pip install 'lm_eval[longbench]'
+run_longbench_qwen3_30b_fp8_static_fsdpa_slicing_compile_test() {
+    echo "➡️ Testing LongBench (longbench_qasper) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with enable_fsdpa_slicing and PT_HPU_LAZY_MODE=0..."
+    pip install 'lm_eval[longbench]' --quiet
+    VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=0 TP_SIZE=2 \
+    VLLM_BUCKETING_STRATEGY=pad VLLM_HPU_FSDPA_SLICE_ENABLED=true \
+    VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD=4096 VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE=2048 \
+    pytest -v -s "${VLLM_GAUDI_PREFIX}/tests/models/language/generation/test_common.py" --model_card_path "${VLLM_GAUDI_PREFIX}/tests/full_tests/model_cards/Qwen3-30B-A3B-FP8-Static-longbench.yaml"
+    echo "✅ LongBench test with Intel/Qwen3-30B-A3B-FP8-Static-Test-Only + enable_fsdpa_slicing + PT_HPU_LAZY_MODE=0 passed."
+}
+
+# LongBench on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with fp8 KV cache and fsdpa slicing in torch.compile mode
+# Requires: pip install 'lm_eval[longbench]'
+run_longbench_qwen3_30b_fp8_static_fp8kv_compile_test() {
+    echo "➡️ Testing LongBench (longbench_qasper) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with KV_CACHE_DTYPE=fp8_inc, enable_fsdpa_slicing, and PT_HPU_LAZY_MODE=0..."
+    pip install 'lm_eval[longbench]' --quiet
+    VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=0 TP_SIZE=2 KV_CACHE_DTYPE=fp8_inc \
+    VLLM_BUCKETING_STRATEGY=pad VLLM_HPU_FSDPA_SLICE_ENABLED=true \
+    VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD=4096 VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE=2048 \
+    pytest -v -s "${VLLM_GAUDI_PREFIX}/tests/models/language/generation/test_common.py" --model_card_path "${VLLM_GAUDI_PREFIX}/tests/full_tests/model_cards/Qwen3-30B-A3B-FP8-Static-longbench.yaml"
+    echo "✅ LongBench test with Intel/Qwen3-30B-A3B-FP8-Static-Test-Only + KV_CACHE_DTYPE=fp8_inc + enable_fsdpa_slicing + PT_HPU_LAZY_MODE=0 passed."
+}
+
+
 # GSM8K on Qwen3.5-35B-A3B
 # This test requires new transformers and huggingface_hub versions for Qwen3.5 model support, once VLLM supports latest transfomer,
 # we can remove the pip version pinning and restoration in this test and just rely on the environment having the right versions.
@@ -496,6 +616,14 @@ launch_all_tests() {
     run_gsm8k_granite_async_test
     run_gsm8k_deepseek_test
     run_gsm8k_qwen3_30b_test
+    run_longbench_qwen3_30b_fp8_static_test
+    run_longbench_qwen3_30b_fp8_static_fsdpa_slicing_test
+    run_longbench_qwen3_30b_fp8_static_fp8kv_test
+    # Compile-mode LongBench variants are intentionally excluded from launch_all_tests
+    # due to a known runtime error: RuntimeError("Not Implemented") in PT_HPU_LAZY_MODE=0.
+    # Keep these discoverable for manual/debug runs:
+    #   run_longbench_qwen3_30b_fp8_static_fsdpa_slicing_compile_test
+    #   run_longbench_qwen3_30b_fp8_static_fp8kv_compile_test
     run_preemption_test
     run_spec_decode_ngram_test
     run_spec_decode_eagle3_test

--- a/tests/full_tests/ci_e2e_discoverable_tests.sh
+++ b/tests/full_tests/ci_e2e_discoverable_tests.sh
@@ -339,7 +339,7 @@ run_gsm8k_qwen3_30b_test() {
 # LongBench on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only (baseline, no fsdpa_slicing)
 # Requires: pip install 'lm_eval[longbench]'
 run_longbench_qwen3_30b_fp8_static_test() {
-    echo "➡️ Testing LongBench (longbench_qasper) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only..."
+    echo "➡️ Testing LongBench (longbench_triviaqa) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only..."
     pip install 'lm_eval[longbench]' --quiet
     VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=1 TP_SIZE=2 \
     VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=600 \
@@ -351,7 +351,7 @@ run_longbench_qwen3_30b_fp8_static_test() {
 # Validates accuracy of the new fsdpa_slicing feature for long-context inference
 # Requires: pip install 'lm_eval[longbench]'
 run_longbench_qwen3_30b_fp8_static_bf16_fsdpa_slicing_lazy_test() {
-    echo "➡️ Testing LongBench (longbench_qasper) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with BF16 KV cache + enable_fsdpa_slicing + PT_HPU_LAZY_MODE=1..."
+    echo "➡️ Testing LongBench (longbench_triviaqa) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with BF16 KV cache + enable_fsdpa_slicing + PT_HPU_LAZY_MODE=1..."
     pip install 'lm_eval[longbench]' --quiet
     VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=1 TP_SIZE=2 \
     VLLM_BUCKETING_STRATEGY=pad VLLM_HPU_FSDPA_SLICE_ENABLED=true \
@@ -364,7 +364,7 @@ run_longbench_qwen3_30b_fp8_static_bf16_fsdpa_slicing_lazy_test() {
 # LongBench on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with FP8 KV cache and fsdpa slicing in lazy mode
 # Requires: pip install 'lm_eval[longbench]'
 run_longbench_qwen3_30b_fp8_static_fp8_fsdpa_slicing_lazy_test() {
-    echo "➡️ Testing LongBench (longbench_qasper) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with KV_CACHE_DTYPE=fp8_inc + enable_fsdpa_slicing + PT_HPU_LAZY_MODE=1..."
+    echo "➡️ Testing LongBench (longbench_triviaqa) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with KV_CACHE_DTYPE=fp8_inc + enable_fsdpa_slicing + PT_HPU_LAZY_MODE=1..."
     pip install 'lm_eval[longbench]' --quiet
     VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=1 TP_SIZE=2 KV_CACHE_DTYPE=fp8_inc \
     VLLM_BUCKETING_STRATEGY=pad VLLM_HPU_FSDPA_SLICE_ENABLED=true \
@@ -377,7 +377,7 @@ run_longbench_qwen3_30b_fp8_static_fp8_fsdpa_slicing_lazy_test() {
 # LongBench on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with BF16 KV cache and fsdpa slicing in torch.compile mode
 # Requires: pip install 'lm_eval[longbench]'
 run_longbench_qwen3_30b_fp8_static_bf16_fsdpa_slicing_compile_test() {
-    echo "➡️ Testing LongBench (longbench_qasper) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with BF16 KV cache + enable_fsdpa_slicing + PT_HPU_LAZY_MODE=0..."
+    echo "➡️ Testing LongBench (longbench_triviaqa) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with BF16 KV cache + enable_fsdpa_slicing + PT_HPU_LAZY_MODE=0..."
     pip install 'lm_eval[longbench]' --quiet
     VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=0 TP_SIZE=2 \
     VLLM_BUCKETING_STRATEGY=pad VLLM_HPU_FSDPA_SLICE_ENABLED=true \
@@ -390,7 +390,7 @@ run_longbench_qwen3_30b_fp8_static_bf16_fsdpa_slicing_compile_test() {
 # LongBench on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with FP8 KV cache and fsdpa slicing in torch.compile mode
 # Requires: pip install 'lm_eval[longbench]'
 run_longbench_qwen3_30b_fp8_static_fp8_fsdpa_slicing_compile_test() {
-    echo "➡️ Testing LongBench (longbench_qasper) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with KV_CACHE_DTYPE=fp8_inc + enable_fsdpa_slicing + PT_HPU_LAZY_MODE=0..."
+    echo "➡️ Testing LongBench (longbench_triviaqa) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with KV_CACHE_DTYPE=fp8_inc + enable_fsdpa_slicing + PT_HPU_LAZY_MODE=0..."
     pip install 'lm_eval[longbench]' --quiet
     VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=0 TP_SIZE=2 KV_CACHE_DTYPE=fp8_inc \
     VLLM_BUCKETING_STRATEGY=pad VLLM_HPU_FSDPA_SLICE_ENABLED=true \

--- a/tests/full_tests/ci_e2e_discoverable_tests.sh
+++ b/tests/full_tests/ci_e2e_discoverable_tests.sh
@@ -401,66 +401,6 @@ run_longbench_qwen3_30b_fp8_static_fp8_fsdpa_slicing_compile_test() {
 }
 
 
-# LongBench on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only (baseline, no fsdpa_slicing)
-# Requires: pip install 'lm_eval[longbench]'
-run_longbench_qwen3_30b_fp8_static_test() {
-    echo "➡️ Testing LongBench (longbench_qasper) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only..."
-    pip install 'lm_eval[longbench]' --quiet
-    VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=1 TP_SIZE=2 \
-    pytest -v -s "${VLLM_GAUDI_PREFIX}/tests/models/language/generation/test_common.py" --model_card_path "${VLLM_GAUDI_PREFIX}/tests/full_tests/model_cards/Qwen3-30B-A3B-FP8-Static-longbench.yaml"
-    echo "✅ LongBench test with Intel/Qwen3-30B-A3B-FP8-Static-Test-Only passed."
-}
-
-# LongBench on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with enable_fsdpa_slicing
-# Validates accuracy of the new fsdpa_slicing feature for long-context inference
-# Requires: pip install 'lm_eval[longbench]'
-run_longbench_qwen3_30b_fp8_static_fsdpa_slicing_test() {
-    echo "➡️ Testing LongBench (longbench_qasper) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with enable_fsdpa_slicing..."
-    pip install 'lm_eval[longbench]' --quiet
-    VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=1 TP_SIZE=2 \
-    VLLM_BUCKETING_STRATEGY=pad VLLM_HPU_FSDPA_SLICE_ENABLED=true \
-    VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD=4096 VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE=2048 \
-    pytest -v -s "${VLLM_GAUDI_PREFIX}/tests/models/language/generation/test_common.py" --model_card_path "${VLLM_GAUDI_PREFIX}/tests/full_tests/model_cards/Qwen3-30B-A3B-FP8-Static-longbench.yaml"
-    echo "✅ LongBench test with Intel/Qwen3-30B-A3B-FP8-Static-Test-Only + enable_fsdpa_slicing passed."
-}
-
-# LongBench on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with fp8 KV cache and fsdpa slicing
-# Requires: pip install 'lm_eval[longbench]'
-run_longbench_qwen3_30b_fp8_static_fp8kv_test() {
-    echo "➡️ Testing LongBench (longbench_qasper) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with KV_CACHE_DTYPE=fp8_inc and enable_fsdpa_slicing..."
-    pip install 'lm_eval[longbench]' --quiet
-    VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=1 TP_SIZE=2 KV_CACHE_DTYPE=fp8_inc \
-    VLLM_BUCKETING_STRATEGY=pad VLLM_HPU_FSDPA_SLICE_ENABLED=true \
-    VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD=4096 VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE=2048 \
-    pytest -v -s "${VLLM_GAUDI_PREFIX}/tests/models/language/generation/test_common.py" --model_card_path "${VLLM_GAUDI_PREFIX}/tests/full_tests/model_cards/Qwen3-30B-A3B-FP8-Static-longbench.yaml"
-    echo "✅ LongBench test with Intel/Qwen3-30B-A3B-FP8-Static-Test-Only + KV_CACHE_DTYPE=fp8_inc + enable_fsdpa_slicing passed."
-}
-
-# LongBench on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with fsdpa slicing in torch.compile mode
-# Requires: pip install 'lm_eval[longbench]'
-run_longbench_qwen3_30b_fp8_static_fsdpa_slicing_compile_test() {
-    echo "➡️ Testing LongBench (longbench_qasper) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with enable_fsdpa_slicing and PT_HPU_LAZY_MODE=0..."
-    pip install 'lm_eval[longbench]' --quiet
-    VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=0 TP_SIZE=2 \
-    VLLM_BUCKETING_STRATEGY=pad VLLM_HPU_FSDPA_SLICE_ENABLED=true \
-    VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD=4096 VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE=2048 \
-    pytest -v -s "${VLLM_GAUDI_PREFIX}/tests/models/language/generation/test_common.py" --model_card_path "${VLLM_GAUDI_PREFIX}/tests/full_tests/model_cards/Qwen3-30B-A3B-FP8-Static-longbench.yaml"
-    echo "✅ LongBench test with Intel/Qwen3-30B-A3B-FP8-Static-Test-Only + enable_fsdpa_slicing + PT_HPU_LAZY_MODE=0 passed."
-}
-
-# LongBench on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with fp8 KV cache and fsdpa slicing in torch.compile mode
-# Requires: pip install 'lm_eval[longbench]'
-run_longbench_qwen3_30b_fp8_static_fp8kv_compile_test() {
-    echo "➡️ Testing LongBench (longbench_qasper) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with KV_CACHE_DTYPE=fp8_inc, enable_fsdpa_slicing, and PT_HPU_LAZY_MODE=0..."
-    pip install 'lm_eval[longbench]' --quiet
-    VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=0 TP_SIZE=2 KV_CACHE_DTYPE=fp8_inc \
-    VLLM_BUCKETING_STRATEGY=pad VLLM_HPU_FSDPA_SLICE_ENABLED=true \
-    VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD=4096 VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE=2048 \
-    pytest -v -s "${VLLM_GAUDI_PREFIX}/tests/models/language/generation/test_common.py" --model_card_path "${VLLM_GAUDI_PREFIX}/tests/full_tests/model_cards/Qwen3-30B-A3B-FP8-Static-longbench.yaml"
-    echo "✅ LongBench test with Intel/Qwen3-30B-A3B-FP8-Static-Test-Only + KV_CACHE_DTYPE=fp8_inc + enable_fsdpa_slicing + PT_HPU_LAZY_MODE=0 passed."
-}
-
-
 # GSM8K on Qwen3.5-35B-A3B
 # This test requires new transformers and huggingface_hub versions for Qwen3.5 model support, once VLLM supports latest transfomer,
 # we can remove the pip version pinning and restoration in this test and just rely on the environment having the right versions.

--- a/tests/full_tests/ci_e2e_discoverable_tests.sh
+++ b/tests/full_tests/ci_e2e_discoverable_tests.sh
@@ -355,7 +355,7 @@ run_longbench_qwen3_30b_fp8_static_bf16_fsdpa_slicing_lazy_test() {
     pip install 'lm_eval[longbench]' --quiet
     VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=1 TP_SIZE=2 \
     VLLM_BUCKETING_STRATEGY=pad VLLM_HPU_FSDPA_SLICE_ENABLED=true \
-    VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD=4096 VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE=2048 \
+    VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD=8192 VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE=4096 \
     VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=600 \
     pytest -v -s "${VLLM_GAUDI_PREFIX}/tests/models/language/generation/test_common.py" --model_card_path "${VLLM_GAUDI_PREFIX}/tests/full_tests/model_cards/Qwen3-30B-A3B-FP8-Static-longbench.yaml"
     echo "✅ LongBench test with Intel/Qwen3-30B-A3B-FP8-Static-Test-Only + BF16 KV cache + enable_fsdpa_slicing + PT_HPU_LAZY_MODE=1 passed."
@@ -368,7 +368,7 @@ run_longbench_qwen3_30b_fp8_static_fp8_fsdpa_slicing_lazy_test() {
     pip install 'lm_eval[longbench]' --quiet
     VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=1 TP_SIZE=2 KV_CACHE_DTYPE=fp8_inc \
     VLLM_BUCKETING_STRATEGY=pad VLLM_HPU_FSDPA_SLICE_ENABLED=true \
-    VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD=4096 VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE=2048 \
+    VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD=8192 VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE=4096 \
     VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=600 \
     pytest -v -s "${VLLM_GAUDI_PREFIX}/tests/models/language/generation/test_common.py" --model_card_path "${VLLM_GAUDI_PREFIX}/tests/full_tests/model_cards/Qwen3-30B-A3B-FP8-Static-longbench.yaml"
     echo "✅ LongBench test with Intel/Qwen3-30B-A3B-FP8-Static-Test-Only + KV_CACHE_DTYPE=fp8_inc + enable_fsdpa_slicing + PT_HPU_LAZY_MODE=1 passed."
@@ -381,7 +381,7 @@ run_longbench_qwen3_30b_fp8_static_bf16_fsdpa_slicing_compile_test() {
     pip install 'lm_eval[longbench]' --quiet
     VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=0 TP_SIZE=2 \
     VLLM_BUCKETING_STRATEGY=pad VLLM_HPU_FSDPA_SLICE_ENABLED=true \
-    VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD=4096 VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE=2048 \
+    VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD=8192 VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE=4096 \
     VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=600 \
     pytest -v -s "${VLLM_GAUDI_PREFIX}/tests/models/language/generation/test_common.py" --model_card_path "${VLLM_GAUDI_PREFIX}/tests/full_tests/model_cards/Qwen3-30B-A3B-FP8-Static-longbench.yaml"
     echo "✅ LongBench test with Intel/Qwen3-30B-A3B-FP8-Static-Test-Only + BF16 KV cache + enable_fsdpa_slicing + PT_HPU_LAZY_MODE=0 passed."
@@ -394,7 +394,7 @@ run_longbench_qwen3_30b_fp8_static_fp8_fsdpa_slicing_compile_test() {
     pip install 'lm_eval[longbench]' --quiet
     VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=0 TP_SIZE=2 KV_CACHE_DTYPE=fp8_inc \
     VLLM_BUCKETING_STRATEGY=pad VLLM_HPU_FSDPA_SLICE_ENABLED=true \
-    VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD=4096 VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE=2048 \
+    VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD=8192 VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE=4096 \
     VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=600 \
     pytest -v -s "${VLLM_GAUDI_PREFIX}/tests/models/language/generation/test_common.py" --model_card_path "${VLLM_GAUDI_PREFIX}/tests/full_tests/model_cards/Qwen3-30B-A3B-FP8-Static-longbench.yaml"
     echo "✅ LongBench test with Intel/Qwen3-30B-A3B-FP8-Static-Test-Only + KV_CACHE_DTYPE=fp8_inc + enable_fsdpa_slicing + PT_HPU_LAZY_MODE=0 passed."

--- a/tests/full_tests/ci_e2e_discoverable_tests.sh
+++ b/tests/full_tests/ci_e2e_discoverable_tests.sh
@@ -347,50 +347,50 @@ run_longbench_qwen3_30b_fp8_static_test() {
     echo "✅ LongBench test with Intel/Qwen3-30B-A3B-FP8-Static-Test-Only passed."
 }
 
-# LongBench on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with enable_fsdpa_slicing
+# LongBench on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with BF16 KV cache and fsdpa slicing in lazy mode
 # Validates accuracy of the new fsdpa_slicing feature for long-context inference
 # Requires: pip install 'lm_eval[longbench]'
-run_longbench_qwen3_30b_fp8_static_fsdpa_slicing_test() {
-    echo "➡️ Testing LongBench (longbench_qasper) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with enable_fsdpa_slicing..."
+run_longbench_qwen3_30b_fp8_static_bf16_fsdpa_slicing_lazy_test() {
+    echo "➡️ Testing LongBench (longbench_qasper) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with BF16 KV cache + enable_fsdpa_slicing + PT_HPU_LAZY_MODE=1..."
     pip install 'lm_eval[longbench]' --quiet
     VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=1 TP_SIZE=2 \
     VLLM_BUCKETING_STRATEGY=pad VLLM_HPU_FSDPA_SLICE_ENABLED=true \
     VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD=4096 VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE=2048 \
     VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=600 \
     pytest -v -s "${VLLM_GAUDI_PREFIX}/tests/models/language/generation/test_common.py" --model_card_path "${VLLM_GAUDI_PREFIX}/tests/full_tests/model_cards/Qwen3-30B-A3B-FP8-Static-longbench.yaml"
-    echo "✅ LongBench test with Intel/Qwen3-30B-A3B-FP8-Static-Test-Only + enable_fsdpa_slicing passed."
+    echo "✅ LongBench test with Intel/Qwen3-30B-A3B-FP8-Static-Test-Only + BF16 KV cache + enable_fsdpa_slicing + PT_HPU_LAZY_MODE=1 passed."
 }
 
-# LongBench on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with fp8 KV cache and fsdpa slicing
+# LongBench on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with FP8 KV cache and fsdpa slicing in lazy mode
 # Requires: pip install 'lm_eval[longbench]'
-run_longbench_qwen3_30b_fp8_static_fp8kv_test() {
-    echo "➡️ Testing LongBench (longbench_qasper) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with KV_CACHE_DTYPE=fp8_inc and enable_fsdpa_slicing..."
+run_longbench_qwen3_30b_fp8_static_fp8_fsdpa_slicing_lazy_test() {
+    echo "➡️ Testing LongBench (longbench_qasper) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with KV_CACHE_DTYPE=fp8_inc + enable_fsdpa_slicing + PT_HPU_LAZY_MODE=1..."
     pip install 'lm_eval[longbench]' --quiet
     VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=1 TP_SIZE=2 KV_CACHE_DTYPE=fp8_inc \
     VLLM_BUCKETING_STRATEGY=pad VLLM_HPU_FSDPA_SLICE_ENABLED=true \
     VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD=4096 VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE=2048 \
     VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=600 \
     pytest -v -s "${VLLM_GAUDI_PREFIX}/tests/models/language/generation/test_common.py" --model_card_path "${VLLM_GAUDI_PREFIX}/tests/full_tests/model_cards/Qwen3-30B-A3B-FP8-Static-longbench.yaml"
-    echo "✅ LongBench test with Intel/Qwen3-30B-A3B-FP8-Static-Test-Only + KV_CACHE_DTYPE=fp8_inc + enable_fsdpa_slicing passed."
+    echo "✅ LongBench test with Intel/Qwen3-30B-A3B-FP8-Static-Test-Only + KV_CACHE_DTYPE=fp8_inc + enable_fsdpa_slicing + PT_HPU_LAZY_MODE=1 passed."
 }
 
-# LongBench on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with fsdpa slicing in torch.compile mode
+# LongBench on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with BF16 KV cache and fsdpa slicing in torch.compile mode
 # Requires: pip install 'lm_eval[longbench]'
-run_longbench_qwen3_30b_fp8_static_fsdpa_slicing_compile_test() {
-    echo "➡️ Testing LongBench (longbench_qasper) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with enable_fsdpa_slicing and PT_HPU_LAZY_MODE=0..."
+run_longbench_qwen3_30b_fp8_static_bf16_fsdpa_slicing_compile_test() {
+    echo "➡️ Testing LongBench (longbench_qasper) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with BF16 KV cache + enable_fsdpa_slicing + PT_HPU_LAZY_MODE=0..."
     pip install 'lm_eval[longbench]' --quiet
     VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=0 TP_SIZE=2 \
     VLLM_BUCKETING_STRATEGY=pad VLLM_HPU_FSDPA_SLICE_ENABLED=true \
     VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD=4096 VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE=2048 \
     VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=600 \
     pytest -v -s "${VLLM_GAUDI_PREFIX}/tests/models/language/generation/test_common.py" --model_card_path "${VLLM_GAUDI_PREFIX}/tests/full_tests/model_cards/Qwen3-30B-A3B-FP8-Static-longbench.yaml"
-    echo "✅ LongBench test with Intel/Qwen3-30B-A3B-FP8-Static-Test-Only + enable_fsdpa_slicing + PT_HPU_LAZY_MODE=0 passed."
+    echo "✅ LongBench test with Intel/Qwen3-30B-A3B-FP8-Static-Test-Only + BF16 KV cache + enable_fsdpa_slicing + PT_HPU_LAZY_MODE=0 passed."
 }
 
-# LongBench on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with fp8 KV cache and fsdpa slicing in torch.compile mode
+# LongBench on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with FP8 KV cache and fsdpa slicing in torch.compile mode
 # Requires: pip install 'lm_eval[longbench]'
-run_longbench_qwen3_30b_fp8_static_fp8kv_compile_test() {
-    echo "➡️ Testing LongBench (longbench_qasper) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with KV_CACHE_DTYPE=fp8_inc, enable_fsdpa_slicing, and PT_HPU_LAZY_MODE=0..."
+run_longbench_qwen3_30b_fp8_static_fp8_fsdpa_slicing_compile_test() {
+    echo "➡️ Testing LongBench (longbench_qasper) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with KV_CACHE_DTYPE=fp8_inc + enable_fsdpa_slicing + PT_HPU_LAZY_MODE=0..."
     pip install 'lm_eval[longbench]' --quiet
     VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=0 TP_SIZE=2 KV_CACHE_DTYPE=fp8_inc \
     VLLM_BUCKETING_STRATEGY=pad VLLM_HPU_FSDPA_SLICE_ENABLED=true \
@@ -622,13 +622,13 @@ launch_all_tests() {
     run_gsm8k_deepseek_test
     run_gsm8k_qwen3_30b_test
     run_longbench_qwen3_30b_fp8_static_test
-    run_longbench_qwen3_30b_fp8_static_fsdpa_slicing_test
-    run_longbench_qwen3_30b_fp8_static_fp8kv_test
+    run_longbench_qwen3_30b_fp8_static_bf16_fsdpa_slicing_lazy_test
+    run_longbench_qwen3_30b_fp8_static_fp8_fsdpa_slicing_lazy_test
     # Compile-mode LongBench variants are intentionally excluded from launch_all_tests
     # due to a known runtime error: RuntimeError("Not Implemented") in PT_HPU_LAZY_MODE=0.
     # Keep these discoverable for manual/debug runs:
-    #   run_longbench_qwen3_30b_fp8_static_fsdpa_slicing_compile_test
-    #   run_longbench_qwen3_30b_fp8_static_fp8kv_compile_test
+    #   run_longbench_qwen3_30b_fp8_static_bf16_fsdpa_slicing_compile_test
+    #   run_longbench_qwen3_30b_fp8_static_fp8_fsdpa_slicing_compile_test
     run_preemption_test
     run_spec_decode_ngram_test
     run_spec_decode_eagle3_test

--- a/tests/full_tests/ci_e2e_discoverable_tests.sh
+++ b/tests/full_tests/ci_e2e_discoverable_tests.sh
@@ -341,7 +341,7 @@ run_gsm8k_qwen3_30b_test() {
 run_longbench_qwen3_30b_fp8_static_test() {
     echo "➡️ Testing LongBench (longbench_triviaqa) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only..."
     pip install 'lm_eval[longbench]' --quiet
-    VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=1 TP_SIZE=2 \
+    VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=0 TP_SIZE=2 \
     VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=600 \
     pytest -v -s "${VLLM_GAUDI_PREFIX}/tests/models/language/generation/test_common.py" --model_card_path "${VLLM_GAUDI_PREFIX}/tests/full_tests/model_cards/Qwen3-30B-A3B-FP8-Static-longbench.yaml"
     echo "✅ LongBench test with Intel/Qwen3-30B-A3B-FP8-Static-Test-Only passed."
@@ -351,6 +351,10 @@ run_longbench_qwen3_30b_fp8_static_test() {
 # Validates accuracy of the new fsdpa_slicing feature for long-context inference
 # Requires: pip install 'lm_eval[longbench]'
 run_longbench_qwen3_30b_fp8_static_bf16_fsdpa_slicing_lazy_test() {
+    if [[ "${RUN_LONGBENCH_LAZY_TESTS:-false}" != "true" ]]; then
+        echo "⏭️ Skipping LongBench lazy-mode test. Set RUN_LONGBENCH_LAZY_TESTS=true to enable."
+        return 0
+    fi
     echo "➡️ Testing LongBench (longbench_triviaqa) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with BF16 KV cache + enable_fsdpa_slicing + PT_HPU_LAZY_MODE=1..."
     pip install 'lm_eval[longbench]' --quiet
     VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=1 TP_SIZE=2 \
@@ -364,6 +368,10 @@ run_longbench_qwen3_30b_fp8_static_bf16_fsdpa_slicing_lazy_test() {
 # LongBench on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with FP8 KV cache and fsdpa slicing in lazy mode
 # Requires: pip install 'lm_eval[longbench]'
 run_longbench_qwen3_30b_fp8_static_fp8_fsdpa_slicing_lazy_test() {
+    if [[ "${RUN_LONGBENCH_LAZY_TESTS:-false}" != "true" ]]; then
+        echo "⏭️ Skipping LongBench lazy-mode test. Set RUN_LONGBENCH_LAZY_TESTS=true to enable."
+        return 0
+    fi
     echo "➡️ Testing LongBench (longbench_triviaqa) on Intel/Qwen3-30B-A3B-FP8-Static-Test-Only with KV_CACHE_DTYPE=fp8_inc + enable_fsdpa_slicing + PT_HPU_LAZY_MODE=1..."
     pip install 'lm_eval[longbench]' --quiet
     VLLM_CONTIGUOUS_PA=False ENABLE_APC=False VLLM_SKIP_WARMUP=True PT_HPU_LAZY_MODE=1 TP_SIZE=2 KV_CACHE_DTYPE=fp8_inc \

--- a/tests/full_tests/model_cards/Qwen3-30B-A3B-FP8-Static-longbench.yaml
+++ b/tests/full_tests/model_cards/Qwen3-30B-A3B-FP8-Static-longbench.yaml
@@ -1,13 +1,15 @@
 model_card:
   model_name: Intel/Qwen3-30B-A3B-FP8-Static-Test-Only
-  tasks: longbench_qasper
+  tasks: longbench_triviaqa
   num_fewshot: 0
   trust_remote_code: true
   limit: 20
   max_model_len: 32768
   max_num_seqs: 8
   enable_expert_parallel: True
+  chat_template_args:
+    enable_thinking: false
 
 metrics:
   name: qa_f1_score,none
-  value: 0.12
+  value: 0.80

--- a/tests/full_tests/model_cards/Qwen3-30B-A3B-FP8-Static-longbench.yaml
+++ b/tests/full_tests/model_cards/Qwen3-30B-A3B-FP8-Static-longbench.yaml
@@ -1,0 +1,13 @@
+model_card:
+  model_name: Intel/Qwen3-30B-A3B-FP8-Static-Test-Only
+  tasks: longbench_qasper
+  num_fewshot: 0
+  trust_remote_code: true
+  limit: 20
+  max_model_len: 32768
+  max_num_seqs: 8
+  enable_expert_parallel: True
+
+metrics:
+  name: qa_f1_score,none
+  value: 0.12

--- a/tests/unit_tests/test_fsdpa_slicing.py
+++ b/tests/unit_tests/test_fsdpa_slicing.py
@@ -415,6 +415,147 @@ class TestSetupSlicing:
         assert result is True
         assert base._with_graph_breaks is True
 
+    @patch('vllm_gaudi.extension.utils.get_config')
+    @patch('vllm_gaudi.extension.bucketing.common.HPUBucketingManager.get_instance')
+    def test_disabled_when_bucketing_off(self, mock_get_instance, mock_get_config):
+        mock_get_config.return_value = _make_config(use_bucketing=False)
+        mock_get_instance.return_value = None
+
+        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
+        base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
+        result = base._setup_slicing()
+        assert result is False
+
+    @patch('habana_frameworks.torch.utils.internal.is_lazy', return_value=False)
+    @patch('vllm_gaudi.extension.utils.get_config')
+    @patch('vllm_gaudi.extension.bucketing.common.HPUBucketingManager.get_instance')
+    def test_threshold_lte_block_size_raises(self, mock_get_instance, mock_get_config, mock_is_lazy, monkeypatch):
+        """slice_thld must be greater than block_size."""
+        monkeypatch.setenv("VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD", "128")
+        mock_get_config.return_value = _make_config()
+        mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=128)
+
+        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
+        base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
+        with pytest.raises(AssertionError):
+            base._setup_slicing()
+
+    @patch('habana_frameworks.torch.utils.internal.is_lazy', return_value=False)
+    @patch('vllm_gaudi.extension.utils.get_config')
+    @patch('vllm_gaudi.extension.bucketing.common.HPUBucketingManager.get_instance')
+    def test_threshold_lte_1024_raises(self, mock_get_instance, mock_get_config, mock_is_lazy, monkeypatch):
+        """slice_thld must be greater than 1024."""
+        monkeypatch.setenv("VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD", "1024")
+        mock_get_config.return_value = _make_config()
+        mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=128)
+
+        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
+        base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
+        with pytest.raises(AssertionError):
+            base._setup_slicing()
+
+
+# ---------------------------------------------------------------------------
+# Manual module construction tests (simulates production _setup_slicing result)
+# ---------------------------------------------------------------------------
+
+
+def _make_sliced_bf16(chunk_size, num_padded_query_chunks=0, num_padded_ctx_chunks=0, with_graph_breaks=False):
+    """Build a SlicedFusedSDPA bypassing _setup_slicing (for testing / HPU accuracy)."""
+    from vllm_gaudi.extension.utils import SlicedFusedSDPA
+    with patch('vllm_gaudi.extension.utils.SlicedFusedSDPABase._setup_slicing', return_value=True):
+        module = SlicedFusedSDPA()
+    module.enable_slicing = True
+    module.chunk_size = chunk_size
+    module.slice_thld = 0
+    module.num_padded_query_chunks = num_padded_query_chunks
+    module.num_padded_ctx_chunks = num_padded_ctx_chunks
+    module._with_graph_breaks = with_graph_breaks
+    if with_graph_breaks:
+        import habana_frameworks.torch as ht
+        if ht.utils.internal.is_lazy():
+            module._break_graph = ht.core.mark_step
+        else:
+            module._break_graph = torch._dynamo.graph_break
+    return module
+
+
+def _make_sliced_fp8(chunk_size,
+                     num_padded_query_chunks=0,
+                     num_padded_ctx_chunks=0,
+                     *,
+                     d_scale_q,
+                     d_scale_k,
+                     d_scale_v,
+                     d_scale_output,
+                     scale_amax,
+                     descale_amax,
+                     with_graph_breaks=False):
+    """Build a SlicedFP8FusedSDPA bypassing _setup_slicing (for testing / HPU accuracy)."""
+    from vllm_gaudi.extension.utils import SlicedFP8FusedSDPA
+
+    # Create a lightweight parent-like namespace to hold scale tensors
+    class _ScaleHolder:
+        pass
+
+    parent = _ScaleHolder()
+    parent.d_scale_q = d_scale_q
+    parent.d_scale_k = d_scale_k
+    parent.d_scale_v = d_scale_v
+    parent.d_scale_output = d_scale_output
+    parent.scale_amax = scale_amax
+    parent.descale_amax = descale_amax
+
+    with patch('vllm_gaudi.extension.utils.SlicedFusedSDPABase._setup_slicing', return_value=True):
+        module = SlicedFP8FusedSDPA(parent)
+    module.enable_slicing = True
+    module.chunk_size = chunk_size
+    module.slice_thld = 0
+    module.num_padded_query_chunks = num_padded_query_chunks
+    module.num_padded_ctx_chunks = num_padded_ctx_chunks
+    module._with_graph_breaks = with_graph_breaks
+    if with_graph_breaks:
+        import habana_frameworks.torch as ht
+        if ht.utils.internal.is_lazy():
+            module._break_graph = ht.core.mark_step
+        else:
+            module._break_graph = torch._dynamo.graph_break
+    return module
+
+
+class TestManualModuleConstruction:
+    """Tests for building sliced modules with manual attribute setup (bypassing _setup_slicing)."""
+
+    def test_bf16_manual_init_sets_attributes(self):
+        module = _make_sliced_bf16(chunk_size=4096,
+                                   num_padded_query_chunks=1,
+                                   num_padded_ctx_chunks=2,
+                                   with_graph_breaks=False)
+        assert module.enable_slicing is True
+        assert module.chunk_size == 4096
+        assert module.num_padded_query_chunks == 1
+        assert module.num_padded_ctx_chunks == 2
+        assert module._with_graph_breaks is False
+
+    def test_fp8_manual_init_sets_scales(self):
+        scales = {
+            'd_scale_q': torch.tensor(1.0),
+            'd_scale_k': torch.tensor(1.0),
+            'd_scale_v': torch.tensor(1.0),
+            'd_scale_output': torch.tensor(1.0),
+            'scale_amax': torch.tensor(1.0),
+            'descale_amax': torch.tensor(1.0),
+        }
+        module = _make_sliced_fp8(chunk_size=4096, num_padded_query_chunks=1, num_padded_ctx_chunks=2, **scales)
+        assert module.chunk_size == 4096
+        assert module._parent.d_scale_q is scales['d_scale_q']
+
+    def test_bf16_defaults_for_optional_params(self):
+        module = _make_sliced_bf16(chunk_size=2048)
+        assert module.num_padded_query_chunks == 0
+        assert module.num_padded_ctx_chunks == 0
+        assert module._with_graph_breaks is False
+
 
 # ---------------------------------------------------------------------------
 # ModuleFusedSDPA.forward dispatch tests
@@ -695,6 +836,60 @@ class TestModuleFP8FusedSDPAForwardDispatch:
         assert call_kwargs['is_causal'] is False
         assert call_kwargs['valid_seq_len'] is None
 
+    def test_default_path_when_q_len_equals_kv_len(self):
+        import torch
+        module = self._patch_quant(self._make_module())
+        q = torch.randn(1, 4, 4096, 64)
+        k = torch.randn(1, 4, 4096, 64)  # q_len == kv_len
+        v = torch.randn(1, 4, 4096, 64)
+        mask = torch.zeros(1, 1, 4096, 4096)
+
+        module.forward(q, k, v, mask, 0.0, True, None, 'fast', True, None, padding_side='right')
+        module._sliced_module.assert_not_called()
+
+    def test_default_path_when_not_causal(self):
+        import torch
+        module = self._patch_quant(self._make_module())
+        q = torch.randn(1, 4, 2048, 64)
+        k = torch.randn(1, 4, 8192, 64)
+        v = torch.randn(1, 4, 8192, 64)
+        mask = torch.zeros(1, 1, 2048, 8192)
+
+        module.forward(q, k, v, mask, 0.0, False, None, 'fast', True, None, padding_side='right')
+        module._sliced_module.assert_not_called()
+
+    def test_default_path_when_no_attn_mask(self):
+        import torch
+        module = self._patch_quant(self._make_module())
+        q = torch.randn(1, 4, 2048, 64)
+        k = torch.randn(1, 4, 8192, 64)
+        v = torch.randn(1, 4, 8192, 64)
+
+        module.forward(q, k, v, None, 0.0, True, None, 'fast', True, None, padding_side='right')
+        module._sliced_module.assert_not_called()
+
+    def test_default_path_when_padding_side_left(self):
+        import torch
+        module = self._patch_quant(self._make_module())
+        q = torch.randn(1, 4, 2048, 64)
+        k = torch.randn(1, 4, 8192, 64)
+        v = torch.randn(1, 4, 8192, 64)
+        mask = torch.zeros(1, 1, 2048, 8192)
+
+        module.forward(q, k, v, mask, 0.0, True, None, 'fast', True, None, padding_side='left')
+        module._sliced_module.assert_not_called()
+
+    def test_default_path_when_kv_len_below_threshold(self):
+        import torch
+        module = self._patch_quant(self._make_module(slice_thld=8192))
+        q = torch.randn(1, 4, 2048, 64)
+        k = torch.randn(1, 4, 4096, 64)  # kv_len < threshold
+        v = torch.randn(1, 4, 4096, 64)
+        mask = torch.zeros(1, 1, 2048, 4096)
+
+        module.forward(q, k, v, mask, 0.0, True, None, 'fast', True, None, padding_side='right')
+        module._sliced_module.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # User flag registration tests
@@ -921,9 +1116,8 @@ class TestFsdpaSlicingAccuracyBF16:
     @staticmethod
     def _run_sliced(q, k, v, attn_mask, slice_thld, chunk_size, q_pad, ctx_pad, graph_breaks=False, mode='eager'):
         """Sliced path via SlicedFusedSDPA module."""
-        from vllm_gaudi.extension.utils import SlicedFusedSDPA
-        module = SlicedFusedSDPA(chunk_size, math.ceil(q_pad / chunk_size), math.ceil(ctx_pad / chunk_size),
-                                 graph_breaks)
+        module = _make_sliced_bf16(chunk_size, math.ceil(q_pad / chunk_size), math.ceil(ctx_pad / chunk_size),
+                                   graph_breaks)
         module = module.to('hpu')
         if mode == 'compile':
             torch._dynamo.reset()
@@ -1025,23 +1219,22 @@ class TestFsdpaSlicingAccuracyFP8:
         Uses dynamic_quant for FP8 quantization following FP8BucketSDPA.__init__
         in profile_fsdpa_apc.py.
         """
-        from vllm_gaudi.extension.utils import SlicedFP8FusedSDPA
         from vllm_gaudi.extension.ops import dynamic_quant
 
         q_fp8, scale_q = dynamic_quant(q, single_scale=True)
         k_fp8, scale_k = dynamic_quant(k, single_scale=True)
         v_fp8, scale_v = dynamic_quant(v, single_scale=True)
 
-        module = SlicedFP8FusedSDPA(chunk_size,
-                                    math.ceil(q_pad / chunk_size),
-                                    math.ceil(ctx_pad / chunk_size),
-                                    d_scale_q=scale_q.to(torch.float32),
-                                    d_scale_k=scale_k.to(torch.float32),
-                                    d_scale_v=scale_v.to(torch.float32),
-                                    d_scale_output=torch.tensor([1.0], dtype=torch.float32, device='hpu'),
-                                    scale_amax=torch.tensor([1.0], dtype=torch.float32, device='hpu'),
-                                    descale_amax=torch.tensor([1.0], dtype=torch.float32, device='hpu'),
-                                    with_graph_breaks=graph_breaks)
+        module = _make_sliced_fp8(chunk_size,
+                                  math.ceil(q_pad / chunk_size),
+                                  math.ceil(ctx_pad / chunk_size),
+                                  d_scale_q=scale_q.to(torch.float32),
+                                  d_scale_k=scale_k.to(torch.float32),
+                                  d_scale_v=scale_v.to(torch.float32),
+                                  d_scale_output=torch.tensor([1.0], dtype=torch.float32, device='hpu'),
+                                  scale_amax=torch.tensor([1.0], dtype=torch.float32, device='hpu'),
+                                  descale_amax=torch.tensor([1.0], dtype=torch.float32, device='hpu'),
+                                  with_graph_breaks=graph_breaks)
         module = module.to('hpu')
         if mode == 'compile':
             torch._dynamo.reset()

--- a/tests/unit_tests/test_fsdpa_slicing.py
+++ b/tests/unit_tests/test_fsdpa_slicing.py
@@ -462,9 +462,10 @@ def _make_sliced_bf16(chunk_size, num_padded_query_chunks=0, num_padded_ctx_chun
     module.slice_thld = 0
     module.num_padded_query_chunks = num_padded_query_chunks
     module.num_padded_ctx_chunks = num_padded_ctx_chunks
-    module._with_graph_breaks = with_graph_breaks
-    if with_graph_breaks:
-        import habana_frameworks.torch as ht
+    # Mirror the production guard: graph breaks only work in lazy mode.
+    is_lazy = ht.utils.internal.is_lazy()
+    module._with_graph_breaks = with_graph_breaks and is_lazy
+    if module._with_graph_breaks:
         module._break_graph = ht.core.mark_step
     return module
 
@@ -506,9 +507,10 @@ def _make_sliced_fp8(chunk_size,
     module.slice_thld = 0
     module.num_padded_query_chunks = num_padded_query_chunks
     module.num_padded_ctx_chunks = num_padded_ctx_chunks
-    module._with_graph_breaks = with_graph_breaks
-    if with_graph_breaks:
-        import habana_frameworks.torch as ht
+    # Mirror the production guard: graph breaks only work in lazy mode.
+    is_lazy = ht.utils.internal.is_lazy()
+    module._with_graph_breaks = with_graph_breaks and is_lazy
+    if module._with_graph_breaks:
         module._break_graph = ht.core.mark_step
     return module
 

--- a/tests/unit_tests/test_fsdpa_slicing.py
+++ b/tests/unit_tests/test_fsdpa_slicing.py
@@ -60,6 +60,7 @@ def _make_config(**overrides):
         enable_fsdpa_slicing=True,
         bucketing_strategy='pad',
         merged_prefill=False,
+        use_bucketing=True,
     )
     defaults.update(overrides)
     return Config(defaults)
@@ -166,7 +167,7 @@ class TestEnableFsdpaSlicingFeature:
 
 
 class TestSetupSlicing:
-    """Tests for ModuleFusedSDPABase._setup_slicing method."""
+    """Tests for SlicedFusedSDPABase._setup_slicing method."""
 
     @patch('vllm_gaudi.extension.utils.get_config')
     @patch('vllm_gaudi.extension.bucketing.common.HPUBucketingManager.get_instance')
@@ -174,8 +175,8 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config(enable_fsdpa_slicing=False)
         mock_get_instance.return_value = None
 
-        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
-        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
+        base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         result = base._setup_slicing()
         assert result is False
 
@@ -185,8 +186,8 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config(bucketing_strategy='exp')
         mock_get_instance.return_value = None
 
-        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
-        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
+        base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         result = base._setup_slicing()
         assert result is False
 
@@ -196,8 +197,8 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config(merged_prefill=True)
         mock_get_instance.return_value = None
 
-        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
-        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
+        base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         result = base._setup_slicing()
         assert result is False
 
@@ -207,8 +208,8 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config()
         mock_get_instance.return_value = None
 
-        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
-        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
+        base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         with pytest.raises(AssertionError):
             base._setup_slicing()
 
@@ -218,8 +219,8 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config()
         mock_get_instance.return_value = _MockBucketingManager(initialized=False)
 
-        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
-        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
+        base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         with pytest.raises(AssertionError):
             base._setup_slicing()
 
@@ -230,8 +231,8 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config()
         mock_get_instance.return_value = _MockBucketingManager(strategy_cls=LinearBucketingStrategy)
 
-        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
-        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
+        base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         with pytest.raises(AssertionError):
             base._setup_slicing()
 
@@ -242,8 +243,8 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config()
         mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=128)
 
-        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
-        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
+        base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         result = base._setup_slicing()
         assert result is True
         assert base.slice_thld == 8192
@@ -257,8 +258,8 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config()
         mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=128)
 
-        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
-        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
+        base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         result = base._setup_slicing()
         assert result is True
         assert base._with_graph_breaks is True
@@ -270,8 +271,8 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config()
         mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=16384, block_size=128)
 
-        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
-        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
+        base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         result = base._setup_slicing()
         assert result is True
         assert base.slice_thld == 8192
@@ -283,8 +284,8 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config()
         mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=4096, block_size=128)
 
-        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
-        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
+        base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         result = base._setup_slicing()
         assert result is True
         assert base.slice_thld == 4096
@@ -298,8 +299,8 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config()
         mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=128)
 
-        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
-        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
+        base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         result = base._setup_slicing()
         assert result is True
         assert base.slice_thld == 16384
@@ -316,8 +317,8 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config()
         mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=128)
 
-        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
-        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
+        base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         result = base._setup_slicing()
         # threshold 4096 < default 8192 logs a warning but proceeds
         assert result is True
@@ -332,8 +333,8 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config()
         mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=128)
 
-        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
-        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
+        base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         result = base._setup_slicing()
         assert result is True
         assert base.chunk_size == 2048
@@ -344,10 +345,10 @@ class TestSetupSlicing:
     def test_chunk_size_too_small_raises(self, mock_get_instance, mock_get_config, mock_is_lazy, monkeypatch):
         monkeypatch.setenv("VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE", "64")
         mock_get_config.return_value = _make_config()
-        mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=128)
+        mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=1024)
 
-        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
-        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
+        base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         with pytest.raises(AssertionError):
             base._setup_slicing()
 
@@ -359,8 +360,8 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config()
         mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=128)
 
-        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
-        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
+        base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         with pytest.raises(AssertionError):
             base._setup_slicing()
 
@@ -372,8 +373,8 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config()
         mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=128)
 
-        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
-        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
+        base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         result = base._setup_slicing()
         assert result is True
         assert base.chunk_size == 2048  # ceil(1500/1024)*1024
@@ -385,8 +386,8 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config()
         mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=128)
 
-        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
-        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
+        base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         result = base._setup_slicing()
         assert result is True
 
@@ -408,8 +409,8 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config()
         mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=128)
 
-        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
-        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
+        base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         result = base._setup_slicing()
         assert result is True
         assert base._with_graph_breaks is True
@@ -431,18 +432,19 @@ class TestModuleFusedSDPAForwardDispatch:
         mock_kernel = MagicMock()
         mock_kernel.apply.return_value = torch.zeros(1, 4, 1024, 64)
 
-        with patch('vllm_gaudi.extension.utils.ModuleFusedSDPABase.__init__', return_value=None):
+        with patch('vllm_gaudi.extension.utils.SlicedFusedSDPABase.__init__', return_value=None):
             module = ModuleFusedSDPA.__new__(ModuleFusedSDPA)
             torch.nn.Module.__init__(module)
             module._hpu_kernel_fsdpa = mock_kernel
-            module.enable_slicing = enable_slicing
             if enable_slicing:
-                module.slice_thld = slice_thld
-                module.chunk_size = chunk_size
-                module.num_padded_query_chunks = 1
-                module.num_padded_ctx_chunks = 1
-                module._with_graph_breaks = False
-                module._sliced_module = MagicMock(return_value=torch.zeros(1, 4, 1024, 64))
+                mock_sliced = MagicMock(return_value=torch.zeros(1, 4, 1024, 64))
+                mock_sliced.enable_slicing = True
+                mock_sliced.slice_thld = slice_thld
+                module._sliced_module = mock_sliced
+            else:
+                mock_sliced = MagicMock()
+                mock_sliced.enable_slicing = False
+                module._sliced_module = mock_sliced
         return module
 
     def test_slicing_dispatched_when_conditions_met(self):
@@ -465,7 +467,6 @@ class TestModuleFusedSDPAForwardDispatch:
         v = torch.randn(1, 4, 8192, 64)
         mask = torch.zeros(1, 1, 2048, 8192)
 
-        assert not hasattr(module, '_sliced_module')
         module.forward(q, k, v, mask, 0.0, True, None, 'fast', True, None, padding_side='right')
         module._hpu_kernel_fsdpa.apply.assert_called_once()
 
@@ -477,9 +478,8 @@ class TestModuleFusedSDPAForwardDispatch:
         v = torch.randn(2, 4, 8192, 64)
         mask = torch.zeros(2, 1, 2048, 8192)
 
-        with patch.object(module, '_sliced_module') as mock_sliced:
-            module.forward(q, k, v, mask, 0.0, True, None, 'fast', True, None, padding_side='right')
-            mock_sliced.assert_not_called()
+        module.forward(q, k, v, mask, 0.0, True, None, 'fast', True, None, padding_side='right')
+        module._sliced_module.assert_not_called()
 
     def test_default_path_when_q_len_equals_kv_len(self):
         import torch
@@ -489,9 +489,8 @@ class TestModuleFusedSDPAForwardDispatch:
         v = torch.randn(1, 4, 4096, 64)
         mask = torch.zeros(1, 1, 4096, 4096)
 
-        with patch.object(module, '_sliced_module') as mock_sliced:
-            module.forward(q, k, v, mask, 0.0, True, None, 'fast', True, None, padding_side='right')
-            mock_sliced.assert_not_called()
+        module.forward(q, k, v, mask, 0.0, True, None, 'fast', True, None, padding_side='right')
+        module._sliced_module.assert_not_called()
 
     def test_default_path_when_not_causal(self):
         import torch
@@ -501,9 +500,8 @@ class TestModuleFusedSDPAForwardDispatch:
         v = torch.randn(1, 4, 8192, 64)
         mask = torch.zeros(1, 1, 2048, 8192)
 
-        with patch.object(module, '_sliced_module') as mock_sliced:
-            module.forward(q, k, v, mask, 0.0, False, None, 'fast', True, None, padding_side='right')
-            mock_sliced.assert_not_called()
+        module.forward(q, k, v, mask, 0.0, False, None, 'fast', True, None, padding_side='right')
+        module._sliced_module.assert_not_called()
 
     def test_default_path_when_no_attn_mask(self):
         import torch
@@ -512,9 +510,8 @@ class TestModuleFusedSDPAForwardDispatch:
         k = torch.randn(1, 4, 8192, 64)
         v = torch.randn(1, 4, 8192, 64)
 
-        with patch.object(module, '_sliced_module') as mock_sliced:
-            module.forward(q, k, v, None, 0.0, True, None, 'fast', True, None, padding_side='right')
-            mock_sliced.assert_not_called()
+        module.forward(q, k, v, None, 0.0, True, None, 'fast', True, None, padding_side='right')
+        module._sliced_module.assert_not_called()
 
     def test_default_path_when_padding_side_left(self):
         import torch
@@ -524,9 +521,8 @@ class TestModuleFusedSDPAForwardDispatch:
         v = torch.randn(1, 4, 8192, 64)
         mask = torch.zeros(1, 1, 2048, 8192)
 
-        with patch.object(module, '_sliced_module') as mock_sliced:
-            module.forward(q, k, v, mask, 0.0, True, None, 'fast', True, None, padding_side='left')
-            mock_sliced.assert_not_called()
+        module.forward(q, k, v, mask, 0.0, True, None, 'fast', True, None, padding_side='left')
+        module._sliced_module.assert_not_called()
 
     def test_default_path_with_window_size(self):
         import torch
@@ -536,20 +532,8 @@ class TestModuleFusedSDPAForwardDispatch:
         v = torch.randn(1, 4, 8192, 64)
         mask = torch.zeros(1, 1, 2048, 8192)
 
-        with patch.object(module, '_sliced_module') as mock_sliced:
-            module.forward(q,
-                           k,
-                           v,
-                           mask,
-                           0.0,
-                           True,
-                           None,
-                           'fast',
-                           True,
-                           None,
-                           padding_side='right',
-                           window_size=(512, 512))
-            mock_sliced.assert_not_called()
+        module.forward(q, k, v, mask, 0.0, True, None, 'fast', True, None, padding_side='right', window_size=(512, 512))
+        module._sliced_module.assert_not_called()
 
     def test_default_path_with_sinks(self):
         import torch
@@ -559,20 +543,19 @@ class TestModuleFusedSDPAForwardDispatch:
         v = torch.randn(1, 4, 8192, 64)
         mask = torch.zeros(1, 1, 2048, 8192)
 
-        with patch.object(module, '_sliced_module') as mock_sliced:
-            module.forward(q,
-                           k,
-                           v,
-                           mask,
-                           0.0,
-                           True,
-                           None,
-                           'fast',
-                           True,
-                           None,
-                           padding_side='right',
-                           sinks=torch.tensor([0, 1]))
-            mock_sliced.assert_not_called()
+        module.forward(q,
+                       k,
+                       v,
+                       mask,
+                       0.0,
+                       True,
+                       None,
+                       'fast',
+                       True,
+                       None,
+                       padding_side='right',
+                       sinks=torch.tensor([0, 1]))
+        module._sliced_module.assert_not_called()
 
     def test_default_path_when_kv_len_below_threshold(self):
         import torch
@@ -582,9 +565,8 @@ class TestModuleFusedSDPAForwardDispatch:
         v = torch.randn(1, 4, 4096, 64)
         mask = torch.zeros(1, 1, 2048, 4096)
 
-        with patch.object(module, '_sliced_module') as mock_sliced:
-            module.forward(q, k, v, mask, 0.0, True, None, 'fast', True, None, padding_side='right')
-            mock_sliced.assert_not_called()
+        module.forward(q, k, v, mask, 0.0, True, None, 'fast', True, None, padding_side='right')
+        module._sliced_module.assert_not_called()
 
     def test_causal_with_mask_clears_causal_on_default_path(self):
         """When slicing is not triggered but is_causal=True and attn_mask is set,
@@ -620,11 +602,10 @@ class TestModuleFP8FusedSDPAForwardDispatch:
         mock_kernel = MagicMock()
         mock_kernel.return_value = (torch.zeros(1, 4, 1024, 64), )
 
-        with patch('vllm_gaudi.extension.utils.ModuleFusedSDPABase.__init__', return_value=None):
+        with patch('vllm_gaudi.extension.utils.SlicedFusedSDPABase.__init__', return_value=None):
             module = ModuleFP8FusedSDPA.__new__(ModuleFP8FusedSDPA)
             torch.nn.Module.__init__(module)
             module.fp8_fused_sdpa = mock_kernel
-            module.enable_slicing = enable_slicing
             module.descale_amax = torch.tensor(1.0, dtype=torch.float32)
             module.scale_amax = torch.tensor(1.0, dtype=torch.float32)
             module.scale_q = torch.tensor(1.0, dtype=torch.float32)
@@ -635,12 +616,14 @@ class TestModuleFP8FusedSDPAForwardDispatch:
             module.d_scale_v = torch.tensor(1.0, dtype=torch.float32)
             module.d_scale_output = torch.tensor(1.0, dtype=torch.float32)
             if enable_slicing:
-                module.slice_thld = slice_thld
-                module.chunk_size = chunk_size
-                module.num_padded_query_chunks = 1
-                module.num_padded_ctx_chunks = 1
-                module._with_graph_breaks = False
-                module._sliced_module = MagicMock(return_value=torch.zeros(1, 4, 1024, 64))
+                mock_sliced = MagicMock(return_value=torch.zeros(1, 4, 1024, 64))
+                mock_sliced.enable_slicing = True
+                mock_sliced.slice_thld = slice_thld
+                module._sliced_module = mock_sliced
+            else:
+                mock_sliced = MagicMock()
+                mock_sliced.enable_slicing = False
+                module._sliced_module = mock_sliced
         return module
 
     def _patch_quant(self, module):
@@ -668,7 +651,6 @@ class TestModuleFP8FusedSDPAForwardDispatch:
         v = torch.randn(1, 4, 8192, 64)
         mask = torch.zeros(1, 1, 2048, 8192)
 
-        assert not hasattr(module, '_sliced_module')
         module.forward(q, k, v, mask, 0.0, True, None, 'fast', True, None, padding_side='right')
         module.fp8_fused_sdpa.assert_called_once()
 
@@ -680,9 +662,8 @@ class TestModuleFP8FusedSDPAForwardDispatch:
         v = torch.randn(2, 4, 8192, 64)
         mask = torch.zeros(2, 1, 2048, 8192)
 
-        with patch.object(module, '_sliced_module') as mock_sliced:
-            module.forward(q, k, v, mask, 0.0, True, None, 'fast', True, None, padding_side='right')
-            mock_sliced.assert_not_called()
+        module.forward(q, k, v, mask, 0.0, True, None, 'fast', True, None, padding_side='right')
+        module._sliced_module.assert_not_called()
 
     def test_default_path_with_window_size(self):
         import torch
@@ -692,20 +673,8 @@ class TestModuleFP8FusedSDPAForwardDispatch:
         v = torch.randn(1, 4, 8192, 64)
         mask = torch.zeros(1, 1, 2048, 8192)
 
-        with patch.object(module, '_sliced_module') as mock_sliced:
-            module.forward(q,
-                           k,
-                           v,
-                           mask,
-                           0.0,
-                           True,
-                           None,
-                           'fast',
-                           True,
-                           None,
-                           padding_side='right',
-                           window_size=(512, 512))
-            mock_sliced.assert_not_called()
+        module.forward(q, k, v, mask, 0.0, True, None, 'fast', True, None, padding_side='right', window_size=(512, 512))
+        module._sliced_module.assert_not_called()
 
     def test_d_scale_output_initialized(self):
         """Verify d_scale_output is properly initialized in __init__."""

--- a/tests/unit_tests/test_fsdpa_slicing.py
+++ b/tests/unit_tests/test_fsdpa_slicing.py
@@ -938,6 +938,33 @@ class TestFsdpaPromptAttentionCausalMask:
 # ---------------------------------------------------------------------------
 
 
+def _generate_realistic_qkv(bs,
+                            heads,
+                            kv_heads,
+                            head_dim,
+                            q_len_pad,
+                            kv_len_pad,
+                            device='hpu',
+                            dtype=torch.bfloat16,
+                            seed=42):
+    """Generate Q/K/V with peaked attention patterns simulating real model inference.
+
+    Real transformers produce attention logits (Q·K^T / sqrt(d)) with std ≈ 3-5,
+    creating peaked softmax distributions where each query attends strongly to a
+    few key positions.  Pure random unit-std Q/K produce logit std ≈ 1, yielding
+    near-uniform attention and near-zero output magnitudes.
+
+    Scaling Q by 3x restores realistic logit spread.  This produces peaked
+    attention (max_weight > 0.9) and meaningful output magnitudes, giving
+    SNR > 5 for FP8 and cos_sim > 0.99.
+    """
+    torch.manual_seed(seed)
+    q = torch.randn(bs, heads, q_len_pad, head_dim, dtype=dtype, device=device) * 3.0
+    k = torch.randn(bs, kv_heads, kv_len_pad, head_dim, dtype=dtype, device=device)
+    v = torch.randn(bs, kv_heads, kv_len_pad, head_dim, dtype=dtype, device=device)
+    return q, k, v
+
+
 def _build_causal_mask(valid_shape, pad_shape, device='hpu', dtype=torch.bfloat16):
     """Build a causal attention mask with prefix context and padding.
 
@@ -986,16 +1013,13 @@ _ACCURACY_SCRIPT = """\
 import torch, math, sys, json
 sys.path.insert(0, '.')
 from tests.unit_tests.test_fsdpa_slicing import (
-    TestFsdpaSlicingAccuracy{dtype}, _build_causal_mask)
+    TestFsdpaSlicingAccuracy{dtype}, _build_causal_mask, _generate_realistic_qkv)
 
 bs, heads, kv_heads, head_dim, pad = 1, 8, 2, 128, 128
 q_len, ctx_len, cs = {q_len}, {ctx_len}, {chunk_size}
-torch.manual_seed(42)
 qp, cp = q_len + pad, ctx_len + pad
 kvp = qp + cp
-q = torch.randn(bs, heads, qp, head_dim, dtype=torch.bfloat16, device='hpu')
-k = torch.randn(bs, kv_heads, kvp, head_dim, dtype=torch.bfloat16, device='hpu')
-v = torch.randn(bs, kv_heads, kvp, head_dim, dtype=torch.bfloat16, device='hpu')
+q, k, v = _generate_realistic_qkv(bs, heads, kv_heads, head_dim, qp, kvp, device='hpu')
 mask = _build_causal_mask((bs, q_len, ctx_len), (bs, qp, cp), device='hpu')
 
 ref_out = TestFsdpaSlicingAccuracy{dtype}._run_reference(q, k, v, mask)
@@ -1005,8 +1029,7 @@ sliced_out = TestFsdpaSlicingAccuracy{dtype}._run_sliced(
 
 cos_sim = torch.nn.functional.cosine_similarity(
     ref_out.flatten().float(), sliced_out.flatten().float(), dim=0).item()
-max_abs_diff = (ref_out.float() - sliced_out.float()).abs().max().item()
-print(json.dumps({{'cos_sim': cos_sim, 'max_abs_diff': max_abs_diff}}))
+print(json.dumps({{'cos_sim': cos_sim}}))
 """
 
 
@@ -1037,7 +1060,7 @@ def _run_accuracy_subprocess(dtype, q_len, ctx_len, chunk_size, graph_breaks, mo
     assert result.returncode == 0, (f"Subprocess failed (mode={mode}, lazy={lazy_mode}, dtype={dtype}):\n"
                                     f"{result.stderr[-500:]}")
     data = json.loads(result.stdout.strip().split('\n')[-1])
-    return data['cos_sim'], data['max_abs_diff']
+    return data['cos_sim']
 
 
 @requires_hpu
@@ -1099,9 +1122,8 @@ class TestFsdpaSlicingAccuracyBF16:
         if graph_breaks and mode == 'compile':
             pytest.skip('graph breaks are not supported with torch.compile')
         if mode in ('lazy', 'hpu_graph'):
-            cos_sim, max_abs_diff = _run_accuracy_subprocess('BF16', q_len, ctx_len, chunk_size, graph_breaks, mode)
+            cos_sim = _run_accuracy_subprocess('BF16', q_len, ctx_len, chunk_size, graph_breaks, mode)
         else:
-            torch.manual_seed(42)
             bs = 1
             heads = 8
             kv_heads = 2
@@ -1112,9 +1134,7 @@ class TestFsdpaSlicingAccuracyBF16:
             kv_len_pad = q_len_pad + ctx_len_pad
             slice_thld = kv_len_pad
 
-            q = torch.randn(bs, heads, q_len_pad, head_dim, dtype=torch.bfloat16, device='hpu')
-            k = torch.randn(bs, kv_heads, kv_len_pad, head_dim, dtype=torch.bfloat16, device='hpu')
-            v = torch.randn(bs, kv_heads, kv_len_pad, head_dim, dtype=torch.bfloat16, device='hpu')
+            q, k, v = _generate_realistic_qkv(bs, heads, kv_heads, head_dim, q_len_pad, kv_len_pad, device='hpu')
             attn_mask = _build_causal_mask((bs, q_len, ctx_len), (bs, q_len_pad, ctx_len_pad), device='hpu')
 
             ref_out = self._run_reference(q, k, v, attn_mask)
@@ -1132,10 +1152,8 @@ class TestFsdpaSlicingAccuracyBF16:
             cos_sim = torch.nn.functional.cosine_similarity(ref_out.flatten().float(),
                                                             sliced_out.flatten().float(),
                                                             dim=0).item()
-            max_abs_diff = (ref_out.float() - sliced_out.float()).abs().max().item()
 
-        assert cos_sim > 0.92, f"BF16 cosine similarity too low: {cos_sim}"
-        assert max_abs_diff < 0.45, f"BF16 max abs diff too large: {max_abs_diff}"
+        assert cos_sim > 0.95, f"BF16 cosine similarity too low: {cos_sim}"
 
 
 @requires_hpu
@@ -1215,9 +1233,8 @@ class TestFsdpaSlicingAccuracyFP8:
         if graph_breaks and mode == 'compile':
             pytest.skip('graph breaks are not supported with torch.compile')
         if mode in ('lazy', 'hpu_graph'):
-            cos_sim, max_abs_diff = _run_accuracy_subprocess('FP8', q_len, ctx_len, chunk_size, graph_breaks, mode)
+            cos_sim = _run_accuracy_subprocess('FP8', q_len, ctx_len, chunk_size, graph_breaks, mode)
         else:
-            torch.manual_seed(42)
             bs = 1
             heads = 8
             kv_heads = 2
@@ -1228,9 +1245,7 @@ class TestFsdpaSlicingAccuracyFP8:
             kv_len_pad = q_len_pad + ctx_len_pad
             slice_thld = kv_len_pad
 
-            q = torch.randn(bs, heads, q_len_pad, head_dim, dtype=torch.bfloat16, device='hpu')
-            k = torch.randn(bs, kv_heads, kv_len_pad, head_dim, dtype=torch.bfloat16, device='hpu')
-            v = torch.randn(bs, kv_heads, kv_len_pad, head_dim, dtype=torch.bfloat16, device='hpu')
+            q, k, v = _generate_realistic_qkv(bs, heads, kv_heads, head_dim, q_len_pad, kv_len_pad, device='hpu')
             attn_mask = _build_causal_mask((bs, q_len, ctx_len), (bs, q_len_pad, ctx_len_pad), device='hpu')
 
             ref_out = self._run_reference(q, k, v, attn_mask)
@@ -1248,10 +1263,8 @@ class TestFsdpaSlicingAccuracyFP8:
             cos_sim = torch.nn.functional.cosine_similarity(ref_out.flatten().float(),
                                                             sliced_out.flatten().float(),
                                                             dim=0).item()
-            max_abs_diff = (ref_out.float() - sliced_out.float()).abs().max().item()
 
-        assert cos_sim > 0.74, f"FP8 cosine similarity too low: {cos_sim}"
-        assert max_abs_diff < 0.45, f"FP8 max abs diff too large: {max_abs_diff}"
+        assert cos_sim > 0.94, f"FP8 cosine similarity too low: {cos_sim}"
 
 
 # ---------------------------------------------------------------------------
@@ -1264,16 +1277,13 @@ _GRAPH_COUNT_SCRIPT = """\
 import torch, math, sys, glob
 sys.path.insert(0, '.')
 from tests.unit_tests.test_fsdpa_slicing import (
-    TestFsdpaSlicingAccuracy{dtype}, _build_causal_mask)
+    TestFsdpaSlicingAccuracy{dtype}, _build_causal_mask, _generate_realistic_qkv)
 
 bs, heads, kv_heads, head_dim, pad = 1, 8, 2, 128, 128
 q_len, ctx_len, cs = 2048, 4096, 2048
-torch.manual_seed(42)
 qp, cp = q_len + pad, ctx_len + pad
 kvp = qp + cp
-q = torch.randn(bs, heads, qp, head_dim, dtype=torch.bfloat16, device='hpu')
-k = torch.randn(bs, kv_heads, kvp, head_dim, dtype=torch.bfloat16, device='hpu')
-v = torch.randn(bs, kv_heads, kvp, head_dim, dtype=torch.bfloat16, device='hpu')
+q, k, v = _generate_realistic_qkv(bs, heads, kv_heads, head_dim, qp, kvp, device='hpu')
 mask = _build_causal_mask((bs, q_len, ctx_len), (bs, qp, cp), device='hpu')
 out = TestFsdpaSlicingAccuracy{dtype}._run_sliced(
     q, k, v, mask, kvp, cs, pad, pad,

--- a/tests/unit_tests/test_fsdpa_slicing.py
+++ b/tests/unit_tests/test_fsdpa_slicing.py
@@ -444,9 +444,9 @@ class TestSetupSlicing:
     @patch('habana_frameworks.torch.utils.internal.is_lazy', return_value=False)
     @patch('vllm_gaudi.extension.utils.get_config')
     @patch('vllm_gaudi.extension.bucketing.common.HPUBucketingManager.get_instance')
-    def test_threshold_lte_1024_raises(self, mock_get_instance, mock_get_config, mock_is_lazy, monkeypatch):
-        """slice_thld must be greater than 1024."""
-        monkeypatch.setenv("VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD", "1024")
+    def test_threshold_lt_1024_raises(self, mock_get_instance, mock_get_config, mock_is_lazy, monkeypatch):
+        """slice_thld must be greater than or equal to 1024."""
+        monkeypatch.setenv("VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD", "512")
         mock_get_config.return_value = _make_config()
         mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=128)
 

--- a/tests/unit_tests/test_fsdpa_slicing.py
+++ b/tests/unit_tests/test_fsdpa_slicing.py
@@ -9,6 +9,7 @@ import math
 import torch
 import json
 import os
+import pathlib
 import shutil
 import subprocess
 import sys
@@ -890,6 +891,9 @@ print(json.dumps({{'cos_sim': cos_sim, 'max_abs_diff': max_abs_diff}}))
 def _run_accuracy_subprocess(dtype, q_len, ctx_len, chunk_size, graph_breaks, mode):
     """Run accuracy test in subprocess with appropriate PT_HPU_LAZY_MODE."""
     lazy_mode = 1 if mode in ('lazy', 'hpu_graph') else 0
+    # Resolve project root from this file's location so the subprocess
+    # can always find the ``tests`` package regardless of the caller's cwd.
+    project_root = str(pathlib.Path(__file__).resolve().parents[2])
     script = _ACCURACY_SCRIPT.format(
         dtype=dtype,
         q_len=q_len,
@@ -904,7 +908,7 @@ def _run_accuracy_subprocess(dtype, q_len, ctx_len, chunk_size, graph_breaks, mo
         [sys.executable, '-c', script],
         capture_output=True,
         text=True,
-        cwd=os.getcwd(),
+        cwd=project_root,
         env=env,
         timeout=120,
     )

--- a/tests/unit_tests/test_fsdpa_slicing.py
+++ b/tests/unit_tests/test_fsdpa_slicing.py
@@ -1,0 +1,1238 @@
+###############################################################################
+# Copyright (C) 2025 Intel Corporation
+#
+# This source code is licensed under the Apache 2.0 license found in the
+# LICENSE file in the root directory of this source tree.
+###############################################################################
+
+import math
+import torch
+import json
+import os
+import shutil
+import subprocess
+import sys
+import pytest
+from unittest.mock import patch, MagicMock
+
+from vllm_gaudi.extension.config import Config, Eq, All, Disabled, Kernel, Value, Env, boolean
+
+# ---------------------------------------------------------------------------
+# HPU availability check
+# ---------------------------------------------------------------------------
+
+
+def _hpu_available():
+    try:
+        import torch
+        return hasattr(torch, 'hpu') and torch.hpu.is_available()
+    except Exception:
+        return False
+
+
+requires_hpu = pytest.mark.skipif(not _hpu_available(), reason="HPU device not available")
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _MockBucketingManager:
+    """Lightweight mock for HPUBucketingManager."""
+
+    def __init__(self, initialized=True, max_num_batched_tokens=8192, block_size=128, strategy_cls=None):
+        self.initialized = initialized
+        self.max_num_batched_tokens = max_num_batched_tokens
+        self.block_size = block_size
+        self._strategy_cls = strategy_cls
+
+    def get_bucketing_strategy(self):
+        if self._strategy_cls is not None:
+            return self._strategy_cls()
+        from vllm_gaudi.extension.bucketing.padding_aware import PaddingAwareBucketingStrategy
+        return PaddingAwareBucketingStrategy()
+
+
+def _make_config(**overrides):
+    """Create a Config with sensible defaults for slicing tests."""
+    defaults = dict(
+        enable_fsdpa_slicing=True,
+        bucketing_strategy='pad',
+        merged_prefill=False,
+    )
+    defaults.update(overrides)
+    return Config(defaults)
+
+
+# ---------------------------------------------------------------------------
+# Feature flag tests
+# ---------------------------------------------------------------------------
+
+
+class TestEnableFsdpaSlicingFeature:
+    """Tests for the enable_fsdpa_slicing Value declaration in features.py."""
+
+    def _make_feature(self):
+
+        def fsdpa_loader():
+            return True  # simulate kernel available
+
+        return Value(
+            'enable_fsdpa_slicing',
+            All(Eq('bucketing_strategy', 'pad'), Disabled('merged_prefill'), Kernel(fsdpa_loader)),
+            env_var='VLLM_HPU_FSDPA_SLICE_ENABLED',
+            env_var_type=boolean,
+        )
+
+    def _make_cfg(self, **overrides):
+        """Create a Config with the VLLM_HPU_FSDPA_SLICE_ENABLED env flag registered."""
+        defaults = dict(bucketing_strategy='pad',
+                        merged_prefill=False,
+                        hw='gaudi3',
+                        VLLM_HPU_FSDPA_SLICE_ENABLED=Env('VLLM_HPU_FSDPA_SLICE_ENABLED', boolean))
+        defaults.update(overrides)
+        return Config(defaults)
+
+    def test_enabled_when_pad_no_merged_prefill_kernel_available(self):
+        feature = self._make_feature()
+        cfg = self._make_cfg()
+        assert feature(cfg) is True
+
+    def test_disabled_when_not_pad_strategy(self):
+        feature = self._make_feature()
+        cfg = self._make_cfg(bucketing_strategy='exp')
+        assert feature(cfg) is False
+
+    def test_disabled_when_lin_strategy(self):
+        feature = self._make_feature()
+        cfg = self._make_cfg(bucketing_strategy='lin')
+        assert feature(cfg) is False
+
+    def test_disabled_when_merged_prefill(self):
+        feature = self._make_feature()
+        cfg = self._make_cfg(merged_prefill=True)
+        assert feature(cfg) is False
+
+    def test_disabled_when_kernel_unavailable(self):
+
+        def no_kernel():
+            return None
+
+        feature = Value(
+            'enable_fsdpa_slicing',
+            All(Eq('bucketing_strategy', 'pad'), Disabled('merged_prefill'), Kernel(no_kernel)),
+            env_var='VLLM_HPU_FSDPA_SLICE_ENABLED',
+            env_var_type=boolean,
+        )
+        cfg = self._make_cfg()
+        assert feature(cfg) is False
+
+    def test_disabled_on_cpu(self):
+        feature = self._make_feature()
+        cfg = self._make_cfg(hw='cpu')
+        assert feature(cfg) is False
+
+    def test_env_override_disables(self, monkeypatch):
+        monkeypatch.setenv('VLLM_HPU_FSDPA_SLICE_ENABLED', 'false')
+        feature = self._make_feature()
+        env_flag = feature.to_env_flag()
+        cfg = Config({
+            'bucketing_strategy': 'pad',
+            'merged_prefill': False,
+            'hw': 'gaudi3',
+            'VLLM_HPU_FSDPA_SLICE_ENABLED': env_flag,
+            'enable_fsdpa_slicing': feature,
+        })
+        assert cfg.enable_fsdpa_slicing is False
+
+    def test_env_override_enables(self, monkeypatch):
+        monkeypatch.setenv('VLLM_HPU_FSDPA_SLICE_ENABLED', 'true')
+        feature = self._make_feature()
+        env_flag = feature.to_env_flag()
+        cfg = Config({
+            'bucketing_strategy': 'exp',
+            'merged_prefill': False,
+            'hw': 'gaudi3',
+            'VLLM_HPU_FSDPA_SLICE_ENABLED': env_flag,
+            'enable_fsdpa_slicing': feature,
+        })
+        assert cfg.enable_fsdpa_slicing is True
+
+
+# ---------------------------------------------------------------------------
+# _setup_slicing tests
+# ---------------------------------------------------------------------------
+
+
+class TestSetupSlicing:
+    """Tests for ModuleFusedSDPABase._setup_slicing method."""
+
+    @patch('vllm_gaudi.extension.utils.get_config')
+    @patch('vllm_gaudi.extension.bucketing.common.HPUBucketingManager.get_instance')
+    def test_disabled_when_feature_flag_off(self, mock_get_instance, mock_get_config):
+        mock_get_config.return_value = _make_config(enable_fsdpa_slicing=False)
+        mock_get_instance.return_value = None
+
+        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
+        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        result = base._setup_slicing()
+        assert result is False
+
+    @patch('vllm_gaudi.extension.utils.get_config')
+    @patch('vllm_gaudi.extension.bucketing.common.HPUBucketingManager.get_instance')
+    def test_disabled_when_not_pad_strategy(self, mock_get_instance, mock_get_config):
+        mock_get_config.return_value = _make_config(bucketing_strategy='exp')
+        mock_get_instance.return_value = None
+
+        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
+        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        result = base._setup_slicing()
+        assert result is False
+
+    @patch('vllm_gaudi.extension.utils.get_config')
+    @patch('vllm_gaudi.extension.bucketing.common.HPUBucketingManager.get_instance')
+    def test_disabled_when_merged_prefill(self, mock_get_instance, mock_get_config):
+        mock_get_config.return_value = _make_config(merged_prefill=True)
+        mock_get_instance.return_value = None
+
+        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
+        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        result = base._setup_slicing()
+        assert result is False
+
+    @patch('vllm_gaudi.extension.utils.get_config')
+    @patch('vllm_gaudi.extension.bucketing.common.HPUBucketingManager.get_instance')
+    def test_raises_when_bucketing_manager_none(self, mock_get_instance, mock_get_config):
+        mock_get_config.return_value = _make_config()
+        mock_get_instance.return_value = None
+
+        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
+        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        with pytest.raises(AssertionError):
+            base._setup_slicing()
+
+    @patch('vllm_gaudi.extension.utils.get_config')
+    @patch('vllm_gaudi.extension.bucketing.common.HPUBucketingManager.get_instance')
+    def test_raises_when_manager_not_initialized(self, mock_get_instance, mock_get_config):
+        mock_get_config.return_value = _make_config()
+        mock_get_instance.return_value = _MockBucketingManager(initialized=False)
+
+        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
+        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        with pytest.raises(AssertionError):
+            base._setup_slicing()
+
+    @patch('vllm_gaudi.extension.utils.get_config')
+    @patch('vllm_gaudi.extension.bucketing.common.HPUBucketingManager.get_instance')
+    def test_raises_when_not_padding_aware_strategy(self, mock_get_instance, mock_get_config):
+        from vllm_gaudi.extension.bucketing.linear import LinearBucketingStrategy
+        mock_get_config.return_value = _make_config()
+        mock_get_instance.return_value = _MockBucketingManager(strategy_cls=LinearBucketingStrategy)
+
+        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
+        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        with pytest.raises(AssertionError):
+            base._setup_slicing()
+
+    @patch('habana_frameworks.torch.utils.internal.is_lazy', return_value=False)
+    @patch('vllm_gaudi.extension.utils.get_config')
+    @patch('vllm_gaudi.extension.bucketing.common.HPUBucketingManager.get_instance')
+    def test_enabled_with_defaults(self, mock_get_instance, mock_get_config, mock_is_lazy):
+        mock_get_config.return_value = _make_config()
+        mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=128)
+
+        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
+        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        result = base._setup_slicing()
+        assert result is True
+        assert base.slice_thld == 8192
+        assert base.chunk_size == 4096
+        assert base._with_graph_breaks is False
+
+    @patch('habana_frameworks.torch.utils.internal.is_lazy', return_value=True)
+    @patch('vllm_gaudi.extension.utils.get_config')
+    @patch('vllm_gaudi.extension.bucketing.common.HPUBucketingManager.get_instance')
+    def test_graph_breaks_enabled_in_lazy_mode(self, mock_get_instance, mock_get_config, mock_is_lazy):
+        mock_get_config.return_value = _make_config()
+        mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=128)
+
+        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
+        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        result = base._setup_slicing()
+        assert result is True
+        assert base._with_graph_breaks is True
+
+    @patch('habana_frameworks.torch.utils.internal.is_lazy', return_value=False)
+    @patch('vllm_gaudi.extension.utils.get_config')
+    @patch('vllm_gaudi.extension.bucketing.common.HPUBucketingManager.get_instance')
+    def test_threshold_default_capped_by_8192(self, mock_get_instance, mock_get_config, mock_is_lazy):
+        mock_get_config.return_value = _make_config()
+        mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=16384, block_size=128)
+
+        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
+        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        result = base._setup_slicing()
+        assert result is True
+        assert base.slice_thld == 8192
+
+    @patch('habana_frameworks.torch.utils.internal.is_lazy', return_value=False)
+    @patch('vllm_gaudi.extension.utils.get_config')
+    @patch('vllm_gaudi.extension.bucketing.common.HPUBucketingManager.get_instance')
+    def test_threshold_uses_max_batched_tokens_when_smaller(self, mock_get_instance, mock_get_config, mock_is_lazy):
+        mock_get_config.return_value = _make_config()
+        mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=4096, block_size=128)
+
+        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
+        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        result = base._setup_slicing()
+        assert result is True
+        assert base.slice_thld == 4096
+        assert base.chunk_size == 2048
+
+    @patch('habana_frameworks.torch.utils.internal.is_lazy', return_value=False)
+    @patch('vllm_gaudi.extension.utils.get_config')
+    @patch('vllm_gaudi.extension.bucketing.common.HPUBucketingManager.get_instance')
+    def test_custom_threshold_from_env(self, mock_get_instance, mock_get_config, mock_is_lazy, monkeypatch):
+        monkeypatch.setenv("VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD", "16384")
+        mock_get_config.return_value = _make_config()
+        mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=128)
+
+        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
+        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        result = base._setup_slicing()
+        assert result is True
+        assert base.slice_thld == 16384
+        # chunk_size = ceil(16384 // 2 / 1024) * 1024 = 8192
+        assert base.chunk_size == 8192
+
+    @patch('habana_frameworks.torch.utils.internal.is_lazy', return_value=False)
+    @patch('vllm_gaudi.extension.utils.get_config')
+    @patch('vllm_gaudi.extension.bucketing.common.HPUBucketingManager.get_instance')
+    def test_threshold_below_default_warns_but_proceeds(self, mock_get_instance, mock_get_config, mock_is_lazy,
+                                                        monkeypatch):
+        """Threshold below default logs a warning but still proceeds."""
+        monkeypatch.setenv("VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD", "4096")
+        mock_get_config.return_value = _make_config()
+        mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=128)
+
+        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
+        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        result = base._setup_slicing()
+        # threshold 4096 < default 8192 logs a warning but proceeds
+        assert result is True
+        assert base.slice_thld == 4096
+        assert base.chunk_size == 2048
+
+    @patch('habana_frameworks.torch.utils.internal.is_lazy', return_value=False)
+    @patch('vllm_gaudi.extension.utils.get_config')
+    @patch('vllm_gaudi.extension.bucketing.common.HPUBucketingManager.get_instance')
+    def test_custom_chunk_size_from_env(self, mock_get_instance, mock_get_config, mock_is_lazy, monkeypatch):
+        monkeypatch.setenv("VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE", "2048")
+        mock_get_config.return_value = _make_config()
+        mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=128)
+
+        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
+        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        result = base._setup_slicing()
+        assert result is True
+        assert base.chunk_size == 2048
+
+    @patch('habana_frameworks.torch.utils.internal.is_lazy', return_value=False)
+    @patch('vllm_gaudi.extension.utils.get_config')
+    @patch('vllm_gaudi.extension.bucketing.common.HPUBucketingManager.get_instance')
+    def test_chunk_size_too_small_raises(self, mock_get_instance, mock_get_config, mock_is_lazy, monkeypatch):
+        monkeypatch.setenv("VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE", "64")
+        mock_get_config.return_value = _make_config()
+        mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=128)
+
+        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
+        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        with pytest.raises(AssertionError):
+            base._setup_slicing()
+
+    @patch('habana_frameworks.torch.utils.internal.is_lazy', return_value=False)
+    @patch('vllm_gaudi.extension.utils.get_config')
+    @patch('vllm_gaudi.extension.bucketing.common.HPUBucketingManager.get_instance')
+    def test_chunk_size_too_large_raises(self, mock_get_instance, mock_get_config, mock_is_lazy, monkeypatch):
+        monkeypatch.setenv("VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE", "16384")
+        mock_get_config.return_value = _make_config()
+        mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=128)
+
+        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
+        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        with pytest.raises(AssertionError):
+            base._setup_slicing()
+
+    @patch('habana_frameworks.torch.utils.internal.is_lazy', return_value=False)
+    @patch('vllm_gaudi.extension.utils.get_config')
+    @patch('vllm_gaudi.extension.bucketing.common.HPUBucketingManager.get_instance')
+    def test_chunk_size_rounded_up_to_1024(self, mock_get_instance, mock_get_config, mock_is_lazy, monkeypatch):
+        monkeypatch.setenv("VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE", "1500")
+        mock_get_config.return_value = _make_config()
+        mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=128)
+
+        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
+        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        result = base._setup_slicing()
+        assert result is True
+        assert base.chunk_size == 2048  # ceil(1500/1024)*1024
+
+    @patch('habana_frameworks.torch.utils.internal.is_lazy', return_value=False)
+    @patch('vllm_gaudi.extension.utils.get_config')
+    @patch('vllm_gaudi.extension.bucketing.common.HPUBucketingManager.get_instance')
+    def test_num_padded_chunks_computation(self, mock_get_instance, mock_get_config, mock_is_lazy):
+        mock_get_config.return_value = _make_config()
+        mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=128)
+
+        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
+        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        result = base._setup_slicing()
+        assert result is True
+
+        # num_padded_query_chunks = ceil(max_query_pad / chunk_size)
+        # max_query_pad = ceil(8192 / 4) = 2048, chunk_size = 4096
+        # => ceil(2048 / 4096) = 1
+        assert base.num_padded_query_chunks == 1
+
+        # num_padded_ctx_chunks = ceil(max_ctx_pad * block_size / chunk_size)
+        # max_ctx_pad = ceil(8192 / 128) = 64, block_size = 128, chunk_size = 4096
+        # => ceil(64 * 128 / 4096) = ceil(2) = 2
+        assert base.num_padded_ctx_chunks == 2
+
+    @patch('habana_frameworks.torch.utils.internal.is_lazy', return_value=False)
+    @patch('vllm_gaudi.extension.utils.get_config')
+    @patch('vllm_gaudi.extension.bucketing.common.HPUBucketingManager.get_instance')
+    def test_graph_breaks_override_from_env(self, mock_get_instance, mock_get_config, mock_is_lazy, monkeypatch):
+        monkeypatch.setenv("VLLM_HPU_FSDPA_SLICE_WITH_GRAPH_BREAKS", "true")
+        mock_get_config.return_value = _make_config()
+        mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=128)
+
+        from vllm_gaudi.extension.utils import ModuleFusedSDPABase
+        base = ModuleFusedSDPABase.__new__(ModuleFusedSDPABase)
+        result = base._setup_slicing()
+        assert result is True
+        assert base._with_graph_breaks is True
+
+
+# ---------------------------------------------------------------------------
+# ModuleFusedSDPA.forward dispatch tests
+# ---------------------------------------------------------------------------
+
+
+class TestModuleFusedSDPAForwardDispatch:
+    """Tests that forward dispatches to _sliced_module versus the default path correctly."""
+
+    def _make_module(self, enable_slicing=True, slice_thld=4096, chunk_size=2048):
+        """Create a ModuleFusedSDPA with slicing attributes set directly."""
+        import torch
+        from vllm_gaudi.extension.utils import ModuleFusedSDPA
+
+        mock_kernel = MagicMock()
+        mock_kernel.apply.return_value = torch.zeros(1, 4, 1024, 64)
+
+        with patch('vllm_gaudi.extension.utils.ModuleFusedSDPABase.__init__', return_value=None):
+            module = ModuleFusedSDPA.__new__(ModuleFusedSDPA)
+            torch.nn.Module.__init__(module)
+            module._hpu_kernel_fsdpa = mock_kernel
+            module.enable_slicing = enable_slicing
+            if enable_slicing:
+                module.slice_thld = slice_thld
+                module.chunk_size = chunk_size
+                module.num_padded_query_chunks = 1
+                module.num_padded_ctx_chunks = 1
+                module._with_graph_breaks = False
+                module._sliced_module = MagicMock(return_value=torch.zeros(1, 4, 1024, 64))
+        return module
+
+    def test_slicing_dispatched_when_conditions_met(self):
+        import torch
+        module = self._make_module()
+        q = torch.randn(1, 4, 2048, 64)  # bs=1, heads=4, q_len=2048
+        k = torch.randn(1, 4, 8192, 64)  # kv_len=8192 >= threshold
+        v = torch.randn(1, 4, 8192, 64)
+        mask = torch.zeros(1, 1, 2048, 8192)
+
+        module._sliced_module.return_value = torch.zeros(1, 4, 2048, 64)
+        module.forward(q, k, v, mask, 0.0, True, None, 'fast', True, None, padding_side='right')
+        module._sliced_module.assert_called_once()
+
+    def test_default_path_when_slicing_disabled(self):
+        import torch
+        module = self._make_module(enable_slicing=False)
+        q = torch.randn(1, 4, 2048, 64)
+        k = torch.randn(1, 4, 8192, 64)
+        v = torch.randn(1, 4, 8192, 64)
+        mask = torch.zeros(1, 1, 2048, 8192)
+
+        assert not hasattr(module, '_sliced_module')
+        module.forward(q, k, v, mask, 0.0, True, None, 'fast', True, None, padding_side='right')
+        module._hpu_kernel_fsdpa.apply.assert_called_once()
+
+    def test_default_path_when_bs_not_1(self):
+        import torch
+        module = self._make_module()
+        q = torch.randn(2, 4, 2048, 64)  # bs=2
+        k = torch.randn(2, 4, 8192, 64)
+        v = torch.randn(2, 4, 8192, 64)
+        mask = torch.zeros(2, 1, 2048, 8192)
+
+        with patch.object(module, '_sliced_module') as mock_sliced:
+            module.forward(q, k, v, mask, 0.0, True, None, 'fast', True, None, padding_side='right')
+            mock_sliced.assert_not_called()
+
+    def test_default_path_when_q_len_equals_kv_len(self):
+        import torch
+        module = self._make_module()
+        q = torch.randn(1, 4, 4096, 64)
+        k = torch.randn(1, 4, 4096, 64)  # q_len == kv_len
+        v = torch.randn(1, 4, 4096, 64)
+        mask = torch.zeros(1, 1, 4096, 4096)
+
+        with patch.object(module, '_sliced_module') as mock_sliced:
+            module.forward(q, k, v, mask, 0.0, True, None, 'fast', True, None, padding_side='right')
+            mock_sliced.assert_not_called()
+
+    def test_default_path_when_not_causal(self):
+        import torch
+        module = self._make_module()
+        q = torch.randn(1, 4, 2048, 64)
+        k = torch.randn(1, 4, 8192, 64)
+        v = torch.randn(1, 4, 8192, 64)
+        mask = torch.zeros(1, 1, 2048, 8192)
+
+        with patch.object(module, '_sliced_module') as mock_sliced:
+            module.forward(q, k, v, mask, 0.0, False, None, 'fast', True, None, padding_side='right')
+            mock_sliced.assert_not_called()
+
+    def test_default_path_when_no_attn_mask(self):
+        import torch
+        module = self._make_module()
+        q = torch.randn(1, 4, 2048, 64)
+        k = torch.randn(1, 4, 8192, 64)
+        v = torch.randn(1, 4, 8192, 64)
+
+        with patch.object(module, '_sliced_module') as mock_sliced:
+            module.forward(q, k, v, None, 0.0, True, None, 'fast', True, None, padding_side='right')
+            mock_sliced.assert_not_called()
+
+    def test_default_path_when_padding_side_left(self):
+        import torch
+        module = self._make_module()
+        q = torch.randn(1, 4, 2048, 64)
+        k = torch.randn(1, 4, 8192, 64)
+        v = torch.randn(1, 4, 8192, 64)
+        mask = torch.zeros(1, 1, 2048, 8192)
+
+        with patch.object(module, '_sliced_module') as mock_sliced:
+            module.forward(q, k, v, mask, 0.0, True, None, 'fast', True, None, padding_side='left')
+            mock_sliced.assert_not_called()
+
+    def test_default_path_with_window_size(self):
+        import torch
+        module = self._make_module()
+        q = torch.randn(1, 4, 2048, 64)
+        k = torch.randn(1, 4, 8192, 64)
+        v = torch.randn(1, 4, 8192, 64)
+        mask = torch.zeros(1, 1, 2048, 8192)
+
+        with patch.object(module, '_sliced_module') as mock_sliced:
+            module.forward(q,
+                           k,
+                           v,
+                           mask,
+                           0.0,
+                           True,
+                           None,
+                           'fast',
+                           True,
+                           None,
+                           padding_side='right',
+                           window_size=(512, 512))
+            mock_sliced.assert_not_called()
+
+    def test_default_path_with_sinks(self):
+        import torch
+        module = self._make_module()
+        q = torch.randn(1, 4, 2048, 64)
+        k = torch.randn(1, 4, 8192, 64)
+        v = torch.randn(1, 4, 8192, 64)
+        mask = torch.zeros(1, 1, 2048, 8192)
+
+        with patch.object(module, '_sliced_module') as mock_sliced:
+            module.forward(q,
+                           k,
+                           v,
+                           mask,
+                           0.0,
+                           True,
+                           None,
+                           'fast',
+                           True,
+                           None,
+                           padding_side='right',
+                           sinks=torch.tensor([0, 1]))
+            mock_sliced.assert_not_called()
+
+    def test_default_path_when_kv_len_below_threshold(self):
+        import torch
+        module = self._make_module(slice_thld=8192)
+        q = torch.randn(1, 4, 2048, 64)
+        k = torch.randn(1, 4, 4096, 64)  # kv_len=4096 < threshold=8192
+        v = torch.randn(1, 4, 4096, 64)
+        mask = torch.zeros(1, 1, 2048, 4096)
+
+        with patch.object(module, '_sliced_module') as mock_sliced:
+            module.forward(q, k, v, mask, 0.0, True, None, 'fast', True, None, padding_side='right')
+            mock_sliced.assert_not_called()
+
+    def test_causal_with_mask_clears_causal_on_default_path(self):
+        """When slicing is not triggered but is_causal=True and attn_mask is set,
+        the default path should clear is_causal and valid_sequence_lengths."""
+        import torch
+        module = self._make_module(enable_slicing=False)
+        q = torch.randn(1, 4, 2048, 64)
+        k = torch.randn(1, 4, 8192, 64)
+        v = torch.randn(1, 4, 8192, 64)
+        mask = torch.zeros(1, 1, 2048, 8192)
+        valid_seq = torch.tensor([2048])
+
+        module.forward(q, k, v, mask, 0.0, True, None, 'fast', True, valid_seq, padding_side='right')
+        call_args = module._hpu_kernel_fsdpa.apply.call_args[0]
+        # is_causal should be False (6th positional arg, index 5)
+        assert call_args[5] is False
+        # valid_sequence_lengths should be None (10th positional arg, index 9)
+        assert call_args[9] is None
+
+
+# ---------------------------------------------------------------------------
+# ModuleFP8FusedSDPA.forward dispatch tests
+# ---------------------------------------------------------------------------
+
+
+class TestModuleFP8FusedSDPAForwardDispatch:
+    """Tests that FP8 forward dispatches correctly."""
+
+    def _make_module(self, enable_slicing=True, slice_thld=4096, chunk_size=2048):
+        import torch
+        from vllm_gaudi.extension.utils import ModuleFP8FusedSDPA
+
+        mock_kernel = MagicMock()
+        mock_kernel.return_value = (torch.zeros(1, 4, 1024, 64), )
+
+        with patch('vllm_gaudi.extension.utils.ModuleFusedSDPABase.__init__', return_value=None):
+            module = ModuleFP8FusedSDPA.__new__(ModuleFP8FusedSDPA)
+            torch.nn.Module.__init__(module)
+            module.fp8_fused_sdpa = mock_kernel
+            module.enable_slicing = enable_slicing
+            module.descale_amax = torch.tensor(1.0, dtype=torch.float32)
+            module.scale_amax = torch.tensor(1.0, dtype=torch.float32)
+            module.scale_q = torch.tensor(1.0, dtype=torch.float32)
+            module.scale_k = torch.tensor(1.0, dtype=torch.float32)
+            module.scale_v = torch.tensor(1.0, dtype=torch.float32)
+            module.d_scale_q = torch.tensor(1.0, dtype=torch.float32)
+            module.d_scale_k = torch.tensor(1.0, dtype=torch.float32)
+            module.d_scale_v = torch.tensor(1.0, dtype=torch.float32)
+            module.d_scale_output = torch.tensor(1.0, dtype=torch.float32)
+            if enable_slicing:
+                module.slice_thld = slice_thld
+                module.chunk_size = chunk_size
+                module.num_padded_query_chunks = 1
+                module.num_padded_ctx_chunks = 1
+                module._with_graph_breaks = False
+                module._sliced_module = MagicMock(return_value=torch.zeros(1, 4, 1024, 64))
+        return module
+
+    def _patch_quant(self, module):
+        """Patch quant_input to be a pass-through for testing dispatch."""
+        module.quant_input = lambda x, scale: x
+        return module
+
+    def test_slicing_dispatched_when_conditions_met(self):
+        import torch
+        module = self._patch_quant(self._make_module())
+        q = torch.randn(1, 4, 2048, 64)
+        k = torch.randn(1, 4, 8192, 64)
+        v = torch.randn(1, 4, 8192, 64)
+        mask = torch.zeros(1, 1, 2048, 8192)
+
+        module._sliced_module.return_value = torch.zeros(1, 4, 2048, 64)
+        module.forward(q, k, v, mask, 0.0, True, None, 'fast', True, None, padding_side='right')
+        module._sliced_module.assert_called_once()
+
+    def test_default_path_when_slicing_disabled(self):
+        import torch
+        module = self._patch_quant(self._make_module(enable_slicing=False))
+        q = torch.randn(1, 4, 2048, 64)
+        k = torch.randn(1, 4, 8192, 64)
+        v = torch.randn(1, 4, 8192, 64)
+        mask = torch.zeros(1, 1, 2048, 8192)
+
+        assert not hasattr(module, '_sliced_module')
+        module.forward(q, k, v, mask, 0.0, True, None, 'fast', True, None, padding_side='right')
+        module.fp8_fused_sdpa.assert_called_once()
+
+    def test_default_path_when_bs_not_1(self):
+        import torch
+        module = self._patch_quant(self._make_module())
+        q = torch.randn(2, 4, 2048, 64)
+        k = torch.randn(2, 4, 8192, 64)
+        v = torch.randn(2, 4, 8192, 64)
+        mask = torch.zeros(2, 1, 2048, 8192)
+
+        with patch.object(module, '_sliced_module') as mock_sliced:
+            module.forward(q, k, v, mask, 0.0, True, None, 'fast', True, None, padding_side='right')
+            mock_sliced.assert_not_called()
+
+    def test_default_path_with_window_size(self):
+        import torch
+        module = self._patch_quant(self._make_module())
+        q = torch.randn(1, 4, 2048, 64)
+        k = torch.randn(1, 4, 8192, 64)
+        v = torch.randn(1, 4, 8192, 64)
+        mask = torch.zeros(1, 1, 2048, 8192)
+
+        with patch.object(module, '_sliced_module') as mock_sliced:
+            module.forward(q,
+                           k,
+                           v,
+                           mask,
+                           0.0,
+                           True,
+                           None,
+                           'fast',
+                           True,
+                           None,
+                           padding_side='right',
+                           window_size=(512, 512))
+            mock_sliced.assert_not_called()
+
+    def test_d_scale_output_initialized(self):
+        """Verify d_scale_output is properly initialized in __init__."""
+        module = self._make_module()
+        assert hasattr(module, 'd_scale_output')
+        assert module.d_scale_output.item() == 1.0
+
+    def test_causal_with_mask_clears_causal_on_default_path(self):
+        import torch
+        module = self._patch_quant(self._make_module(enable_slicing=False))
+        q = torch.randn(1, 4, 2048, 64)
+        k = torch.randn(1, 4, 8192, 64)
+        v = torch.randn(1, 4, 8192, 64)
+        mask = torch.zeros(1, 1, 2048, 8192)
+
+        module.forward(q, k, v, mask, 0.0, True, None, 'fast', True, None, padding_side='right')
+        call_kwargs = module.fp8_fused_sdpa.call_args[1]
+        assert call_kwargs['is_causal'] is False
+        assert call_kwargs['valid_seq_len'] is None
+
+
+# ---------------------------------------------------------------------------
+# User flag registration tests
+# ---------------------------------------------------------------------------
+
+
+class TestFsdpaSlicingUserFlags:
+    """Tests for the FSDPA slicing env flags registered in features.py."""
+
+    def test_slicing_env_flags_registered(self):
+        from vllm_gaudi.extension.features import get_user_flags
+        flags = get_user_flags()
+        assert 'VLLM_HPU_FSDPA_SLICE_ENABLED' in flags
+        assert 'VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD' in flags
+        assert 'VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE' in flags
+        assert 'VLLM_HPU_FSDPA_SLICE_WITH_GRAPH_BREAKS' in flags
+
+    def test_slice_enabled_flag_is_boolean(self):
+        from vllm_gaudi.extension.features import get_user_flags
+        flags = get_user_flags()
+        flag = flags['VLLM_HPU_FSDPA_SLICE_ENABLED']
+        assert flag.value_type is boolean
+
+    def test_slice_thld_flag_is_int(self):
+        from vllm_gaudi.extension.features import get_user_flags
+        flags = get_user_flags()
+        flag = flags['VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD']
+        assert flag.value_type is int
+
+    def test_slice_chunk_size_flag_is_int(self):
+        from vllm_gaudi.extension.features import get_user_flags
+        flags = get_user_flags()
+        flag = flags['VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE']
+        assert flag.value_type is int
+
+    def test_enable_fsdpa_slicing_feature_registered(self):
+        from vllm_gaudi.extension.features import get_features
+        values, flags = get_features()
+        assert 'enable_fsdpa_slicing' in values
+        assert 'VLLM_HPU_FSDPA_SLICE_ENABLED' in flags
+
+
+# ---------------------------------------------------------------------------
+# ops.py: _fsdpa_prompt_attention causal+mask path test
+# ---------------------------------------------------------------------------
+
+
+class TestFsdpaPromptAttentionCausalMask:
+    """Test that _fsdpa_prompt_attention no longer strips causal+mask."""
+
+    def test_causal_and_mask_passed_through(self):
+        """After removal of the workaround, is_causal and attn_bias should
+        both be forwarded to the fsdpa kernel when both are provided."""
+        import torch
+        from unittest.mock import MagicMock
+
+        mock_fsdpa_op = MagicMock(return_value=torch.randn(1, 4, 2048, 64))
+
+        with patch('vllm_gaudi.extension.ops.get_config') as mock_cfg:
+            cfg = MagicMock()
+            cfg.fp32_softmax = False
+            mock_cfg.return_value = cfg
+
+            from vllm_gaudi.extension.ops import _fsdpa_prompt_attention
+
+            q = torch.randn(1, 2048, 4, 64)  # before transpose: [bs, seq, heads, dim]
+            k = torch.randn(1, 2048, 4, 64)
+            v = torch.randn(1, 2048, 4, 64)
+            bias = torch.zeros(1, 1, 2048, 2048)
+
+            _fsdpa_prompt_attention(query=q,
+                                    key=k,
+                                    value=v,
+                                    scale=0.125,
+                                    fsdpa_op=mock_fsdpa_op,
+                                    is_causal=True,
+                                    attn_bias=bias)
+
+            call_args = mock_fsdpa_op.call_args[0]
+            # attn_bias (index 3) should be the bias tensor, not None
+            assert call_args[3] is not None
+            # is_causal (index 5) should still be True
+            assert call_args[5] is True
+
+
+# ---------------------------------------------------------------------------
+# Accuracy tests on HPU
+# ---------------------------------------------------------------------------
+
+
+def _build_causal_mask(valid_shape, pad_shape, device='hpu', dtype=torch.bfloat16):
+    """Build a causal attention mask with prefix context and padding.
+
+    Follows ``get_attention_mask`` from ``profile_fsdpa_apc.py``.
+
+    Args:
+        valid_shape: ``(bs, q_len, ctx_len)`` – valid (unpadded) lengths.
+        pad_shape: ``(bs_pad, q_len_pad, ctx_len_pad)`` – padded lengths.
+
+    Returns:
+        attn_bias of shape ``(bs_pad, 1, q_len_pad, q_len_pad + ctx_len_pad)``
+        where masked positions are filled with ``-3e38`` and valid positions
+        are ``0``.
+    """
+    _, q_len, ctx_len = valid_shape
+    bs_pad, q_len_pad, ctx_len_pad = pad_shape
+    off_value = -3e38  # finite value to avoid nan in exp() during chunk rescaling
+
+    context_len_t = torch.tensor([ctx_len], dtype=torch.int32, device=device)
+    query_lens_t = torch.tensor([q_len], dtype=torch.int32, device=device)
+
+    # Mask for past context – positions >= ctx_len in the context portion
+    past_mask = torch.arange(0, ctx_len_pad, dtype=torch.int32, device=device)
+    past_mask = (past_mask.view(1, -1).expand(bs_pad, -1).ge(context_len_t.view(-1, 1)).view(bs_pad, 1, -1).expand(
+        bs_pad, q_len_pad, -1).view(bs_pad, 1, q_len_pad, -1))
+
+    # Mask for query length – positions >= q_len in the query portion
+    len_mask = (torch.arange(0, q_len_pad, device=device, dtype=torch.int32).view(1, q_len_pad).ge(
+        query_lens_t.unsqueeze(-1)).view(bs_pad, 1, 1, q_len_pad))
+
+    # Upper-triangular causal mask for the query portion
+    attn_mask = torch.triu(torch.ones((bs_pad, 1, q_len_pad, q_len_pad), device=device, dtype=torch.bool), diagonal=1)
+    mask = attn_mask.logical_or(len_mask)
+
+    mask = torch.cat([past_mask, mask], dim=-1)
+    attn_bias = torch.zeros_like(mask, dtype=dtype).masked_fill_(mask, off_value)
+    assert attn_bias.shape == (bs_pad, 1, q_len_pad, q_len_pad + ctx_len_pad)
+    return attn_bias
+
+
+# ---------------------------------------------------------------------------
+# Subprocess helper for lazy-mode accuracy tests
+# ---------------------------------------------------------------------------
+
+_ACCURACY_SCRIPT = """\
+import torch, math, sys, json
+sys.path.insert(0, '.')
+from tests.unit_tests.test_fsdpa_slicing import (
+    TestFsdpaSlicingAccuracy{dtype}, _build_causal_mask)
+
+bs, heads, kv_heads, head_dim, pad = 1, 8, 2, 128, 128
+q_len, ctx_len, cs = {q_len}, {ctx_len}, {chunk_size}
+torch.manual_seed(42)
+qp, cp = q_len + pad, ctx_len + pad
+kvp = qp + cp
+q = torch.randn(bs, heads, qp, head_dim, dtype=torch.bfloat16, device='hpu')
+k = torch.randn(bs, kv_heads, kvp, head_dim, dtype=torch.bfloat16, device='hpu')
+v = torch.randn(bs, kv_heads, kvp, head_dim, dtype=torch.bfloat16, device='hpu')
+mask = _build_causal_mask((bs, q_len, ctx_len), (bs, qp, cp), device='hpu')
+
+ref_out = TestFsdpaSlicingAccuracy{dtype}._run_reference(q, k, v, mask)
+sliced_out = TestFsdpaSlicingAccuracy{dtype}._run_sliced(
+    q, k, v, mask, kvp, cs, pad, pad,
+    graph_breaks={graph_breaks}, mode='{mode}')
+
+cos_sim = torch.nn.functional.cosine_similarity(
+    ref_out.flatten().float(), sliced_out.flatten().float(), dim=0).item()
+max_abs_diff = (ref_out.float() - sliced_out.float()).abs().max().item()
+print(json.dumps({{'cos_sim': cos_sim, 'max_abs_diff': max_abs_diff}}))
+"""
+
+
+def _run_accuracy_subprocess(dtype, q_len, ctx_len, chunk_size, graph_breaks, mode):
+    """Run accuracy test in subprocess with appropriate PT_HPU_LAZY_MODE."""
+    lazy_mode = 1 if mode in ('lazy', 'hpu_graph') else 0
+    script = _ACCURACY_SCRIPT.format(
+        dtype=dtype,
+        q_len=q_len,
+        ctx_len=ctx_len,
+        chunk_size=chunk_size,
+        graph_breaks=graph_breaks,
+        mode=mode,
+    )
+    env = os.environ.copy()
+    env['PT_HPU_LAZY_MODE'] = str(lazy_mode)
+    result = subprocess.run(
+        [sys.executable, '-c', script],
+        capture_output=True,
+        text=True,
+        cwd=os.getcwd(),
+        env=env,
+        timeout=120,
+    )
+    assert result.returncode == 0, (f"Subprocess failed (mode={mode}, lazy={lazy_mode}, dtype={dtype}):\n"
+                                    f"{result.stderr[-500:]}")
+    data = json.loads(result.stdout.strip().split('\n')[-1])
+    return data['cos_sim'], data['max_abs_diff']
+
+
+@requires_hpu
+class TestFsdpaSlicingAccuracyBF16:
+    """Compare BF16 FusedSDPA output with slicing enabled vs disabled on HPU.
+
+    Reference uses FusedSDPA.apply with is_causal=False and the full mask
+    (equivalent to BucketSDPA_bf16_origin in the profile script).
+    Sliced uses SlicedFusedSDPA which chunks the
+    is_causal=True+mask operation.
+    """
+
+    @staticmethod
+    def _run_reference(q, k, v, attn_mask):
+        """Non-sliced reference: single FusedSDPA call with full mask."""
+        from habana_frameworks.torch.hpex.kernels import FusedSDPA
+        with torch.inference_mode():
+            output = FusedSDPA.apply(
+                q,
+                k,
+                v,
+                attn_mask,
+                0.0,  # dropout_p
+                False,  # is_causal (mask encodes causality)
+                None,  # scale
+                'fast',  # softmax_mode
+                True,  # recompute_mode
+                None,  # valid_sequence_lengths
+                'right',  # padding_side
+            )
+        torch.hpu.synchronize()
+        return output
+
+    @staticmethod
+    def _run_sliced(q, k, v, attn_mask, slice_thld, chunk_size, q_pad, ctx_pad, graph_breaks=False, mode='eager'):
+        """Sliced path via SlicedFusedSDPA module."""
+        from vllm_gaudi.extension.utils import SlicedFusedSDPA
+        module = SlicedFusedSDPA(chunk_size, math.ceil(q_pad / chunk_size), math.ceil(ctx_pad / chunk_size),
+                                 graph_breaks)
+        module = module.to('hpu')
+        if mode == 'compile':
+            torch._dynamo.reset()
+            module = torch.compile(module, backend='hpu_backend')
+        elif mode == 'hpu_graph':
+            import habana_frameworks.torch as ht
+            module = ht.hpu.wrap_in_hpu_graph(module)
+        with torch.inference_mode():
+            output = module(q, k, v, attn_mask, 0.0, True, None, 'fast')
+        torch.hpu.synchronize()
+        return output
+
+    @pytest.mark.parametrize("mode", ["eager", "compile", "lazy", "hpu_graph"],
+                             ids=["eager", "compile", "lazy", "hpu_graph"])
+    @pytest.mark.parametrize("graph_breaks", [False, True], ids=["no_gb", "gb"])
+    @pytest.mark.parametrize("q_len,ctx_len,chunk_size", [
+        (2048, 2048, 1024),
+        (2048, 4096, 2048),
+        (4096, 4096, 2048),
+        (1024, 8192, 4096),
+    ])
+    def test_bf16_accuracy(self, q_len, ctx_len, chunk_size, graph_breaks, mode):
+        if mode in ('lazy', 'hpu_graph'):
+            cos_sim, max_abs_diff = _run_accuracy_subprocess('BF16', q_len, ctx_len, chunk_size, graph_breaks, mode)
+        else:
+            torch.manual_seed(42)
+            bs = 1
+            heads = 8
+            kv_heads = 2
+            head_dim = 128
+            pad = 128
+            q_len_pad = q_len + pad
+            ctx_len_pad = ctx_len + pad
+            kv_len_pad = q_len_pad + ctx_len_pad
+            slice_thld = kv_len_pad
+
+            q = torch.randn(bs, heads, q_len_pad, head_dim, dtype=torch.bfloat16, device='hpu')
+            k = torch.randn(bs, kv_heads, kv_len_pad, head_dim, dtype=torch.bfloat16, device='hpu')
+            v = torch.randn(bs, kv_heads, kv_len_pad, head_dim, dtype=torch.bfloat16, device='hpu')
+            attn_mask = _build_causal_mask((bs, q_len, ctx_len), (bs, q_len_pad, ctx_len_pad), device='hpu')
+
+            ref_out = self._run_reference(q, k, v, attn_mask)
+            sliced_out = self._run_sliced(q,
+                                          k,
+                                          v,
+                                          attn_mask,
+                                          slice_thld=slice_thld,
+                                          chunk_size=chunk_size,
+                                          q_pad=pad,
+                                          ctx_pad=pad,
+                                          graph_breaks=graph_breaks,
+                                          mode=mode)
+
+            cos_sim = torch.nn.functional.cosine_similarity(ref_out.flatten().float(),
+                                                            sliced_out.flatten().float(),
+                                                            dim=0).item()
+            max_abs_diff = (ref_out.float() - sliced_out.float()).abs().max().item()
+
+        assert cos_sim > 0.92, f"BF16 cosine similarity too low: {cos_sim}"
+        assert max_abs_diff < 0.45, f"BF16 max abs diff too large: {max_abs_diff}"
+
+
+@requires_hpu
+class TestFsdpaSlicingAccuracyFP8:
+    """Compare FP8 FusedSDPA sliced output against BF16 ground truth on HPU.
+
+    Reference uses BF16 FusedSDPA.apply (ground truth) because the FP8
+    single-call kernel itself quantises its output to FP8, introducing
+    significant noise at attention-output magnitudes.  The sliced path
+    dequantises each chunk output to BF16/FP32 before merging, so it is
+    actually closer to the BF16 truth than a single FP8 call.
+    """
+
+    @staticmethod
+    def _run_reference(q, k, v, attn_mask):
+        """BF16 ground-truth reference: single FusedSDPA call with full mask."""
+        from habana_frameworks.torch.hpex.kernels import FusedSDPA
+        with torch.inference_mode():
+            output = FusedSDPA.apply(
+                q,
+                k,
+                v,
+                attn_mask,
+                0.0,  # dropout_p
+                False,  # is_causal (mask encodes causality)
+                None,  # scale
+                'fast',  # softmax_mode
+                True,  # recompute_mode
+                None,  # valid_sequence_lengths
+                'right',  # padding_side
+            )
+        torch.hpu.synchronize()
+        return output
+
+    @staticmethod
+    def _run_sliced(q, k, v, attn_mask, slice_thld, chunk_size, q_pad, ctx_pad, graph_breaks=False, mode='eager'):
+        """Sliced path via SlicedFP8FusedSDPA module.
+
+        Uses dynamic_quant for FP8 quantization following FP8BucketSDPA.__init__
+        in profile_fsdpa_apc.py.
+        """
+        from vllm_gaudi.extension.utils import SlicedFP8FusedSDPA
+        from vllm_gaudi.extension.ops import dynamic_quant
+
+        q_fp8, scale_q = dynamic_quant(q, single_scale=True)
+        k_fp8, scale_k = dynamic_quant(k, single_scale=True)
+        v_fp8, scale_v = dynamic_quant(v, single_scale=True)
+
+        module = SlicedFP8FusedSDPA(chunk_size,
+                                    math.ceil(q_pad / chunk_size),
+                                    math.ceil(ctx_pad / chunk_size),
+                                    d_scale_q=scale_q.to(torch.float32),
+                                    d_scale_k=scale_k.to(torch.float32),
+                                    d_scale_v=scale_v.to(torch.float32),
+                                    d_scale_output=torch.tensor([1.0], dtype=torch.float32, device='hpu'),
+                                    scale_amax=torch.tensor([1.0], dtype=torch.float32, device='hpu'),
+                                    descale_amax=torch.tensor([1.0], dtype=torch.float32, device='hpu'),
+                                    with_graph_breaks=graph_breaks)
+        module = module.to('hpu')
+        if mode == 'compile':
+            torch._dynamo.reset()
+            module = torch.compile(module, backend='hpu_backend')
+        elif mode == 'hpu_graph':
+            import habana_frameworks.torch as ht
+            module = ht.hpu.wrap_in_hpu_graph(module)
+        with torch.inference_mode():
+            output = module(q_fp8, k_fp8, v_fp8, attn_mask, 0.0, True, None, 'fast')
+        torch.hpu.synchronize()
+        return output.to(q.dtype)
+
+    @pytest.mark.parametrize("mode", ["eager", "compile", "lazy", "hpu_graph"],
+                             ids=["eager", "compile", "lazy", "hpu_graph"])
+    @pytest.mark.parametrize("graph_breaks", [False, True], ids=["no_gb", "gb"])
+    @pytest.mark.parametrize("q_len,ctx_len,chunk_size", [
+        (2048, 2048, 1024),
+        (2048, 4096, 2048),
+        (4096, 4096, 2048),
+        (1024, 8192, 4096),
+    ])
+    def test_fp8_accuracy(self, q_len, ctx_len, chunk_size, graph_breaks, mode):
+        if mode == 'compile' and graph_breaks:
+            pytest.skip("FP8 fp8_sdpa_recomp_fwd not supported across "
+                        "graph break boundaries in torch.compile")
+        if mode in ('lazy', 'hpu_graph'):
+            cos_sim, max_abs_diff = _run_accuracy_subprocess('FP8', q_len, ctx_len, chunk_size, graph_breaks, mode)
+        else:
+            torch.manual_seed(42)
+            bs = 1
+            heads = 8
+            kv_heads = 2
+            head_dim = 128
+            pad = 128
+            q_len_pad = q_len + pad
+            ctx_len_pad = ctx_len + pad
+            kv_len_pad = q_len_pad + ctx_len_pad
+            slice_thld = kv_len_pad
+
+            q = torch.randn(bs, heads, q_len_pad, head_dim, dtype=torch.bfloat16, device='hpu')
+            k = torch.randn(bs, kv_heads, kv_len_pad, head_dim, dtype=torch.bfloat16, device='hpu')
+            v = torch.randn(bs, kv_heads, kv_len_pad, head_dim, dtype=torch.bfloat16, device='hpu')
+            attn_mask = _build_causal_mask((bs, q_len, ctx_len), (bs, q_len_pad, ctx_len_pad), device='hpu')
+
+            ref_out = self._run_reference(q, k, v, attn_mask)
+            sliced_out = self._run_sliced(q,
+                                          k,
+                                          v,
+                                          attn_mask,
+                                          slice_thld=slice_thld,
+                                          chunk_size=chunk_size,
+                                          q_pad=pad,
+                                          ctx_pad=pad,
+                                          graph_breaks=graph_breaks,
+                                          mode=mode)
+
+            cos_sim = torch.nn.functional.cosine_similarity(ref_out.flatten().float(),
+                                                            sliced_out.flatten().float(),
+                                                            dim=0).item()
+            max_abs_diff = (ref_out.float() - sliced_out.float()).abs().max().item()
+
+        assert cos_sim > 0.74, f"FP8 cosine similarity too low: {cos_sim}"
+        assert max_abs_diff < 0.45, f"FP8 max abs diff too large: {max_abs_diff}"
+
+
+# ---------------------------------------------------------------------------
+# Graph break verification tests
+# ---------------------------------------------------------------------------
+
+# Helper script template executed in a subprocess so that GRAPH_VISUALIZATION
+# and PT_HPU_LAZY_MODE can be set before the Habana runtime initialises.
+_GRAPH_COUNT_SCRIPT = """\
+import torch, math, sys, glob
+sys.path.insert(0, '.')
+from tests.unit_tests.test_fsdpa_slicing import (
+    TestFsdpaSlicingAccuracy{dtype}, _build_causal_mask)
+
+bs, heads, kv_heads, head_dim, pad = 1, 8, 2, 128, 128
+q_len, ctx_len, cs = 2048, 4096, 2048
+torch.manual_seed(42)
+qp, cp = q_len + pad, ctx_len + pad
+kvp = qp + cp
+q = torch.randn(bs, heads, qp, head_dim, dtype=torch.bfloat16, device='hpu')
+k = torch.randn(bs, kv_heads, kvp, head_dim, dtype=torch.bfloat16, device='hpu')
+v = torch.randn(bs, kv_heads, kvp, head_dim, dtype=torch.bfloat16, device='hpu')
+mask = _build_causal_mask((bs, q_len, ctx_len), (bs, qp, cp), device='hpu')
+out = TestFsdpaSlicingAccuracy{dtype}._run_sliced(
+    q, k, v, mask, kvp, cs, pad, pad,
+    graph_breaks={graph_breaks}, mode='{mode}')
+print(len(glob.glob('.graph_dumps/*PreGraph*')))
+"""
+
+
+def _count_graphs(lazy_mode: int, graph_breaks: bool, dtype: str = "BF16", mode: str = 'eager') -> int:
+    """Run slicing in a subprocess with GRAPH_VISUALIZATION=1 and return graph count."""
+    dump_dir = os.path.join(os.getcwd(), '.graph_dumps')
+    if os.path.isdir(dump_dir):
+        shutil.rmtree(dump_dir)
+
+    script = _GRAPH_COUNT_SCRIPT.format(
+        dtype=dtype,
+        graph_breaks=graph_breaks,
+        mode=mode,
+    )
+    env = os.environ.copy()
+    env['GRAPH_VISUALIZATION'] = '1'
+    env['PT_HPU_LAZY_MODE'] = str(lazy_mode)
+    result = subprocess.run(
+        [sys.executable, '-c', script],
+        capture_output=True,
+        text=True,
+        cwd=os.getcwd(),
+        env=env,
+        timeout=120,
+    )
+    assert result.returncode == 0, (f"Subprocess failed (lazy={lazy_mode}, gb={graph_breaks}, "
+                                    f"mode={mode}, dtype={dtype}):\n"
+                                    f"{result.stderr[-500:]}")
+    return int(result.stdout.strip().split('\n')[-1])
+
+
+@requires_hpu
+class TestGraphBreaksSplitGraphs:
+    """Verify that graph_breaks=True splits the monolithic lazy graph into
+    multiple smaller, reusable chunk-level graphs.
+
+    In lazy mode (PT_HPU_LAZY_MODE=1), ``ht.core.mark_step`` is called
+    between chunks, materialising each chunk as a separate Synapse graph.
+    This produces *more* graph dumps than the single monolithic graph
+    compiled without graph breaks, but the individual graphs are small
+    and can be reused across different bucket sizes.
+
+    In eager mode (PT_HPU_LAZY_MODE=0), ``torch._dynamo.graph_break`` is
+    a no-op outside ``torch.compile``, so the graph count is unchanged.
+
+    In eager + torch.compile mode, ``torch._dynamo.graph_break`` forces
+    TorchDynamo to split the traced graph at each call site, producing
+    more compiled graph segments.
+    """
+
+    @pytest.mark.parametrize("dtype", ["BF16", "FP8"])
+    def test_lazy_graph_breaks_split_graphs(self, dtype):
+        """In lazy mode, graph_breaks should split into more graphs."""
+        n_no_gb = _count_graphs(lazy_mode=1, graph_breaks=False, dtype=dtype, mode='lazy')
+        n_gb = _count_graphs(lazy_mode=1, graph_breaks=True, dtype=dtype, mode='lazy')
+        assert n_no_gb == 1, (f"Expected 1 monolithic graph without graph breaks, got {n_no_gb}")
+        assert n_gb > n_no_gb, (f"graph_breaks should split lazy graph into more chunks: "
+                                f"{n_gb} (gb) should be > {n_no_gb} (no gb)")
+
+    @pytest.mark.parametrize("dtype", ["BF16", "FP8"])
+    def test_eager_graph_breaks_no_effect(self, dtype):
+        """In eager mode without torch.compile, graph_break is a no-op."""
+        n_no_gb = _count_graphs(lazy_mode=0, graph_breaks=False, dtype=dtype)
+        n_gb = _count_graphs(lazy_mode=0, graph_breaks=True, dtype=dtype)
+        assert n_gb == n_no_gb, (f"graph_breaks should not affect eager graph count: "
+                                 f"{n_gb} (gb) != {n_no_gb} (no gb)")
+
+    @pytest.mark.parametrize("dtype", ["BF16", "FP8"])
+    def test_compile_graph_breaks_split_graphs(self, dtype):
+        """In eager + torch.compile mode, graph_breaks should split graphs."""
+        n_no_gb = _count_graphs(lazy_mode=0, graph_breaks=False, dtype=dtype, mode='compile')
+        if dtype == "FP8":
+            pytest.skip("FP8 fp8_sdpa_recomp_fwd not supported across "
+                        "graph break boundaries in torch.compile")
+        n_gb = _count_graphs(lazy_mode=0, graph_breaks=True, dtype=dtype, mode='compile')
+        assert n_gb > n_no_gb, (f"graph_breaks should split compiled graph into more segments: "
+                                f"{n_gb} (gb) should be > {n_no_gb} (no gb)")

--- a/tests/unit_tests/test_fsdpa_slicing.py
+++ b/tests/unit_tests/test_fsdpa_slicing.py
@@ -405,7 +405,9 @@ class TestSetupSlicing:
     @patch('habana_frameworks.torch.utils.internal.is_lazy', return_value=False)
     @patch('vllm_gaudi.extension.utils.get_config')
     @patch('vllm_gaudi.extension.bucketing.common.HPUBucketingManager.get_instance')
-    def test_graph_breaks_override_from_env(self, mock_get_instance, mock_get_config, mock_is_lazy, monkeypatch):
+    def test_graph_breaks_override_from_env_ignored_in_eager(self, mock_get_instance, mock_get_config, mock_is_lazy,
+                                                             monkeypatch):
+        """Env override to enable graph breaks is ignored in non-lazy mode."""
         monkeypatch.setenv("VLLM_HPU_FSDPA_SLICE_WITH_GRAPH_BREAKS", "true")
         mock_get_config.return_value = _make_config()
         mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=128)
@@ -414,7 +416,7 @@ class TestSetupSlicing:
         base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         result = base._setup_slicing()
         assert result is True
-        assert base._with_graph_breaks is True
+        assert base._with_graph_breaks is False
 
     @patch('vllm_gaudi.extension.utils.get_config')
     @patch('vllm_gaudi.extension.bucketing.common.HPUBucketingManager.get_instance')
@@ -474,10 +476,7 @@ def _make_sliced_bf16(chunk_size, num_padded_query_chunks=0, num_padded_ctx_chun
     module._with_graph_breaks = with_graph_breaks
     if with_graph_breaks:
         import habana_frameworks.torch as ht
-        if ht.utils.internal.is_lazy():
-            module._break_graph = ht.core.mark_step
-        else:
-            module._break_graph = torch._dynamo.graph_break
+        module._break_graph = ht.core.mark_step
     return module
 
 
@@ -522,10 +521,7 @@ def _make_sliced_fp8(chunk_size,
     module._with_graph_breaks = with_graph_breaks
     if with_graph_breaks:
         import habana_frameworks.torch as ht
-        if ht.utils.internal.is_lazy():
-            module._break_graph = ht.core.mark_step
-        else:
-            module._break_graph = torch._dynamo.graph_break
+        module._break_graph = ht.core.mark_step
     return module
 
 
@@ -1146,6 +1142,8 @@ class TestFsdpaSlicingAccuracyBF16:
         (1024, 8192, 4096),
     ])
     def test_bf16_accuracy(self, q_len, ctx_len, chunk_size, graph_breaks, mode):
+        if graph_breaks and mode == 'compile':
+            pytest.skip('graph breaks are not supported with torch.compile')
         if mode in ('lazy', 'hpu_graph'):
             cos_sim, max_abs_diff = _run_accuracy_subprocess('BF16', q_len, ctx_len, chunk_size, graph_breaks, mode)
         else:
@@ -1263,9 +1261,8 @@ class TestFsdpaSlicingAccuracyFP8:
         (1024, 8192, 4096),
     ])
     def test_fp8_accuracy(self, q_len, ctx_len, chunk_size, graph_breaks, mode):
-        if mode == 'compile' and graph_breaks:
-            pytest.skip("FP8 fp8_sdpa_recomp_fwd not supported across "
-                        "graph break boundaries in torch.compile")
+        if graph_breaks and mode == 'compile':
+            pytest.skip('graph breaks are not supported with torch.compile')
         if mode in ('lazy', 'hpu_graph'):
             cos_sim, max_abs_diff = _run_accuracy_subprocess('FP8', q_len, ctx_len, chunk_size, graph_breaks, mode)
         else:
@@ -1377,9 +1374,10 @@ class TestGraphBreaksSplitGraphs:
     In eager mode (PT_HPU_LAZY_MODE=0), ``torch._dynamo.graph_break`` is
     a no-op outside ``torch.compile``, so the graph count is unchanged.
 
-    In eager + torch.compile mode, ``torch._dynamo.graph_break`` forces
-    TorchDynamo to split the traced graph at each call site, producing
-    more compiled graph segments.
+    Graph breaks are not supported in ``torch.compile`` mode because the
+    Synapse compiler cannot create ``fp8_sdpa_recomp_fwd`` nodes in
+    standalone graph segments produced by TorchDynamo re-entry after a
+    graph break.  The constraint is enforced in ``_setup_slicing``.
     """
 
     @pytest.mark.parametrize("dtype", ["BF16", "FP8"])
@@ -1400,12 +1398,7 @@ class TestGraphBreaksSplitGraphs:
                                  f"{n_gb} (gb) != {n_no_gb} (no gb)")
 
     @pytest.mark.parametrize("dtype", ["BF16", "FP8"])
-    def test_compile_graph_breaks_split_graphs(self, dtype):
-        """In eager + torch.compile mode, graph_breaks should split graphs."""
+    def test_compile_no_graph_breaks(self, dtype):
+        """In compile mode, graph breaks are disabled; verify single graph."""
         n_no_gb = _count_graphs(lazy_mode=0, graph_breaks=False, dtype=dtype, mode='compile')
-        if dtype == "FP8":
-            pytest.skip("FP8 fp8_sdpa_recomp_fwd not supported across "
-                        "graph break boundaries in torch.compile")
-        n_gb = _count_graphs(lazy_mode=0, graph_breaks=True, dtype=dtype, mode='compile')
-        assert n_gb > n_no_gb, (f"graph_breaks should split compiled graph into more segments: "
-                                f"{n_gb} (gb) should be > {n_no_gb} (no gb)")
+        assert n_no_gb >= 1, f"Expected at least 1 compiled graph, got {n_no_gb}"

--- a/tests/unit_tests/test_fsdpa_slicing.py
+++ b/tests/unit_tests/test_fsdpa_slicing.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 ###############################################################################
-# Copyright (C) 2025 Intel Corporation
+# Copyright (C) 2026 Intel Corporation
 #
 # This source code is licensed under the Apache 2.0 license found in the
 # LICENSE file in the root directory of this source tree.

--- a/tests/unit_tests/test_fsdpa_slicing.py
+++ b/tests/unit_tests/test_fsdpa_slicing.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 ###############################################################################
 # Copyright (C) 2025 Intel Corporation
 #

--- a/tests/unit_tests/test_fsdpa_slicing.py
+++ b/tests/unit_tests/test_fsdpa_slicing.py
@@ -17,7 +17,21 @@ import sys
 import pytest
 from unittest.mock import patch, MagicMock
 
+import habana_frameworks.torch as ht
+from habana_frameworks.torch.hpex.kernels import FusedSDPA
+
+from vllm_gaudi.extension.bucketing.linear import LinearBucketingStrategy
+from vllm_gaudi.extension.bucketing.padding_aware import PaddingAwareBucketingStrategy
 from vllm_gaudi.extension.config import Config, Eq, All, Disabled, Kernel, Value, Env, boolean
+from vllm_gaudi.extension.features import get_user_flags, get_features
+from vllm_gaudi.extension.ops import _fsdpa_prompt_attention, dynamic_quant
+from vllm_gaudi.extension.utils import (
+    ModuleFP8FusedSDPA,
+    ModuleFusedSDPA,
+    SlicedFP8FusedSDPA,
+    SlicedFusedSDPA,
+    SlicedFusedSDPABase,
+)
 
 # ---------------------------------------------------------------------------
 # HPU availability check
@@ -26,7 +40,6 @@ from vllm_gaudi.extension.config import Config, Eq, All, Disabled, Kernel, Value
 
 def _hpu_available():
     try:
-        import torch
         return hasattr(torch, 'hpu') and torch.hpu.is_available()
     except Exception:
         return False
@@ -51,7 +64,6 @@ class _MockBucketingManager:
     def get_bucketing_strategy(self):
         if self._strategy_cls is not None:
             return self._strategy_cls()
-        from vllm_gaudi.extension.bucketing.padding_aware import PaddingAwareBucketingStrategy
         return PaddingAwareBucketingStrategy()
 
 
@@ -176,7 +188,6 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config(enable_fsdpa_slicing=False)
         mock_get_instance.return_value = None
 
-        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
         base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         result = base._setup_slicing()
         assert result is False
@@ -187,7 +198,6 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config(bucketing_strategy='exp')
         mock_get_instance.return_value = None
 
-        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
         base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         result = base._setup_slicing()
         assert result is False
@@ -198,7 +208,6 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config(merged_prefill=True)
         mock_get_instance.return_value = None
 
-        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
         base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         result = base._setup_slicing()
         assert result is False
@@ -209,7 +218,6 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config()
         mock_get_instance.return_value = None
 
-        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
         base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         with pytest.raises(AssertionError):
             base._setup_slicing()
@@ -220,7 +228,6 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config()
         mock_get_instance.return_value = _MockBucketingManager(initialized=False)
 
-        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
         base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         with pytest.raises(AssertionError):
             base._setup_slicing()
@@ -228,11 +235,9 @@ class TestSetupSlicing:
     @patch('vllm_gaudi.extension.utils.get_config')
     @patch('vllm_gaudi.extension.bucketing.common.HPUBucketingManager.get_instance')
     def test_raises_when_not_padding_aware_strategy(self, mock_get_instance, mock_get_config):
-        from vllm_gaudi.extension.bucketing.linear import LinearBucketingStrategy
         mock_get_config.return_value = _make_config()
         mock_get_instance.return_value = _MockBucketingManager(strategy_cls=LinearBucketingStrategy)
 
-        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
         base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         with pytest.raises(AssertionError):
             base._setup_slicing()
@@ -244,7 +249,6 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config()
         mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=128)
 
-        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
         base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         result = base._setup_slicing()
         assert result is True
@@ -259,7 +263,6 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config()
         mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=128)
 
-        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
         base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         result = base._setup_slicing()
         assert result is True
@@ -272,7 +275,6 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config()
         mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=16384, block_size=128)
 
-        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
         base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         result = base._setup_slicing()
         assert result is True
@@ -285,7 +287,6 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config()
         mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=4096, block_size=128)
 
-        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
         base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         result = base._setup_slicing()
         assert result is True
@@ -300,7 +301,6 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config()
         mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=128)
 
-        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
         base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         result = base._setup_slicing()
         assert result is True
@@ -318,7 +318,6 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config()
         mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=128)
 
-        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
         base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         result = base._setup_slicing()
         # threshold 4096 < default 8192 logs a warning but proceeds
@@ -334,7 +333,6 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config()
         mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=128)
 
-        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
         base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         result = base._setup_slicing()
         assert result is True
@@ -348,7 +346,6 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config()
         mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=1024)
 
-        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
         base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         with pytest.raises(AssertionError):
             base._setup_slicing()
@@ -361,7 +358,6 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config()
         mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=128)
 
-        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
         base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         with pytest.raises(AssertionError):
             base._setup_slicing()
@@ -374,7 +370,6 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config()
         mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=128)
 
-        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
         base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         result = base._setup_slicing()
         assert result is True
@@ -387,7 +382,6 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config()
         mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=128)
 
-        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
         base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         result = base._setup_slicing()
         assert result is True
@@ -412,7 +406,6 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config()
         mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=128)
 
-        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
         base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         result = base._setup_slicing()
         assert result is True
@@ -424,7 +417,6 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config(use_bucketing=False)
         mock_get_instance.return_value = None
 
-        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
         base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         result = base._setup_slicing()
         assert result is False
@@ -438,7 +430,6 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config()
         mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=128)
 
-        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
         base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         with pytest.raises(AssertionError):
             base._setup_slicing()
@@ -452,7 +443,6 @@ class TestSetupSlicing:
         mock_get_config.return_value = _make_config()
         mock_get_instance.return_value = _MockBucketingManager(max_num_batched_tokens=8192, block_size=128)
 
-        from vllm_gaudi.extension.utils import SlicedFusedSDPABase
         base = SlicedFusedSDPABase.__new__(SlicedFusedSDPABase)
         with pytest.raises(AssertionError):
             base._setup_slicing()
@@ -465,7 +455,6 @@ class TestSetupSlicing:
 
 def _make_sliced_bf16(chunk_size, num_padded_query_chunks=0, num_padded_ctx_chunks=0, with_graph_breaks=False):
     """Build a SlicedFusedSDPA bypassing _setup_slicing (for testing / HPU accuracy)."""
-    from vllm_gaudi.extension.utils import SlicedFusedSDPA
     with patch('vllm_gaudi.extension.utils.SlicedFusedSDPABase._setup_slicing', return_value=True):
         module = SlicedFusedSDPA()
     module.enable_slicing = True
@@ -492,7 +481,6 @@ def _make_sliced_fp8(chunk_size,
                      descale_amax,
                      with_graph_breaks=False):
     """Build a SlicedFP8FusedSDPA bypassing _setup_slicing (for testing / HPU accuracy)."""
-    from vllm_gaudi.extension.utils import SlicedFP8FusedSDPA
 
     # Create a lightweight parent-like namespace to hold scale tensors
     class _ScaleHolder:
@@ -569,8 +557,6 @@ class TestModuleFusedSDPAForwardDispatch:
 
     def _make_module(self, enable_slicing=True, slice_thld=4096, chunk_size=2048):
         """Create a ModuleFusedSDPA with slicing attributes set directly."""
-        import torch
-        from vllm_gaudi.extension.utils import ModuleFusedSDPA
 
         mock_kernel = MagicMock()
         mock_kernel.apply.return_value = torch.zeros(1, 4, 1024, 64)
@@ -591,7 +577,6 @@ class TestModuleFusedSDPAForwardDispatch:
         return module
 
     def test_slicing_dispatched_when_conditions_met(self):
-        import torch
         module = self._make_module()
         q = torch.randn(1, 4, 2048, 64)  # bs=1, heads=4, q_len=2048
         k = torch.randn(1, 4, 8192, 64)  # kv_len=8192 >= threshold
@@ -603,7 +588,6 @@ class TestModuleFusedSDPAForwardDispatch:
         module._sliced_module.assert_called_once()
 
     def test_default_path_when_slicing_disabled(self):
-        import torch
         module = self._make_module(enable_slicing=False)
         q = torch.randn(1, 4, 2048, 64)
         k = torch.randn(1, 4, 8192, 64)
@@ -614,7 +598,6 @@ class TestModuleFusedSDPAForwardDispatch:
         module._hpu_kernel_fsdpa.apply.assert_called_once()
 
     def test_default_path_when_bs_not_1(self):
-        import torch
         module = self._make_module()
         q = torch.randn(2, 4, 2048, 64)  # bs=2
         k = torch.randn(2, 4, 8192, 64)
@@ -625,7 +608,6 @@ class TestModuleFusedSDPAForwardDispatch:
         module._sliced_module.assert_not_called()
 
     def test_default_path_when_q_len_equals_kv_len(self):
-        import torch
         module = self._make_module()
         q = torch.randn(1, 4, 4096, 64)
         k = torch.randn(1, 4, 4096, 64)  # q_len == kv_len
@@ -636,7 +618,6 @@ class TestModuleFusedSDPAForwardDispatch:
         module._sliced_module.assert_not_called()
 
     def test_default_path_when_not_causal(self):
-        import torch
         module = self._make_module()
         q = torch.randn(1, 4, 2048, 64)
         k = torch.randn(1, 4, 8192, 64)
@@ -647,7 +628,6 @@ class TestModuleFusedSDPAForwardDispatch:
         module._sliced_module.assert_not_called()
 
     def test_default_path_when_no_attn_mask(self):
-        import torch
         module = self._make_module()
         q = torch.randn(1, 4, 2048, 64)
         k = torch.randn(1, 4, 8192, 64)
@@ -657,7 +637,6 @@ class TestModuleFusedSDPAForwardDispatch:
         module._sliced_module.assert_not_called()
 
     def test_default_path_when_padding_side_left(self):
-        import torch
         module = self._make_module()
         q = torch.randn(1, 4, 2048, 64)
         k = torch.randn(1, 4, 8192, 64)
@@ -668,7 +647,6 @@ class TestModuleFusedSDPAForwardDispatch:
         module._sliced_module.assert_not_called()
 
     def test_default_path_with_window_size(self):
-        import torch
         module = self._make_module()
         q = torch.randn(1, 4, 2048, 64)
         k = torch.randn(1, 4, 8192, 64)
@@ -679,7 +657,6 @@ class TestModuleFusedSDPAForwardDispatch:
         module._sliced_module.assert_not_called()
 
     def test_default_path_with_sinks(self):
-        import torch
         module = self._make_module()
         q = torch.randn(1, 4, 2048, 64)
         k = torch.randn(1, 4, 8192, 64)
@@ -701,7 +678,6 @@ class TestModuleFusedSDPAForwardDispatch:
         module._sliced_module.assert_not_called()
 
     def test_default_path_when_kv_len_below_threshold(self):
-        import torch
         module = self._make_module(slice_thld=8192)
         q = torch.randn(1, 4, 2048, 64)
         k = torch.randn(1, 4, 4096, 64)  # kv_len=4096 < threshold=8192
@@ -714,7 +690,6 @@ class TestModuleFusedSDPAForwardDispatch:
     def test_causal_with_mask_clears_causal_on_default_path(self):
         """When slicing is not triggered but is_causal=True and attn_mask is set,
         the default path should clear is_causal and valid_sequence_lengths."""
-        import torch
         module = self._make_module(enable_slicing=False)
         q = torch.randn(1, 4, 2048, 64)
         k = torch.randn(1, 4, 8192, 64)
@@ -739,8 +714,6 @@ class TestModuleFP8FusedSDPAForwardDispatch:
     """Tests that FP8 forward dispatches correctly."""
 
     def _make_module(self, enable_slicing=True, slice_thld=4096, chunk_size=2048):
-        import torch
-        from vllm_gaudi.extension.utils import ModuleFP8FusedSDPA
 
         mock_kernel = MagicMock()
         mock_kernel.return_value = (torch.zeros(1, 4, 1024, 64), )
@@ -775,7 +748,6 @@ class TestModuleFP8FusedSDPAForwardDispatch:
         return module
 
     def test_slicing_dispatched_when_conditions_met(self):
-        import torch
         module = self._patch_quant(self._make_module())
         q = torch.randn(1, 4, 2048, 64)
         k = torch.randn(1, 4, 8192, 64)
@@ -787,7 +759,6 @@ class TestModuleFP8FusedSDPAForwardDispatch:
         module._sliced_module.assert_called_once()
 
     def test_default_path_when_slicing_disabled(self):
-        import torch
         module = self._patch_quant(self._make_module(enable_slicing=False))
         q = torch.randn(1, 4, 2048, 64)
         k = torch.randn(1, 4, 8192, 64)
@@ -798,7 +769,6 @@ class TestModuleFP8FusedSDPAForwardDispatch:
         module.fp8_fused_sdpa.assert_called_once()
 
     def test_default_path_when_bs_not_1(self):
-        import torch
         module = self._patch_quant(self._make_module())
         q = torch.randn(2, 4, 2048, 64)
         k = torch.randn(2, 4, 8192, 64)
@@ -809,7 +779,6 @@ class TestModuleFP8FusedSDPAForwardDispatch:
         module._sliced_module.assert_not_called()
 
     def test_default_path_with_window_size(self):
-        import torch
         module = self._patch_quant(self._make_module())
         q = torch.randn(1, 4, 2048, 64)
         k = torch.randn(1, 4, 8192, 64)
@@ -826,7 +795,6 @@ class TestModuleFP8FusedSDPAForwardDispatch:
         assert module.d_scale_output.item() == 1.0
 
     def test_causal_with_mask_clears_causal_on_default_path(self):
-        import torch
         module = self._patch_quant(self._make_module(enable_slicing=False))
         q = torch.randn(1, 4, 2048, 64)
         k = torch.randn(1, 4, 8192, 64)
@@ -839,7 +807,6 @@ class TestModuleFP8FusedSDPAForwardDispatch:
         assert call_kwargs['valid_seq_len'] is None
 
     def test_default_path_when_q_len_equals_kv_len(self):
-        import torch
         module = self._patch_quant(self._make_module())
         q = torch.randn(1, 4, 4096, 64)
         k = torch.randn(1, 4, 4096, 64)  # q_len == kv_len
@@ -850,7 +817,6 @@ class TestModuleFP8FusedSDPAForwardDispatch:
         module._sliced_module.assert_not_called()
 
     def test_default_path_when_not_causal(self):
-        import torch
         module = self._patch_quant(self._make_module())
         q = torch.randn(1, 4, 2048, 64)
         k = torch.randn(1, 4, 8192, 64)
@@ -861,7 +827,6 @@ class TestModuleFP8FusedSDPAForwardDispatch:
         module._sliced_module.assert_not_called()
 
     def test_default_path_when_no_attn_mask(self):
-        import torch
         module = self._patch_quant(self._make_module())
         q = torch.randn(1, 4, 2048, 64)
         k = torch.randn(1, 4, 8192, 64)
@@ -871,7 +836,6 @@ class TestModuleFP8FusedSDPAForwardDispatch:
         module._sliced_module.assert_not_called()
 
     def test_default_path_when_padding_side_left(self):
-        import torch
         module = self._patch_quant(self._make_module())
         q = torch.randn(1, 4, 2048, 64)
         k = torch.randn(1, 4, 8192, 64)
@@ -882,7 +846,6 @@ class TestModuleFP8FusedSDPAForwardDispatch:
         module._sliced_module.assert_not_called()
 
     def test_default_path_when_kv_len_below_threshold(self):
-        import torch
         module = self._patch_quant(self._make_module(slice_thld=8192))
         q = torch.randn(1, 4, 2048, 64)
         k = torch.randn(1, 4, 4096, 64)  # kv_len < threshold
@@ -902,7 +865,6 @@ class TestFsdpaSlicingUserFlags:
     """Tests for the FSDPA slicing env flags registered in features.py."""
 
     def test_slicing_env_flags_registered(self):
-        from vllm_gaudi.extension.features import get_user_flags
         flags = get_user_flags()
         assert 'VLLM_HPU_FSDPA_SLICE_ENABLED' in flags
         assert 'VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD' in flags
@@ -910,25 +872,21 @@ class TestFsdpaSlicingUserFlags:
         assert 'VLLM_HPU_FSDPA_SLICE_WITH_GRAPH_BREAKS' in flags
 
     def test_slice_enabled_flag_is_boolean(self):
-        from vllm_gaudi.extension.features import get_user_flags
         flags = get_user_flags()
         flag = flags['VLLM_HPU_FSDPA_SLICE_ENABLED']
         assert flag.value_type is boolean
 
     def test_slice_thld_flag_is_int(self):
-        from vllm_gaudi.extension.features import get_user_flags
         flags = get_user_flags()
         flag = flags['VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD']
         assert flag.value_type is int
 
     def test_slice_chunk_size_flag_is_int(self):
-        from vllm_gaudi.extension.features import get_user_flags
         flags = get_user_flags()
         flag = flags['VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE']
         assert flag.value_type is int
 
     def test_enable_fsdpa_slicing_feature_registered(self):
-        from vllm_gaudi.extension.features import get_features
         values, flags = get_features()
         assert 'enable_fsdpa_slicing' in values
         assert 'VLLM_HPU_FSDPA_SLICE_ENABLED' in flags
@@ -945,8 +903,6 @@ class TestFsdpaPromptAttentionCausalMask:
     def test_causal_and_mask_passed_through(self):
         """After removal of the workaround, is_causal and attn_bias should
         both be forwarded to the fsdpa kernel when both are provided."""
-        import torch
-        from unittest.mock import MagicMock
 
         mock_fsdpa_op = MagicMock(return_value=torch.randn(1, 4, 2048, 64))
 
@@ -954,8 +910,6 @@ class TestFsdpaPromptAttentionCausalMask:
             cfg = MagicMock()
             cfg.fp32_softmax = False
             mock_cfg.return_value = cfg
-
-            from vllm_gaudi.extension.ops import _fsdpa_prompt_attention
 
             q = torch.randn(1, 2048, 4, 64)  # before transpose: [bs, seq, heads, dim]
             k = torch.randn(1, 2048, 4, 64)
@@ -1097,7 +1051,6 @@ class TestFsdpaSlicingAccuracyBF16:
     @staticmethod
     def _run_reference(q, k, v, attn_mask):
         """Non-sliced reference: single FusedSDPA call with full mask."""
-        from habana_frameworks.torch.hpex.kernels import FusedSDPA
         with torch.inference_mode():
             output = FusedSDPA.apply(
                 q,
@@ -1125,7 +1078,6 @@ class TestFsdpaSlicingAccuracyBF16:
             torch._dynamo.reset()
             module = torch.compile(module, backend='hpu_backend')
         elif mode == 'hpu_graph':
-            import habana_frameworks.torch as ht
             module = ht.hpu.wrap_in_hpu_graph(module)
         with torch.inference_mode():
             output = module(q, k, v, attn_mask, 0.0, True, None, 'fast')
@@ -1198,7 +1150,6 @@ class TestFsdpaSlicingAccuracyFP8:
     @staticmethod
     def _run_reference(q, k, v, attn_mask):
         """BF16 ground-truth reference: single FusedSDPA call with full mask."""
-        from habana_frameworks.torch.hpex.kernels import FusedSDPA
         with torch.inference_mode():
             output = FusedSDPA.apply(
                 q,
@@ -1223,7 +1174,6 @@ class TestFsdpaSlicingAccuracyFP8:
         Uses dynamic_quant for FP8 quantization following FP8BucketSDPA.__init__
         in profile_fsdpa_apc.py.
         """
-        from vllm_gaudi.extension.ops import dynamic_quant
 
         q_fp8, scale_q = dynamic_quant(q, single_scale=True)
         k_fp8, scale_k = dynamic_quant(k, single_scale=True)
@@ -1244,7 +1194,6 @@ class TestFsdpaSlicingAccuracyFP8:
             torch._dynamo.reset()
             module = torch.compile(module, backend='hpu_backend')
         elif mode == 'hpu_graph':
-            import habana_frameworks.torch as ht
             module = ht.hpu.wrap_in_hpu_graph(module)
         with torch.inference_mode():
             output = module(q_fp8, k_fp8, v_fp8, attn_mask, 0.0, True, None, 'fast')

--- a/tests/unit_tests/test_fsdpa_slicing.py
+++ b/tests/unit_tests/test_fsdpa_slicing.py
@@ -1153,7 +1153,7 @@ class TestFsdpaSlicingAccuracyBF16:
                                                             sliced_out.flatten().float(),
                                                             dim=0).item()
 
-        assert cos_sim > 0.95, f"BF16 cosine similarity too low: {cos_sim}"
+        assert cos_sim > 0.999, f"BF16 cosine similarity too low: {cos_sim}"
 
 
 @requires_hpu
@@ -1264,7 +1264,7 @@ class TestFsdpaSlicingAccuracyFP8:
                                                             sliced_out.flatten().float(),
                                                             dim=0).item()
 
-        assert cos_sim > 0.94, f"FP8 cosine similarity too low: {cos_sim}"
+        assert cos_sim > 0.99, f"FP8 cosine similarity too low: {cos_sim}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/test_fsdpa_slicing.py
+++ b/tests/unit_tests/test_fsdpa_slicing.py
@@ -496,7 +496,12 @@ def _make_sliced_fp8(chunk_size,
 
     # Create a lightweight parent-like namespace to hold scale tensors
     class _ScaleHolder:
-        pass
+        d_scale_q: torch.Tensor
+        d_scale_k: torch.Tensor
+        d_scale_v: torch.Tensor
+        d_scale_output: torch.Tensor
+        scale_amax: torch.Tensor
+        descale_amax: torch.Tensor
 
     parent = _ScaleHolder()
     parent.d_scale_q = d_scale_q

--- a/tests/unit_tests/test_fsdpa_slicing.py
+++ b/tests/unit_tests/test_fsdpa_slicing.py
@@ -1168,7 +1168,8 @@ print(len(glob.glob('.graph_dumps/*PreGraph*')))
 
 def _count_graphs(lazy_mode: int, graph_breaks: bool, dtype: str = "BF16", mode: str = 'eager') -> int:
     """Run slicing in a subprocess with GRAPH_VISUALIZATION=1 and return graph count."""
-    dump_dir = os.path.join(os.getcwd(), '.graph_dumps')
+    project_root = str(pathlib.Path(__file__).resolve().parents[2])
+    dump_dir = os.path.join(project_root, '.graph_dumps')
     if os.path.isdir(dump_dir):
         shutil.rmtree(dump_dir)
 
@@ -1184,7 +1185,7 @@ def _count_graphs(lazy_mode: int, graph_breaks: bool, dtype: str = "BF16", mode:
         [sys.executable, '-c', script],
         capture_output=True,
         text=True,
-        cwd=os.getcwd(),
+        cwd=project_root,
         env=env,
         timeout=120,
     )

--- a/tests/unit_tests/test_fsdpa_slicing.py
+++ b/tests/unit_tests/test_fsdpa_slicing.py
@@ -17,9 +17,6 @@ import sys
 import pytest
 from unittest.mock import patch, MagicMock
 
-import habana_frameworks.torch as ht
-from habana_frameworks.torch.hpex.kernels import FusedSDPA
-
 from vllm_gaudi.extension.bucketing.linear import LinearBucketingStrategy
 from vllm_gaudi.extension.bucketing.padding_aware import PaddingAwareBucketingStrategy
 from vllm_gaudi.extension.config import Config, Eq, All, Disabled, Kernel, Value, Env, boolean
@@ -463,6 +460,7 @@ def _make_sliced_bf16(chunk_size, num_padded_query_chunks=0, num_padded_ctx_chun
     module.num_padded_query_chunks = num_padded_query_chunks
     module.num_padded_ctx_chunks = num_padded_ctx_chunks
     # Mirror the production guard: graph breaks only work in lazy mode.
+    import habana_frameworks.torch as ht
     is_lazy = ht.utils.internal.is_lazy()
     module._with_graph_breaks = with_graph_breaks and is_lazy
     if module._with_graph_breaks:
@@ -508,6 +506,7 @@ def _make_sliced_fp8(chunk_size,
     module.num_padded_query_chunks = num_padded_query_chunks
     module.num_padded_ctx_chunks = num_padded_ctx_chunks
     # Mirror the production guard: graph breaks only work in lazy mode.
+    import habana_frameworks.torch as ht
     is_lazy = ht.utils.internal.is_lazy()
     module._with_graph_breaks = with_graph_breaks and is_lazy
     if module._with_graph_breaks:
@@ -1076,6 +1075,7 @@ class TestFsdpaSlicingAccuracyBF16:
     @staticmethod
     def _run_reference(q, k, v, attn_mask):
         """Non-sliced reference: single FusedSDPA call with full mask."""
+        from habana_frameworks.torch.hpex.kernels import FusedSDPA
         with torch.inference_mode():
             output = FusedSDPA.apply(
                 q,
@@ -1103,6 +1103,7 @@ class TestFsdpaSlicingAccuracyBF16:
             torch._dynamo.reset()
             module = torch.compile(module, backend='hpu_backend')
         elif mode == 'hpu_graph':
+            import habana_frameworks.torch as ht
             module = ht.hpu.wrap_in_hpu_graph(module)
         with torch.inference_mode():
             output = module(q, k, v, attn_mask, 0.0, True, None, 'fast')
@@ -1170,6 +1171,7 @@ class TestFsdpaSlicingAccuracyFP8:
     @staticmethod
     def _run_reference(q, k, v, attn_mask):
         """BF16 ground-truth reference: single FusedSDPA call with full mask."""
+        from habana_frameworks.torch.hpex.kernels import FusedSDPA
         with torch.inference_mode():
             output = FusedSDPA.apply(
                 q,
@@ -1214,6 +1216,7 @@ class TestFsdpaSlicingAccuracyFP8:
             torch._dynamo.reset()
             module = torch.compile(module, backend='hpu_backend')
         elif mode == 'hpu_graph':
+            import habana_frameworks.torch as ht
             module = ht.hpu.wrap_in_hpu_graph(module)
         with torch.inference_mode():
             output = module(q_fp8, k_fp8, v_fp8, attn_mask, 0.0, True, None, 'fast')

--- a/tests/unit_tests/test_fsdpa_slicing.py
+++ b/tests/unit_tests/test_fsdpa_slicing.py
@@ -253,6 +253,7 @@ class TestSetupSlicing:
         assert base.chunk_size == 4096
         assert base._with_graph_breaks is False
 
+    @pytest.mark.skip(reason='lazy mode tests are skipped')
     @patch('habana_frameworks.torch.utils.internal.is_lazy', return_value=True)
     @patch('vllm_gaudi.extension.utils.get_config')
     @patch('vllm_gaudi.extension.bucketing.common.HPUBucketingManager.get_instance')
@@ -1120,6 +1121,8 @@ class TestFsdpaSlicingAccuracyBF16:
         (1024, 8192, 4096),
     ])
     def test_bf16_accuracy(self, q_len, ctx_len, chunk_size, graph_breaks, mode):
+        if mode in ('lazy', 'hpu_graph'):
+            pytest.skip('lazy mode tests are skipped')
         if graph_breaks and mode == 'compile':
             pytest.skip('graph breaks are not supported with torch.compile')
         if mode in ('lazy', 'hpu_graph'):
@@ -1233,6 +1236,8 @@ class TestFsdpaSlicingAccuracyFP8:
         (1024, 8192, 4096),
     ])
     def test_fp8_accuracy(self, q_len, ctx_len, chunk_size, graph_breaks, mode):
+        if mode in ('lazy', 'hpu_graph'):
+            pytest.skip('lazy mode tests are skipped')
         if graph_breaks and mode == 'compile':
             pytest.skip('graph breaks are not supported with torch.compile')
         if mode in ('lazy', 'hpu_graph'):
@@ -1344,6 +1349,7 @@ class TestGraphBreaksSplitGraphs:
     graph break.  The constraint is enforced in ``_setup_slicing``.
     """
 
+    @pytest.mark.skip(reason='lazy mode tests are skipped')
     @pytest.mark.parametrize("dtype", ["BF16", "FP8"])
     def test_lazy_graph_breaks_split_graphs(self, dtype):
         """In lazy mode, graph_breaks should split into more graphs."""

--- a/vllm_gaudi/extension/features.py
+++ b/vllm_gaudi/extension/features.py
@@ -121,7 +121,8 @@ def get_features():
               env_var_type=boolean),
         Value('use_hpu_aligned_scale', False, env_var='HPU_ALIGNED_SCALE', env_var_type=boolean),
         Value('enable_fsdpa_slicing',
-              All(Eq('bucketing_strategy', 'pad'), Disabled('merged_prefill'), Kernel(fsdpa)),
+              All(Eq('use_bucketing', True), Eq('bucketing_strategy', 'pad'), Disabled('merged_prefill'),
+                  Kernel(fsdpa)),
               env_var='VLLM_HPU_FSDPA_SLICE_ENABLED',
               env_var_type=boolean),
     ]

--- a/vllm_gaudi/extension/features.py
+++ b/vllm_gaudi/extension/features.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 ###############################################################################
 
-from vllm_gaudi.extension.config import Not, Hardware, VersionRange, ModelType, Kernel, Any, All, Value, ValueFromList, Env, Disabled, Enabled, Engine, MinPackageVersion, boolean, to_dict, split_values_and_flags, list_of
+from vllm_gaudi.extension.config import Not, Hardware, VersionRange, ModelType, Kernel, Any, All, Value, ValueFromList, Env, Eq, Disabled, Enabled, MinPackageVersion, boolean, to_dict, split_values_and_flags, list_of
 from vllm_gaudi.extension.kernels import fsdpa, block_softmax_adjustment
 from vllm_gaudi.extension.validation import for_all, choice
 
@@ -55,6 +55,12 @@ def get_user_flags():
         Env('PT_HPU_SDPA_QKV_SLICE_MODE_FWD', boolean),
         Env('PT_HPU_SDPA_BC_FACTOR', int),
         Env('VLLM_FUSEDSDPA_SLIDE_THLD', int),
+
+        # FusedSDPA slicing flags
+        Env('VLLM_HPU_FSDPA_SLICE_ENABLED', boolean),
+        Env('VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD', int),
+        Env('VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE', int),
+        Env('VLLM_HPU_FSDPA_SLICE_WITH_GRAPH_BREAKS', boolean),
     ]
     return to_dict(flags)
 
@@ -114,5 +120,9 @@ def get_features():
               All(VersionRange(">=1.24.0.460"), MinPackageVersion("neural_compressor_pt", "3.7")),
               env_var_type=boolean),
         Value('use_hpu_aligned_scale', False, env_var='HPU_ALIGNED_SCALE', env_var_type=boolean),
+        Value('enable_fsdpa_slicing',
+              All(Eq('bucketing_strategy', 'pad'), Disabled('merged_prefill'), Kernel(fsdpa)),
+              env_var='VLLM_HPU_FSDPA_SLICE_ENABLED',
+              env_var_type=boolean),
     ]
     return split_values_and_flags(features)

--- a/vllm_gaudi/extension/ops.py
+++ b/vllm_gaudi/extension/ops.py
@@ -397,11 +397,11 @@ def _fsdpa_prompt_attention(query: torch.Tensor,
     assert attn_bias is not None or valid_seq_lengths is not None, \
         'Either attn_bias or valid_seq_lengths must be != None'
 
-    # moved to ModuleFusedSDPA and ModuleFP8FusedSDPA after the dispatching for sliced FusedSDPA
-    # if is_causal and attn_bias is not None:
-    #     # TODO: causal + attn_bias is not yet supported
-    #     is_causal = False
-    #     valid_seq_lengths = None
+    # moved to ModuleFusedSDPA and ModuleFP8FusedSDPA after the dispatching for sliced FusedSDPA when INC is not used
+    if is_causal and attn_bias is not None and os.getenv("QUANT_CONFIG") is not None:
+        # TODO: causal + attn_bias is not yet supported
+        is_causal = False
+        valid_seq_lengths = None
 
     args = [
         query, key, value, attn_bias, 0.0, is_causal, scale, softmax_mode, recompute_mode, valid_seq_lengths,

--- a/vllm_gaudi/extension/ops.py
+++ b/vllm_gaudi/extension/ops.py
@@ -396,10 +396,6 @@ def _fsdpa_prompt_attention(query: torch.Tensor,
     recompute_mode = True
     assert attn_bias is not None or valid_seq_lengths is not None, \
         'Either attn_bias or valid_seq_lengths must be != None'
-    if is_causal and attn_bias is not None:
-        # TODO: causal + attn_bias is not yet supported
-        is_causal = False
-        valid_seq_lengths = None
 
     args = [
         query, key, value, attn_bias, 0.0, is_causal, scale, softmax_mode, recompute_mode, valid_seq_lengths,

--- a/vllm_gaudi/extension/ops.py
+++ b/vllm_gaudi/extension/ops.py
@@ -374,6 +374,9 @@ def _naive_prompt_attention(query: torch.Tensor,
     return attn_weights
 
 
+USING_INC = os.getenv("QUANT_CONFIG") is not None
+
+
 def _fsdpa_prompt_attention(query: torch.Tensor,
                             key: torch.Tensor,
                             value: torch.Tensor,
@@ -398,7 +401,7 @@ def _fsdpa_prompt_attention(query: torch.Tensor,
         'Either attn_bias or valid_seq_lengths must be != None'
 
     # moved to ModuleFusedSDPA and ModuleFP8FusedSDPA after the dispatching for sliced FusedSDPA when INC is not used
-    if is_causal and attn_bias is not None and os.getenv("QUANT_CONFIG") is not None:
+    if is_causal and attn_bias is not None and USING_INC:
         # TODO: causal + attn_bias is not yet supported
         is_causal = False
         valid_seq_lengths = None

--- a/vllm_gaudi/extension/ops.py
+++ b/vllm_gaudi/extension/ops.py
@@ -397,6 +397,12 @@ def _fsdpa_prompt_attention(query: torch.Tensor,
     assert attn_bias is not None or valid_seq_lengths is not None, \
         'Either attn_bias or valid_seq_lengths must be != None'
 
+    # moved to ModuleFusedSDPA and ModuleFP8FusedSDPA after the dispatching for sliced FusedSDPA
+    # if is_causal and attn_bias is not None:
+    #     # TODO: causal + attn_bias is not yet supported
+    #     is_causal = False
+    #     valid_seq_lengths = None
+
     args = [
         query, key, value, attn_bias, 0.0, is_causal, scale, softmax_mode, recompute_mode, valid_seq_lengths,
         padding_side

--- a/vllm_gaudi/extension/utils.py
+++ b/vllm_gaudi/extension/utils.py
@@ -198,13 +198,15 @@ class ModuleFusedSDPABase(torch.nn.Module):
                 f'The FusedSDPA slice sequence length threshold {slice_thld} is less than the default {slice_thld_default} which is not recommended.'
             )
 
+        assert slice_thld > 1024, 'The FusedSDPA slice sequence length threshold should be greater than 1024 to ensure the chunk sizes are valid for the attention kernel.'
+
         # default to half of the threshold and round up by 1024
         chunk_size_default = math.ceil(slice_thld // 2 / 1024) * 1024
         chunk_size = int(os.getenv("VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE", str(chunk_size_default)))
-        assert chunk_size > block_size and chunk_size <= slice_thld, 'Invalid FusedSDPA slice chunk size, the chunk size should be between the block size and the slice sequence length threshold.'
         if chunk_size % 1024 != 0:
             chunk_size = math.ceil(chunk_size / 1024) * 1024
             logger().warning_once('Rounded up the chunk size for FusedSDPA slicing to the next multiple of 1024.')
+        assert chunk_size > block_size and chunk_size <= slice_thld, 'Invalid FusedSDPA slice chunk size, the chunk size should be between the block size and the slice sequence length threshold.'
 
         self.slice_thld = slice_thld
         self.chunk_size = chunk_size

--- a/vllm_gaudi/extension/utils.py
+++ b/vllm_gaudi/extension/utils.py
@@ -151,7 +151,13 @@ class FP8Matmul(torch.nn.Module):
         return output
 
 
-class ModuleFusedSDPABase(torch.nn.Module):
+class SlicedFusedSDPABase(torch.nn.Module):
+    """Base class for sliced FusedSDPA modules.
+
+    Encapsulates the common slicing initialization (chunk size, padded chunk
+    counts, graph-break setup) shared by :class:`SlicedFusedSDPA` and
+    :class:`SlicedFP8FusedSDPA`.
+    """
 
     def __init__(self):
         super().__init__()
@@ -211,13 +217,13 @@ class ModuleFusedSDPABase(torch.nn.Module):
         self.slice_thld = slice_thld
         self.chunk_size = chunk_size
 
-        max_query_pad_default = math.ceil(max_num_batched_tokens /
-                                          4)  # should align with the default in PaddingAwareBucketingStrategy
+        # should align with the default in PaddingAwareBucketingStrategy
+        max_query_pad_default = math.ceil(max_num_batched_tokens / 4)
         max_query_pad = int(os.getenv("VLLM_PROMPT_QUERY_BUCKET_PAD_MAX", str(max_query_pad_default)))
         self.num_padded_query_chunks = math.ceil(max_query_pad / self.chunk_size)
 
-        max_ctx_pad_default = math.ceil(max_num_batched_tokens /
-                                        block_size)  # should align with the default in PaddingAwareBucketingStrategy
+        # should align with the default in PaddingAwareBucketingStrategy
+        max_ctx_pad_default = math.ceil(max_num_batched_tokens / block_size)
         max_ctx_pad = int(os.getenv("VLLM_PROMPT_CTX_BUCKET_PAD_MAX", str(max_ctx_pad_default)))
         self.num_padded_ctx_chunks = math.ceil(max_ctx_pad * block_size / self.chunk_size)
 
@@ -229,10 +235,21 @@ class ModuleFusedSDPABase(torch.nn.Module):
                f"chunk size {self.chunk_size}, num padded query chunks {self.num_padded_query_chunks}, "
                f"num padded ctx chunks {self.num_padded_ctx_chunks}, with graph breaks {self._with_graph_breaks}.")
         logger().debug(msg)
+
+        if self._with_graph_breaks:
+            if ht.utils.internal.is_lazy():
+                self._break_graph = ht.core.mark_step
+            else:
+                self._break_graph = torch._dynamo.graph_break
+
         return True
 
+    def maybe_break_graph(self):
+        if self._with_graph_breaks:
+            self._break_graph()
 
-class SlicedFusedSDPA(torch.nn.Module):
+
+class SlicedFusedSDPA(SlicedFusedSDPABase):
     """Standalone module for BF16 sliced FusedSDPA.
 
     Extracting the sliced attention path into its own ``nn.Module`` allows it
@@ -240,23 +257,6 @@ class SlicedFusedSDPA(torch.nn.Module):
     any other module-level wrapper independently of the dispatch logic in
     :class:`ModuleFusedSDPA`.
     """
-
-    def __init__(self, chunk_size, num_padded_query_chunks, num_padded_ctx_chunks, with_graph_breaks=False):
-        super().__init__()
-        self.chunk_size = chunk_size
-        self.num_padded_query_chunks = num_padded_query_chunks
-        self.num_padded_ctx_chunks = num_padded_ctx_chunks
-        self._with_graph_breaks = with_graph_breaks
-        if with_graph_breaks:
-            import habana_frameworks.torch as ht
-            if ht.utils.internal.is_lazy():
-                self._break_graph = ht.core.mark_step
-            else:
-                self._break_graph = torch._dynamo.graph_break
-
-    def maybe_break_graph(self):
-        if self._with_graph_breaks:
-            self._break_graph()
 
     def forward(self, query, key, value, attn_mask, dropout_p, is_causal, scale, softmax_mode):
         assert is_causal and attn_mask is not None
@@ -380,15 +380,13 @@ class SlicedFusedSDPA(torch.nn.Module):
         return output.to(q.dtype)
 
 
-class ModuleFusedSDPA(ModuleFusedSDPABase):
+class ModuleFusedSDPA(torch.nn.Module):
 
     def __init__(self, fusedSDPA):
         super().__init__()
         assert fusedSDPA is not None, f'fusedSDPA kernel is None'
         self._hpu_kernel_fsdpa = fusedSDPA
-        if self.enable_slicing:
-            self._sliced_module = SlicedFusedSDPA(self.chunk_size, self.num_padded_query_chunks,
-                                                  self.num_padded_ctx_chunks, self._with_graph_breaks)
+        self._sliced_module = SlicedFusedSDPA()
 
     def forward(
         self,
@@ -409,7 +407,7 @@ class ModuleFusedSDPA(ModuleFusedSDPABase):
         bs = query.shape[0]
         q_len = query.shape[-2]
         kv_len = key.shape[-2]
-        if (self.enable_slicing and kv_len >= self.slice_thld \
+        if (self._sliced_module.enable_slicing and kv_len >= self._sliced_module.slice_thld \
                 and bs == 1  # bs should be 1 for chunked prefill
                 and q_len != kv_len  # normal causal prefill route to the default dispatch for better performance
                 and is_causal and attn_mask is not None  # only supports causal attention with mask
@@ -434,7 +432,7 @@ class ModuleFusedSDPA(ModuleFusedSDPABase):
                                                 (-1, -1), sinks)
 
 
-class SlicedFP8FusedSDPA(torch.nn.Module):
+class SlicedFP8FusedSDPA(SlicedFusedSDPABase):
     """Standalone module for FP8 sliced FusedSDPA.
 
     Like :class:`SlicedFusedSDPA`, extracting the sliced path enables
@@ -443,41 +441,14 @@ class SlicedFP8FusedSDPA(torch.nn.Module):
     BF16/FP32 before the online-softmax rescaling merge.
     """
 
-    def __init__(self,
-                 chunk_size,
-                 num_padded_query_chunks,
-                 num_padded_ctx_chunks,
-                 d_scale_q,
-                 d_scale_k,
-                 d_scale_v,
-                 d_scale_output,
-                 scale_amax,
-                 descale_amax,
-                 with_graph_breaks=False):
+    def __init__(self, parent):
         super().__init__()
-        self.chunk_size = chunk_size
-        self.num_padded_query_chunks = num_padded_query_chunks
-        self.num_padded_ctx_chunks = num_padded_ctx_chunks
-        self.d_scale_q = d_scale_q
-        self.d_scale_k = d_scale_k
-        self.d_scale_v = d_scale_v
-        self.d_scale_output = d_scale_output
-        self.scale_amax = scale_amax
-        self.descale_amax = descale_amax
-        self._with_graph_breaks = with_graph_breaks
-        if with_graph_breaks:
-            import habana_frameworks.torch as ht
-            if ht.utils.internal.is_lazy():
-                self._break_graph = ht.core.mark_step
-            else:
-                self._break_graph = torch._dynamo.graph_break
+        # Store parent reference without registering as a submodule
+        # to avoid circular module graph while sharing scale tensors.
+        object.__setattr__(self, '_parent', parent)
 
-    def maybe_break_graph(self):
-        if self._with_graph_breaks:
-            self._break_graph()
-
-    def dequant_output(self, output, scale):
-        return torch.ops.hpu.cast_from_fp8(output, scale, torch.bfloat16)
+    def dequant_output(self, output):
+        return torch.ops.hpu.cast_from_fp8(output, self._parent.d_scale_output, torch.bfloat16)
 
     def fp8_fsdpa_fwd(self, q, k, v, attn_mask, dropout_p, scale, is_causal, softmax_mode):
         results = torch.ops.hpu.fp8_sdpa_recomp_fwd(
@@ -490,12 +461,12 @@ class SlicedFP8FusedSDPA(torch.nn.Module):
             is_causal,
             True,  # requires_backward
             softmax_mode,
-            self.d_scale_q,
-            self.d_scale_k,
-            self.d_scale_v,
-            self.scale_amax,
-            self.d_scale_output,
-            self.descale_amax,
+            self._parent.d_scale_q,
+            self._parent.d_scale_k,
+            self._parent.d_scale_v,
+            self._parent.scale_amax,
+            self._parent.d_scale_output,
+            self._parent.descale_amax,
             False,  # is_amax_s
             False,  # is_amax_o
             None,  # valid_seq_len
@@ -557,7 +528,7 @@ class SlicedFP8FusedSDPA(torch.nn.Module):
                 chunk_out, chunk_m, chunk_linv = (gqa_output_reshape(x) if gqa else x for x in chunk_res[:3])
                 chunk_m = chunk_m.to(torch.float32)
                 chunk_linv = chunk_linv.to(torch.float32) * (128.0 if softmax_mode == "fast" else 1.0)
-                chunk_out = self.dequant_output(chunk_out, self.d_scale_output).to(torch.float32)
+                chunk_out = self.dequant_output(chunk_out).to(torch.float32)
 
                 if last_out is None or last_m is None or last_linv is None:
                     last_out = chunk_out
@@ -591,7 +562,7 @@ class SlicedFP8FusedSDPA(torch.nn.Module):
                 chunk_out, chunk_m, chunk_linv = (gqa_output_reshape(x) if gqa else x for x in chunk_res[:3])
                 chunk_m = chunk_m.to(torch.float32)
                 chunk_linv = chunk_linv.to(torch.float32) * (128.0 if softmax_mode == "fast" else 1.0)
-                chunk_out = self.dequant_output(chunk_out, self.d_scale_output).to(torch.float32)
+                chunk_out = self.dequant_output(chunk_out).to(torch.float32)
 
                 assert not (last_out is None or last_m is None or last_linv is None)
                 new_m = torch.maximum(last_m, chunk_m)
@@ -608,7 +579,7 @@ class SlicedFP8FusedSDPA(torch.nn.Module):
         return torch.cat(chunk_outputs, dim=-2)
 
 
-class ModuleFP8FusedSDPA(ModuleFusedSDPABase):
+class ModuleFP8FusedSDPA(torch.nn.Module):
 
     def __init__(self, fusedSDPA):
         super().__init__()
@@ -625,23 +596,7 @@ class ModuleFP8FusedSDPA(ModuleFusedSDPABase):
         self.d_scale_k = torch.tensor(1.0, dtype=torch.float32)
         self.d_scale_v = torch.tensor(1.0, dtype=torch.float32)
         self.d_scale_output = torch.tensor(1.0, dtype=torch.float32)
-        if self.enable_slicing:
-            self._sliced_module = SlicedFP8FusedSDPA(self.chunk_size, self.num_padded_query_chunks,
-                                                     self.num_padded_ctx_chunks, self.d_scale_q, self.d_scale_k,
-                                                     self.d_scale_v, self.d_scale_output, self.scale_amax,
-                                                     self.descale_amax, self._with_graph_breaks)
-
-    def _sync_sliced_module_scales(self) -> None:
-        if not self.enable_slicing:
-            return
-        # Scales can be reassigned after module construction (e.g. during
-        # post-load quantization setup), so keep sliced-module references in sync.
-        self._sliced_module.d_scale_q = self.d_scale_q
-        self._sliced_module.d_scale_k = self.d_scale_k
-        self._sliced_module.d_scale_v = self.d_scale_v
-        self._sliced_module.d_scale_output = self.d_scale_output
-        self._sliced_module.scale_amax = self.scale_amax
-        self._sliced_module.descale_amax = self.descale_amax
+        self._sliced_module = SlicedFP8FusedSDPA(parent=self)
 
     def quant_input(self, x, scale):
         return torch.ops.hpu.cast_to_fp8_v2(x, scale, False, False, torch.float8_e4m3fn)[0]
@@ -669,7 +624,7 @@ class ModuleFP8FusedSDPA(ModuleFusedSDPABase):
         bs = query.shape[0]
         q_len = query.shape[-2]
         kv_len = key.shape[-2]
-        if (self.enable_slicing and kv_len >= self.slice_thld \
+        if (self._sliced_module.enable_slicing and kv_len >= self._sliced_module.slice_thld \
                 and bs == 1  # bs should be 1 for chunked prefill
                 and q_len != kv_len  # normal causal prefill route to the default dispatch for better performance
                 and is_causal and attn_mask is not None  # only supports causal attention with mask

--- a/vllm_gaudi/extension/utils.py
+++ b/vllm_gaudi/extension/utils.py
@@ -255,9 +255,11 @@ class SlicedFusedSDPABase(torch.nn.Module):
             return chunk_out, chunk_m, chunk_linv
         eps = 1e-8
         new_m = torch.maximum(last_m, chunk_m)
-        last_linv_rescaled = (1.0 / (last_linv + eps)) * torch.exp(last_m - new_m)
-        chunk_linv_rescaled = (1.0 / (chunk_linv + eps)) * torch.exp(chunk_m - new_m)
-        new_linv = 1.0 / (last_linv_rescaled + chunk_linv_rescaled)
+        # When both m values are -inf (fully masked rows), the diff -inf - (-inf) = NaN.
+        # Replace NaN with -inf so that exp(-inf) = 0, giving zero contribution.
+        last_linv_rescaled = (1.0 / (last_linv + eps)) * torch.exp(torch.nan_to_num(last_m - new_m, float('-inf')))
+        chunk_linv_rescaled = (1.0 / (chunk_linv + eps)) * torch.exp(torch.nan_to_num(chunk_m - new_m, float('-inf')))
+        new_linv = 1.0 / (last_linv_rescaled + chunk_linv_rescaled + eps)
         new_out = (last_linv_rescaled * new_linv) * last_out + (chunk_linv_rescaled * new_linv) * chunk_out
         return new_out, new_m, new_linv
 
@@ -370,7 +372,13 @@ class SlicedFusedSDPA(SlicedFusedSDPABase):
 
         def chunk_kernel(q_c, k_c, v_c, mask_c, dp, sc, is_c, sm):
             res = torch.ops.hpu.sdpa_recomp_fwd(q_c, k_c, v_c, mask_c, dp, sc, is_c, True, sm, None, 'right')
-            return tuple((gqa_output_reshape(x) if gqa else x).to(torch.float32) for x in res[:3])
+            out, m, linv = tuple((gqa_output_reshape(x) if gqa else x).to(torch.float32) for x in res[:3])
+            # Sanitize NaN from fully-masked rows: the kernel returns NaN when all
+            # attention scores are -inf (padding positions).  Replace with safe
+            # defaults so the online-softmax merge treats them as zero-contribution.
+            out = torch.nan_to_num(out, 0.0)
+            linv = torch.nan_to_num(linv, 0.0)
+            return out, m, linv
 
         output = self._chunked_attention(q, k, v, attn_mask, dropout_p, scale, softmax_mode, chunk_kernel)
         return output.to(q.dtype)
@@ -491,6 +499,9 @@ class SlicedFP8FusedSDPA(SlicedFusedSDPABase):
             m = m.to(torch.float32)
             linv = linv.to(torch.float32) * (128.0 if sm == "fast" else 1.0)
             out = self._dequant_output(out).to(torch.float32)
+            # Sanitize NaN from fully-masked rows (same as BF16 path).
+            out = torch.nan_to_num(out, 0.0)
+            linv = torch.nan_to_num(linv, 0.0)
             return out, m, linv
 
         return self._chunked_attention(q, k, v, attn_mask, dropout_p, scale, softmax_mode, chunk_kernel)

--- a/vllm_gaudi/extension/utils.py
+++ b/vllm_gaudi/extension/utils.py
@@ -6,12 +6,14 @@
 ###############################################################################
 
 import os
+import math
 from functools import lru_cache, wraps
 from typing import Optional, Any
 
 import habana_frameworks.torch as htorch
 import torch
 import itertools
+from vllm_gaudi.extension.logger import logger
 
 from vllm_gaudi.extension.runtime import get_config
 
@@ -149,12 +151,237 @@ class FP8Matmul(torch.nn.Module):
         return output
 
 
-class ModuleFusedSDPA(torch.nn.Module):
+class ModuleFusedSDPABase(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+        self.enable_slicing = self._setup_slicing()
+
+    def _setup_slicing(self) -> bool:
+        enable_slicing = get_config().enable_fsdpa_slicing
+        if not enable_slicing:
+            return False
+
+        if get_config().bucketing_strategy != 'pad':
+            logger().warning_once(
+                'FusedSDPA slicing is only compatible with padding-based bucketing strategy, slicing in FusedSDPA will be disabled.'
+            )
+            return False
+
+        if get_config().merged_prefill:
+            logger().warning_once(
+                'FusedSDPA slicing is not compatible with merged prefill, slicing in FusedSDPA will be disabled.')
+            return False
+
+        from vllm_gaudi.extension.bucketing.common import get_bucketing_manager
+        bucketing_manager = get_bucketing_manager()
+        assert bucketing_manager is not None and bucketing_manager.initialized, 'Bucketing manager should be instantiated and initialized to enable FusedSDPA slicing.'
+
+        from vllm_gaudi.extension.bucketing.padding_aware import PaddingAwareBucketingStrategy
+        strategy = bucketing_manager.get_bucketing_strategy()
+        assert isinstance(
+            strategy,
+            PaddingAwareBucketingStrategy), 'Bucketing strategy should be Padding-Aware to enable FusedSDPA slicing.'
+
+        max_num_batched_tokens = bucketing_manager.max_num_batched_tokens
+        block_size = bucketing_manager.block_size
+        slice_thld_default = min(max_num_batched_tokens, 8192)
+        slice_thld = int(os.getenv("VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD", str(slice_thld_default)))
+        assert slice_thld > block_size, 'Invalid FusedSDPA slice sequence length threshold, the threshold should be greater than the block size.'
+        if slice_thld < slice_thld_default:
+            logger().warning_once(
+                f'The FusedSDPA slice sequence length threshold {slice_thld} is less than the default {slice_thld_default} which is not recommended.'
+            )
+
+        # default to half of the threshold and round up by 1024
+        chunk_size_default = math.ceil(slice_thld // 2 / 1024) * 1024
+        chunk_size = int(os.getenv("VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE", str(chunk_size_default)))
+        assert chunk_size > block_size and chunk_size <= slice_thld, 'Invalid FusedSDPA slice chunk size, the chunk size should be between the block size and the slice sequence length threshold.'
+        if chunk_size % 1024 != 0:
+            chunk_size = math.ceil(chunk_size / 1024) * 1024
+            logger().warning_once('Rounded up the chunk size for FusedSDPA slicing to the next multiple of 1024.')
+
+        self.slice_thld = slice_thld
+        self.chunk_size = chunk_size
+
+        max_query_pad_default = math.ceil(max_num_batched_tokens /
+                                          4)  # should align with the default in PaddingAwareBucketingStrategy
+        max_query_pad = int(os.getenv("VLLM_PROMPT_QUERY_BUCKET_PAD_MAX", str(max_query_pad_default)))
+        self.num_padded_query_chunks = math.ceil(max_query_pad / self.chunk_size)
+
+        max_ctx_pad_default = math.ceil(max_num_batched_tokens /
+                                        block_size)  # should align with the default in PaddingAwareBucketingStrategy
+        max_ctx_pad = int(os.getenv("VLLM_PROMPT_CTX_BUCKET_PAD_MAX", str(max_ctx_pad_default)))
+        self.num_padded_ctx_chunks = math.ceil(max_ctx_pad * block_size / self.chunk_size)
+
+        import habana_frameworks.torch as ht
+        is_lazy = ht.utils.internal.is_lazy()
+        self._with_graph_breaks = os.getenv("VLLM_HPU_FSDPA_SLICE_WITH_GRAPH_BREAKS",
+                                            str(is_lazy)).strip().lower() in ['true', 't', '1', 'yes', 'y', 'on']
+        msg = (f"FusedSDPA slicing is enabled with sequence length threshold {slice_thld}, "
+               f"chunk size {self.chunk_size}, num padded query chunks {self.num_padded_query_chunks}, "
+               f"num padded ctx chunks {self.num_padded_ctx_chunks}, with graph breaks {self._with_graph_breaks}.")
+        logger().debug(msg)
+        return True
+
+
+class SlicedFusedSDPA(torch.nn.Module):
+    """Standalone module for BF16 sliced FusedSDPA.
+
+    Extracting the sliced attention path into its own ``nn.Module`` allows it
+    to be wrapped with ``torch.compile``, ``ht.hpu.wrap_in_hpu_graph``, or
+    any other module-level wrapper independently of the dispatch logic in
+    :class:`ModuleFusedSDPA`.
+    """
+
+    def __init__(self, chunk_size, num_padded_query_chunks, num_padded_ctx_chunks, with_graph_breaks=False):
+        super().__init__()
+        self.chunk_size = chunk_size
+        self.num_padded_query_chunks = num_padded_query_chunks
+        self.num_padded_ctx_chunks = num_padded_ctx_chunks
+        self._with_graph_breaks = with_graph_breaks
+        if with_graph_breaks:
+            import habana_frameworks.torch as ht
+            if ht.utils.internal.is_lazy():
+                self._break_graph = ht.core.mark_step
+            else:
+                self._break_graph = torch._dynamo.graph_break
+
+    def maybe_break_graph(self):
+        if self._with_graph_breaks:
+            self._break_graph()
+
+    def forward(self, query, key, value, attn_mask, dropout_p, is_causal, scale, softmax_mode):
+        assert is_causal and attn_mask is not None
+
+        from habana_frameworks.torch.hpex.kernels.FusedSDPA import is_gqa, gqa_input_reshape_fwd, gqa_output_reshape
+        gqa = is_gqa(query, key)
+        if gqa:
+            q, k, v, attn_mask = gqa_input_reshape_fwd(query, key, value, attn_mask)
+        else:
+            q, k, v, attn_mask = (query, key, value, attn_mask)
+        q_len = q.shape[-2]
+        kv_len = k.shape[-2]
+        prefix_len = kv_len - q_len
+        if scale is None:
+            scale = 1.0 / (query.shape[-1]**0.5)
+
+        chunk_outputs = []
+        num_q_chunks = math.ceil(q_len / self.chunk_size)
+        num_prefix_chunks = math.ceil(prefix_len / self.chunk_size)
+        for q_chunk_idx in range(num_q_chunks):
+            q_start = q_len - (q_chunk_idx + 1) * self.chunk_size
+            q_start = max(q_start, 0)
+            q_end = q_len - q_chunk_idx * self.chunk_size
+            q_chunk_size = q_end - q_start
+            q_chunk = q[..., q_start:q_end, :].contiguous()
+
+            last_out = None
+            last_m = None
+            last_linv = None
+
+            # the causal part
+            for kv_chunk_idx in range(0, num_q_chunks - q_chunk_idx):
+                kv_start = prefix_len + q_end - (kv_chunk_idx + 1) * self.chunk_size
+                kv_start = max(kv_start, prefix_len)
+                kv_end = prefix_len + q_end - kv_chunk_idx * self.chunk_size
+                kv_chunk_size = kv_end - kv_start
+                k_chunk = k[..., kv_start:kv_end, :].contiguous()
+                v_chunk = v[..., kv_start:kv_end, :].contiguous()
+
+                is_causal_chunk = kv_chunk_idx == 0 and q_chunk_idx >= self.num_padded_query_chunks
+                # chunk sizes must be multiples of 1024 to get valid m and linv
+                is_causal_chunk = is_causal_chunk and q_chunk_size % 1024 == 0 and kv_chunk_size % 1024 == 0
+                # use mask only for the causal chunks that may have padding
+                mask_chunk = (attn_mask[..., q_start:q_end, kv_start:kv_end].contiguous()
+                              if kv_chunk_idx < self.num_padded_query_chunks and not is_causal_chunk else None)
+
+                self.maybe_break_graph()
+
+                chunk_res = torch.ops.hpu.sdpa_recomp_fwd(
+                    q_chunk,
+                    k_chunk,
+                    v_chunk,
+                    mask_chunk,
+                    dropout_p,
+                    scale,
+                    is_causal_chunk,
+                    True,  # requires_backward
+                    softmax_mode,
+                    None,  # valid_seq_len
+                    'right',  # padding_side
+                )
+                chunk_out, chunk_m, chunk_linv = ((gqa_output_reshape(x) if gqa else x).to(torch.float32)
+                                                  for x in (chunk_res[:3]))
+
+                if last_out is None or last_m is None or last_linv is None:
+                    last_out = chunk_out
+                    last_m = chunk_m
+                    last_linv = chunk_linv
+                else:
+                    new_m = torch.maximum(last_m, chunk_m)
+                    last_linv_rescaled = (1.0 / last_linv) * torch.exp(last_m - new_m)
+                    chunk_linv_rescaled = (1.0 / chunk_linv) * torch.exp(chunk_m - new_m)
+                    last_linv = 1.0 / (last_linv_rescaled + chunk_linv_rescaled)
+                    last_out = (last_linv_rescaled * last_linv) * last_out + \
+                              (chunk_linv_rescaled * last_linv) * chunk_out
+                    last_m = new_m
+
+                self.maybe_break_graph()
+
+            # the context part
+            for kv_chunk_idx in range(num_prefix_chunks):
+                kv_start = prefix_len - (kv_chunk_idx + 1) * self.chunk_size
+                kv_start = max(kv_start, 0)
+                kv_end = prefix_len - kv_chunk_idx * self.chunk_size
+                k_chunk = k[..., kv_start:kv_end, :].contiguous()
+                v_chunk = v[..., kv_start:kv_end, :].contiguous()
+                # use mask only for the chunks that may have padding
+                mask_chunk = (attn_mask[..., q_start:q_end, kv_start:kv_end].contiguous()
+                              if kv_chunk_idx < self.num_padded_ctx_chunks else None)
+
+                self.maybe_break_graph()
+
+                chunk_res = torch.ops.hpu.sdpa_recomp_fwd(
+                    q_chunk,
+                    k_chunk,
+                    v_chunk,
+                    mask_chunk,
+                    dropout_p,
+                    scale,
+                    False,  # is_causal
+                    True,  # requires_backward
+                    softmax_mode,
+                    None,  # valid_seq_len
+                    'right',  # padding_side
+                )
+                chunk_out, chunk_m, chunk_linv = ((gqa_output_reshape(x) if gqa else x).to(torch.float32)
+                                                  for x in chunk_res[:3])
+
+                assert not (last_out is None or last_m is None or last_linv is None)
+                new_m = torch.maximum(last_m, chunk_m)
+                last_linv_rescaled = (1.0 / last_linv) * torch.exp(last_m - new_m)
+                chunk_linv_rescaled = (1.0 / chunk_linv) * torch.exp(chunk_m - new_m)
+                last_linv = 1.0 / (last_linv_rescaled + chunk_linv_rescaled)
+                last_out = (last_linv_rescaled * last_linv) * last_out + (chunk_linv_rescaled * last_linv) * chunk_out
+                last_m = new_m
+
+                self.maybe_break_graph()
+            chunk_outputs.append(last_out)
+        chunk_outputs = list(reversed(chunk_outputs))
+        output = torch.cat(chunk_outputs, dim=-2)
+        return output.to(q.dtype)
+
+
+class ModuleFusedSDPA(ModuleFusedSDPABase):
 
     def __init__(self, fusedSDPA):
         super().__init__()
         assert fusedSDPA is not None, f'fusedSDPA kernel is None'
         self._hpu_kernel_fsdpa = fusedSDPA
+        if self.enable_slicing:
+            self._sliced_module = SlicedFusedSDPA(self.chunk_size, self.num_padded_query_chunks,
+                                                  self.num_padded_ctx_chunks, self._with_graph_breaks)
 
     def forward(
         self,
@@ -172,6 +399,24 @@ class ModuleFusedSDPA(torch.nn.Module):
         window_size=None,
         sinks=None,
     ):
+        bs = query.shape[0]
+        q_len = query.shape[-2]
+        kv_len = key.shape[-2]
+        if (self.enable_slicing and kv_len >= self.slice_thld \
+                and bs == 1  # bs should be 1 for chunked prefill
+                and q_len != kv_len  # normal causal prefill route to the default dispatch for better performance
+                and is_causal and attn_mask is not None  # only supports causal attention with mask
+                and padding_side == 'right'  # currently only supports right padding for the chunks that may have padding
+                and window_size is None  # slicing is not compatible with sliding window attention
+                and sinks is None  # slicing is not compatible with kernel fusion with sinks
+            ):
+            return self._sliced_module(query, key, value, attn_mask, dropout_p, is_causal, scale, softmax_mode)
+
+        if is_causal and attn_mask is not None:
+            # TODO: causal + attn_bias is not yet supported
+            is_causal = False
+            valid_sequence_lengths = None
+
         if window_size is not None:
             return self._hpu_kernel_fsdpa.apply(query, key, value, attn_mask, dropout_p, is_causal, scale, softmax_mode,
                                                 recompute_mode, valid_sequence_lengths, padding_side, False, False,
@@ -182,7 +427,181 @@ class ModuleFusedSDPA(torch.nn.Module):
                                                 (-1, -1), sinks)
 
 
-class ModuleFP8FusedSDPA(torch.nn.Module):
+class SlicedFP8FusedSDPA(torch.nn.Module):
+    """Standalone module for FP8 sliced FusedSDPA.
+
+    Like :class:`SlicedFusedSDPA`, extracting the sliced path enables
+    wrapping with ``torch.compile`` or ``ht.hpu.wrap_in_hpu_graph``.
+    Expects pre-quantized FP8 inputs; dequantises chunk outputs to
+    BF16/FP32 before the online-softmax rescaling merge.
+    """
+
+    def __init__(self,
+                 chunk_size,
+                 num_padded_query_chunks,
+                 num_padded_ctx_chunks,
+                 d_scale_q,
+                 d_scale_k,
+                 d_scale_v,
+                 d_scale_output,
+                 scale_amax,
+                 descale_amax,
+                 with_graph_breaks=False):
+        super().__init__()
+        self.chunk_size = chunk_size
+        self.num_padded_query_chunks = num_padded_query_chunks
+        self.num_padded_ctx_chunks = num_padded_ctx_chunks
+        self.d_scale_q = d_scale_q
+        self.d_scale_k = d_scale_k
+        self.d_scale_v = d_scale_v
+        self.d_scale_output = d_scale_output
+        self.scale_amax = scale_amax
+        self.descale_amax = descale_amax
+        self._with_graph_breaks = with_graph_breaks
+        if with_graph_breaks:
+            import habana_frameworks.torch as ht
+            if ht.utils.internal.is_lazy():
+                self._break_graph = ht.core.mark_step
+            else:
+                self._break_graph = torch._dynamo.graph_break
+
+    def maybe_break_graph(self):
+        if self._with_graph_breaks:
+            self._break_graph()
+
+    def dequant_output(self, output, scale):
+        return torch.ops.hpu.cast_from_fp8(output, scale, torch.bfloat16)
+
+    def fp8_fsdpa_fwd(self, q, k, v, attn_mask, dropout_p, scale, is_causal, softmax_mode):
+        results = torch.ops.hpu.fp8_sdpa_recomp_fwd(
+            q,
+            k,
+            v,
+            attn_mask,
+            dropout_p,
+            scale,
+            is_causal,
+            True,  # requires_backward
+            softmax_mode,
+            self.d_scale_q,
+            self.d_scale_k,
+            self.d_scale_v,
+            self.scale_amax,
+            self.d_scale_output,
+            self.descale_amax,
+            False,  # is_amax_s
+            False,  # is_amax_o
+            None,  # valid_seq_len
+            "right",
+            (-1, -1),
+            None,
+        )
+        return results
+
+    def forward(self, query, key, value, attn_mask, dropout_p, is_causal, scale, softmax_mode):
+        assert is_causal and attn_mask is not None
+
+        from habana_frameworks.torch.hpex.kernels.Fp8FusedSDPA import is_gqa, gqa_input_reshape_fwd, gqa_output_reshape
+        gqa = is_gqa(query, key)
+        if gqa:
+            q, k, v, attn_mask = gqa_input_reshape_fwd(query, key, value, attn_mask)
+        else:
+            q, k, v, attn_mask = (query, key, value, attn_mask)
+        q_len = query.shape[-2]
+        kv_len = key.shape[-2]
+        prefix_len = kv_len - q_len
+        softmax_mode = softmax_mode if softmax_mode == "fp32" else "fast"
+        if scale is None:
+            scale = 1.0 / (query.shape[-1]**0.5)
+
+        chunk_outputs = []
+        num_q_chunks = math.ceil(q_len / self.chunk_size)
+        num_prefix_chunks = math.ceil(prefix_len / self.chunk_size)
+        for q_chunk_idx in range(num_q_chunks):
+            q_start = q_len - (q_chunk_idx + 1) * self.chunk_size
+            q_start = max(q_start, 0)
+            q_end = q_len - q_chunk_idx * self.chunk_size
+            q_chunk_size = q_end - q_start
+            q_chunk = q[..., q_start:q_end, :].contiguous()
+
+            last_out = None
+            last_m = None
+            last_linv = None
+
+            # the causal part
+            for kv_chunk_idx in range(0, num_q_chunks - q_chunk_idx):
+                kv_start = prefix_len + q_end - (kv_chunk_idx + 1) * self.chunk_size
+                kv_start = max(kv_start, prefix_len)
+                kv_end = prefix_len + q_end - kv_chunk_idx * self.chunk_size
+                kv_chunk_size = kv_end - kv_start
+                k_chunk = k[..., kv_start:kv_end, :].contiguous()
+                v_chunk = v[..., kv_start:kv_end, :].contiguous()
+
+                is_causal_chunk = kv_chunk_idx == 0 and q_chunk_idx >= self.num_padded_query_chunks
+                is_causal_chunk = is_causal_chunk and q_chunk_size % 1024 == 0 and kv_chunk_size % 1024 == 0
+                mask_chunk = (attn_mask[..., q_start:q_end, kv_start:kv_end].contiguous()
+                              if kv_chunk_idx < self.num_padded_query_chunks and not is_causal_chunk else None)
+
+                self.maybe_break_graph()
+
+                chunk_res = self.fp8_fsdpa_fwd(q_chunk, k_chunk, v_chunk, mask_chunk, dropout_p, scale, is_causal_chunk,
+                                               softmax_mode)
+
+                chunk_out, chunk_m, chunk_linv = (gqa_output_reshape(x) if gqa else x for x in chunk_res[:3])
+                chunk_m = chunk_m.to(torch.float32)
+                chunk_linv = chunk_linv.to(torch.float32) * (128.0 if softmax_mode == "fast" else 1.0)
+                chunk_out = self.dequant_output(chunk_out, self.d_scale_output).to(torch.float32)
+
+                if last_out is None or last_m is None or last_linv is None:
+                    last_out = chunk_out
+                    last_m = chunk_m
+                    last_linv = chunk_linv
+                else:
+                    new_m = torch.maximum(last_m, chunk_m)
+                    last_linv_rescaled = (1.0 / last_linv) * torch.exp(last_m - new_m)
+                    chunk_linv_rescaled = (1.0 / chunk_linv) * torch.exp(chunk_m - new_m)
+                    last_linv = 1.0 / (last_linv_rescaled + chunk_linv_rescaled)
+                    last_out = (last_linv_rescaled * last_linv) * last_out + \
+                              (chunk_linv_rescaled * last_linv) * chunk_out
+                    last_m = new_m
+
+                self.maybe_break_graph()
+
+            # the context part
+            for kv_chunk_idx in range(num_prefix_chunks):
+                kv_start = prefix_len - (kv_chunk_idx + 1) * self.chunk_size
+                kv_start = max(kv_start, 0)
+                kv_end = prefix_len - kv_chunk_idx * self.chunk_size
+                k_chunk = k[..., kv_start:kv_end, :].contiguous()
+                v_chunk = v[..., kv_start:kv_end, :].contiguous()
+                mask_chunk = (attn_mask[..., q_start:q_end, kv_start:kv_end].contiguous()
+                              if kv_chunk_idx < self.num_padded_ctx_chunks else None)
+
+                self.maybe_break_graph()
+
+                chunk_res = self.fp8_fsdpa_fwd(q_chunk, k_chunk, v_chunk, mask_chunk, dropout_p, scale, False,
+                                               softmax_mode)
+                chunk_out, chunk_m, chunk_linv = (gqa_output_reshape(x) if gqa else x for x in chunk_res[:3])
+                chunk_m = chunk_m.to(torch.float32)
+                chunk_linv = chunk_linv.to(torch.float32) * (128.0 if softmax_mode == "fast" else 1.0)
+                chunk_out = self.dequant_output(chunk_out, self.d_scale_output).to(torch.float32)
+
+                assert not (last_out is None or last_m is None or last_linv is None)
+                new_m = torch.maximum(last_m, chunk_m)
+                last_linv_rescaled = (1.0 / last_linv) * torch.exp(last_m - new_m)
+                chunk_linv_rescaled = (1.0 / chunk_linv) * torch.exp(chunk_m - new_m)
+                last_linv = 1.0 / (last_linv_rescaled + chunk_linv_rescaled)
+                last_out = (last_linv_rescaled * last_linv) * last_out + (chunk_linv_rescaled * last_linv) * chunk_out
+                last_m = new_m
+
+                self.maybe_break_graph()
+
+            chunk_outputs.append(last_out)
+        chunk_outputs = list(reversed(chunk_outputs))
+        return torch.cat(chunk_outputs, dim=-2)
+
+
+class ModuleFP8FusedSDPA(ModuleFusedSDPABase):
 
     def __init__(self, fusedSDPA):
         super().__init__()
@@ -198,12 +617,15 @@ class ModuleFP8FusedSDPA(torch.nn.Module):
         self.d_scale_q = torch.tensor(1.0, dtype=torch.float32)
         self.d_scale_k = torch.tensor(1.0, dtype=torch.float32)
         self.d_scale_v = torch.tensor(1.0, dtype=torch.float32)
+        self.d_scale_output = torch.tensor(1.0, dtype=torch.float32)
+        if self.enable_slicing:
+            self._sliced_module = SlicedFP8FusedSDPA(self.chunk_size, self.num_padded_query_chunks,
+                                                     self.num_padded_ctx_chunks, self.d_scale_q, self.d_scale_k,
+                                                     self.d_scale_v, self.d_scale_output, self.scale_amax,
+                                                     self.descale_amax, self._with_graph_breaks)
 
     def quant_input(self, x, scale):
         return torch.ops.hpu.cast_to_fp8_v2(x, scale, False, False, torch.float8_e4m3fn)[0]
-
-    def dequant_output(self, output, scale):
-        return torch.ops.hpu.cast_from_fp8(output, scale, torch.bfloat16)
 
     def forward(
         self,
@@ -221,9 +643,27 @@ class ModuleFP8FusedSDPA(torch.nn.Module):
         window_size=None,
     ):
 
-        qinput = self.quant_input(query, self.scale_q)
-        kinput = self.quant_input(key, self.scale_k)
-        vinput = self.quant_input(value, self.scale_v)
+        qinput = self.quant_input(query, self.scale_q).detach()
+        kinput = self.quant_input(key, self.scale_k).detach()
+        vinput = self.quant_input(value, self.scale_v).detach()
+
+        bs = query.shape[0]
+        q_len = query.shape[-2]
+        kv_len = key.shape[-2]
+        if (self.enable_slicing and kv_len >= self.slice_thld \
+                and bs == 1  # bs should be 1 for chunked prefill
+                and q_len != kv_len  # normal causal prefill route to the default dispatch for better performance
+                and is_causal and attn_mask is not None  # only supports causal attention with mask
+                and padding_side == 'right'  # currently only supports right padding for the chunks that may have padding
+                and window_size is None  # slicing is not compatible with sliding window attention
+            ):
+            return self._sliced_module(qinput, kinput, vinput, attn_mask, dropout_p, is_causal, scale,
+                                       softmax_mode).to(query.dtype)
+
+        if is_causal and attn_mask is not None:
+            # TODO: causal + attn_bias is not yet supported
+            is_causal = False
+            valid_sequence_lengths = None
 
         results = self.fp8_fused_sdpa(
             qinput,

--- a/vllm_gaudi/extension/utils.py
+++ b/vllm_gaudi/extension/utils.py
@@ -199,7 +199,7 @@ class SlicedFusedSDPABase(torch.nn.Module):
         slice_thld_default = min(max_num_batched_tokens, 8192)
         slice_thld = int(os.getenv("VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD", str(slice_thld_default)))
         assert slice_thld > block_size, 'Invalid FusedSDPA slice sequence length threshold, the threshold should be greater than the block size.'
-        assert slice_thld > 1024, 'The FusedSDPA slice sequence length threshold should be greater than 1024 to ensure the chunk sizes are valid for the attention kernel.'
+        assert slice_thld >= 1024, 'The FusedSDPA slice sequence length threshold should be greater than or equal to 1024 to ensure the chunk sizes are valid for the attention kernel.'
         if slice_thld < slice_thld_default:
             logger().warning_once(
                 f'The FusedSDPA slice sequence length threshold {slice_thld} is less than the default {slice_thld_default} which is not recommended.'

--- a/vllm_gaudi/extension/utils.py
+++ b/vllm_gaudi/extension/utils.py
@@ -230,11 +230,12 @@ class SlicedFusedSDPABase(torch.nn.Module):
         is_lazy = ht.utils.internal.is_lazy()
         self._with_graph_breaks = os.getenv("VLLM_HPU_FSDPA_SLICE_WITH_GRAPH_BREAKS",
                                             str(is_lazy)).strip().lower() in ['true', 't', '1', 'yes', 'y', 'on']
+        if self._with_graph_breaks and not is_lazy:
+            logger().warning_once('FusedSDPA slicing graph breaks are only supported in lazy mode. '
+                                  'Disabling graph breaks for eager/compile mode to avoid Synapse compiler failures.')
+            self._with_graph_breaks = False
         if self._with_graph_breaks:
-            if is_lazy:
-                self._break_graph = ht.core.mark_step
-            else:
-                self._break_graph = torch._dynamo.graph_break
+            self._break_graph = ht.core.mark_step
 
         msg = (f"FusedSDPA slicing is enabled with sequence length threshold {slice_thld}, "
                f"chunk size {self.chunk_size}, num padded query chunks {self.num_padded_query_chunks}, "

--- a/vllm_gaudi/extension/utils.py
+++ b/vllm_gaudi/extension/utils.py
@@ -199,14 +199,13 @@ class SlicedFusedSDPABase(torch.nn.Module):
         slice_thld_default = min(max_num_batched_tokens, 8192)
         slice_thld = int(os.getenv("VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD", str(slice_thld_default)))
         assert slice_thld > block_size, 'Invalid FusedSDPA slice sequence length threshold, the threshold should be greater than the block size.'
+        assert slice_thld > 1024, 'The FusedSDPA slice sequence length threshold should be greater than 1024 to ensure the chunk sizes are valid for the attention kernel.'
         if slice_thld < slice_thld_default:
             logger().warning_once(
                 f'The FusedSDPA slice sequence length threshold {slice_thld} is less than the default {slice_thld_default} which is not recommended.'
             )
 
-        assert slice_thld > 1024, 'The FusedSDPA slice sequence length threshold should be greater than 1024 to ensure the chunk sizes are valid for the attention kernel.'
-
-        # default to half of the threshold and round up by 1024
+        # defaults to half of the threshold and round up by 1024
         chunk_size_default = math.ceil(slice_thld // 2 / 1024) * 1024
         chunk_size = int(os.getenv("VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE", str(chunk_size_default)))
         if chunk_size % 1024 != 0:
@@ -217,12 +216,12 @@ class SlicedFusedSDPABase(torch.nn.Module):
         self.slice_thld = slice_thld
         self.chunk_size = chunk_size
 
-        # should align with the default in PaddingAwareBucketingStrategy
+        # should align with the default value in PaddingAwareBucketingStrategy
         max_query_pad_default = math.ceil(max_num_batched_tokens / 4)
         max_query_pad = int(os.getenv("VLLM_PROMPT_QUERY_BUCKET_PAD_MAX", str(max_query_pad_default)))
         self.num_padded_query_chunks = math.ceil(max_query_pad / self.chunk_size)
 
-        # should align with the default in PaddingAwareBucketingStrategy
+        # should align with the default value in PaddingAwareBucketingStrategy
         max_ctx_pad_default = math.ceil(max_num_batched_tokens / block_size)
         max_ctx_pad = int(os.getenv("VLLM_PROMPT_CTX_BUCKET_PAD_MAX", str(max_ctx_pad_default)))
         self.num_padded_ctx_chunks = math.ceil(max_ctx_pad * block_size / self.chunk_size)
@@ -231,16 +230,16 @@ class SlicedFusedSDPABase(torch.nn.Module):
         is_lazy = ht.utils.internal.is_lazy()
         self._with_graph_breaks = os.getenv("VLLM_HPU_FSDPA_SLICE_WITH_GRAPH_BREAKS",
                                             str(is_lazy)).strip().lower() in ['true', 't', '1', 'yes', 'y', 'on']
-        msg = (f"FusedSDPA slicing is enabled with sequence length threshold {slice_thld}, "
-               f"chunk size {self.chunk_size}, num padded query chunks {self.num_padded_query_chunks}, "
-               f"num padded ctx chunks {self.num_padded_ctx_chunks}, with graph breaks {self._with_graph_breaks}.")
-        logger().debug(msg)
-
         if self._with_graph_breaks:
-            if ht.utils.internal.is_lazy():
+            if is_lazy:
                 self._break_graph = ht.core.mark_step
             else:
                 self._break_graph = torch._dynamo.graph_break
+
+        msg = (f"FusedSDPA slicing is enabled with sequence length threshold {slice_thld}, "
+               f"chunk size {self.chunk_size}, num padded query chunks {self.num_padded_query_chunks}, "
+               f"num padded ctx chunks {self.num_padded_ctx_chunks}, with graph breaks {self._with_graph_breaks}.")
+        logger().debug_once(msg)
 
         return True
 

--- a/vllm_gaudi/extension/utils.py
+++ b/vllm_gaudi/extension/utils.py
@@ -219,6 +219,7 @@ class SlicedFusedSDPABase(torch.nn.Module):
         # should align with the default value in PaddingAwareBucketingStrategy
         max_query_pad_default = math.ceil(max_num_batched_tokens / 4)
         max_query_pad = int(os.getenv("VLLM_PROMPT_QUERY_BUCKET_PAD_MAX", str(max_query_pad_default)))
+        assert max_query_pad >= block_size, 'Invalid max query padding, the max query padding should be greater than or equal to the block size.'
         self.num_padded_query_chunks = math.ceil(max_query_pad / self.chunk_size)
 
         # should align with the default value in PaddingAwareBucketingStrategy

--- a/vllm_gaudi/extension/utils.py
+++ b/vllm_gaudi/extension/utils.py
@@ -409,14 +409,12 @@ class ModuleFusedSDPA(torch.nn.Module):
         window_size=None,
         sinks=None,
     ):
-        bs = query.shape[0]
-        q_len = query.shape[-2]
-        kv_len = key.shape[-2]
-        if (self._sliced_module.enable_slicing and kv_len >= self._sliced_module.slice_thld \
-                and bs == 1  # bs should be 1 for chunked prefill
-                and q_len != kv_len  # normal causal prefill route to the default dispatch for better performance
+        if (self._sliced_module.enable_slicing
+                and key.shape[-2] >= self._sliced_module.slice_thld  # apply for kv_len >= slice_thld only
+                and query.shape[0] == 1  # bs should be 1 for prefix-prefill
+                and query.shape[-2] != key.shape[-2]  # normal prefill with q_len == kv_len route to the default
                 and is_causal and attn_mask is not None  # only supports causal attention with mask
-                and padding_side == 'right'  # currently only supports right padding for the chunks that may have padding
+                and padding_side == 'right'  # supports right padding only for the chunks that may have padding
                 and window_size is None  # slicing is not compatible with sliding window attention
                 and sinks is None  # slicing is not compatible with kernel fusion with sinks
             ):

--- a/vllm_gaudi/extension/utils.py
+++ b/vllm_gaudi/extension/utils.py
@@ -307,17 +307,18 @@ class SlicedFusedSDPABase(torch.nn.Module):
                 k_chunk = k[..., kv_start:kv_end, :].contiguous()
                 v_chunk = v[..., kv_start:kv_end, :].contiguous()
 
-                is_causal_chunk = kv_chunk_idx == 0 and q_chunk_idx >= self.num_padded_query_chunks
-                # chunk sizes must be multiples of 1024 to get valid m and linv
-                is_causal_chunk = is_causal_chunk and q_chunk_size % 1024 == 0 and kv_chunk_size % 1024 == 0
-                # use mask only for the causal chunks that may have padding
+                # Always pass explicit mask for the diagonal chunk (kv_chunk_idx==0)
+                # to ensure numerical consistency. The kernel's is_causal=True path
+                # uses a different internal algorithm that can diverge from the
+                # explicit mask path even when both encode the same triangular pattern.
+                # For non-diagonal chunks within the padded region, also pass mask.
                 mask_chunk = (attn_mask[..., q_start:q_end, kv_start:kv_end].contiguous()
-                              if kv_chunk_idx < self.num_padded_query_chunks and not is_causal_chunk else None)
+                              if kv_chunk_idx == 0 or kv_chunk_idx < self.num_padded_query_chunks else None)
 
                 self.maybe_break_graph()
 
                 chunk_out, chunk_m, chunk_linv = chunk_kernel_fn(q_chunk, k_chunk, v_chunk, mask_chunk, dropout_p,
-                                                                 scale, is_causal_chunk, softmax_mode)
+                                                                 scale, False, softmax_mode)
 
                 last_out, last_m, last_linv = self._merge_chunk(last_out, last_m, last_linv, chunk_out, chunk_m,
                                                                 chunk_linv)

--- a/vllm_gaudi/extension/utils.py
+++ b/vllm_gaudi/extension/utils.py
@@ -173,6 +173,11 @@ class ModuleFusedSDPABase(torch.nn.Module):
                 'FusedSDPA slicing is not compatible with merged prefill, slicing in FusedSDPA will be disabled.')
             return False
 
+        if not get_config().use_bucketing:
+            logger().warning_once(
+                'FusedSDPA slicing requires bucketing to be enabled, slicing in FusedSDPA will be disabled.')
+            return False
+
         from vllm_gaudi.extension.bucketing.common import get_bucketing_manager
         bucketing_manager = get_bucketing_manager()
         assert bucketing_manager is not None and bucketing_manager.initialized, 'Bucketing manager should be instantiated and initialized to enable FusedSDPA slicing.'

--- a/vllm_gaudi/extension/utils.py
+++ b/vllm_gaudi/extension/utils.py
@@ -624,6 +624,18 @@ class ModuleFP8FusedSDPA(ModuleFusedSDPABase):
                                                      self.d_scale_v, self.d_scale_output, self.scale_amax,
                                                      self.descale_amax, self._with_graph_breaks)
 
+    def _sync_sliced_module_scales(self) -> None:
+        if not self.enable_slicing:
+            return
+        # Scales can be reassigned after module construction (e.g. during
+        # post-load quantization setup), so keep sliced-module references in sync.
+        self._sliced_module.d_scale_q = self.d_scale_q
+        self._sliced_module.d_scale_k = self.d_scale_k
+        self._sliced_module.d_scale_v = self.d_scale_v
+        self._sliced_module.d_scale_output = self.d_scale_output
+        self._sliced_module.scale_amax = self.scale_amax
+        self._sliced_module.descale_amax = self.descale_amax
+
     def quant_input(self, x, scale):
         return torch.ops.hpu.cast_to_fp8_v2(x, scale, False, False, torch.float8_e4m3fn)[0]
 

--- a/vllm_gaudi/extension/utils.py
+++ b/vllm_gaudi/extension/utils.py
@@ -253,9 +253,10 @@ class SlicedFusedSDPABase(torch.nn.Module):
         """Online softmax rescaling merge of two attention chunks."""
         if last_out is None or last_m is None or last_linv is None:
             return chunk_out, chunk_m, chunk_linv
+        eps = 1e-8
         new_m = torch.maximum(last_m, chunk_m)
-        last_linv_rescaled = (1.0 / last_linv) * torch.exp(last_m - new_m)
-        chunk_linv_rescaled = (1.0 / chunk_linv) * torch.exp(chunk_m - new_m)
+        last_linv_rescaled = (1.0 / (last_linv + eps)) * torch.exp(last_m - new_m)
+        chunk_linv_rescaled = (1.0 / (chunk_linv + eps)) * torch.exp(chunk_m - new_m)
         new_linv = 1.0 / (last_linv_rescaled + chunk_linv_rescaled)
         new_out = (last_linv_rescaled * new_linv) * last_out + (chunk_linv_rescaled * new_linv) * chunk_out
         return new_out, new_m, new_linv
@@ -486,7 +487,7 @@ class SlicedFP8FusedSDPA(SlicedFusedSDPABase):
 
         def chunk_kernel(q_c, k_c, v_c, mask_c, dp, sc, is_c, sm):
             res = self._fp8_fsdpa_fwd(q_c, k_c, v_c, mask_c, dp, sc, is_c, sm)
-            out, m, linv = (gqa_output_reshape(x) if gqa else x for x in res[:3])
+            out, m, linv = tuple(gqa_output_reshape(x) if gqa else x for x in res[:3])
             m = m.to(torch.float32)
             linv = linv.to(torch.float32) * (128.0 if sm == "fast" else 1.0)
             out = self._dequant_output(out).to(torch.float32)

--- a/vllm_gaudi/extension/utils.py
+++ b/vllm_gaudi/extension/utils.py
@@ -248,30 +248,37 @@ class SlicedFusedSDPABase(torch.nn.Module):
         if self._with_graph_breaks:
             self._break_graph()
 
+    @staticmethod
+    def _merge_chunk(last_out, last_m, last_linv, chunk_out, chunk_m, chunk_linv):
+        """Online softmax rescaling merge of two attention chunks."""
+        if last_out is None or last_m is None or last_linv is None:
+            return chunk_out, chunk_m, chunk_linv
+        new_m = torch.maximum(last_m, chunk_m)
+        last_linv_rescaled = (1.0 / last_linv) * torch.exp(last_m - new_m)
+        chunk_linv_rescaled = (1.0 / chunk_linv) * torch.exp(chunk_m - new_m)
+        new_linv = 1.0 / (last_linv_rescaled + chunk_linv_rescaled)
+        new_out = (last_linv_rescaled * new_linv) * last_out + (chunk_linv_rescaled * new_linv) * chunk_out
+        return new_out, new_m, new_linv
 
-class SlicedFusedSDPA(SlicedFusedSDPABase):
-    """Standalone module for BF16 sliced FusedSDPA.
+    def _chunked_attention(self, q, k, v, attn_mask, dropout_p, scale, softmax_mode, chunk_kernel_fn):
+        """Run chunked attention with online softmax rescaling.
 
-    Extracting the sliced attention path into its own ``nn.Module`` allows it
-    to be wrapped with ``torch.compile``, ``ht.hpu.wrap_in_hpu_graph``, or
-    any other module-level wrapper independently of the dispatch logic in
-    :class:`ModuleFusedSDPA`.
-    """
+        Args:
+            q, k, v: Query, key, value tensors (after GQA reshape if needed).
+            attn_mask: Attention mask tensor.
+            dropout_p: Dropout probability.
+            scale: Attention scale factor.
+            softmax_mode: Softmax mode string.
+            chunk_kernel_fn: Callable
+                ``(q, k, v, mask, dropout_p, scale, is_causal, softmax_mode)``
+                returning ``(out, m, linv)`` all as float32.
 
-    def forward(self, query, key, value, attn_mask, dropout_p, is_causal, scale, softmax_mode):
-        assert is_causal and attn_mask is not None
-
-        from habana_frameworks.torch.hpex.kernels.FusedSDPA import is_gqa, gqa_input_reshape_fwd, gqa_output_reshape
-        gqa = is_gqa(query, key)
-        if gqa:
-            q, k, v, attn_mask = gqa_input_reshape_fwd(query, key, value, attn_mask)
-        else:
-            q, k, v, attn_mask = (query, key, value, attn_mask)
+        Returns:
+            Concatenated output tensor in float32.
+        """
         q_len = q.shape[-2]
         kv_len = k.shape[-2]
         prefix_len = kv_len - q_len
-        if scale is None:
-            scale = 1.0 / (query.shape[-1]**0.5)
 
         chunk_outputs = []
         num_q_chunks = math.ceil(q_len / self.chunk_size)
@@ -305,34 +312,11 @@ class SlicedFusedSDPA(SlicedFusedSDPABase):
 
                 self.maybe_break_graph()
 
-                chunk_res = torch.ops.hpu.sdpa_recomp_fwd(
-                    q_chunk,
-                    k_chunk,
-                    v_chunk,
-                    mask_chunk,
-                    dropout_p,
-                    scale,
-                    is_causal_chunk,
-                    True,  # requires_backward
-                    softmax_mode,
-                    None,  # valid_seq_len
-                    'right',  # padding_side
-                )
-                chunk_out, chunk_m, chunk_linv = ((gqa_output_reshape(x) if gqa else x).to(torch.float32)
-                                                  for x in (chunk_res[:3]))
+                chunk_out, chunk_m, chunk_linv = chunk_kernel_fn(q_chunk, k_chunk, v_chunk, mask_chunk, dropout_p,
+                                                                 scale, is_causal_chunk, softmax_mode)
 
-                if last_out is None or last_m is None or last_linv is None:
-                    last_out = chunk_out
-                    last_m = chunk_m
-                    last_linv = chunk_linv
-                else:
-                    new_m = torch.maximum(last_m, chunk_m)
-                    last_linv_rescaled = (1.0 / last_linv) * torch.exp(last_m - new_m)
-                    chunk_linv_rescaled = (1.0 / chunk_linv) * torch.exp(chunk_m - new_m)
-                    last_linv = 1.0 / (last_linv_rescaled + chunk_linv_rescaled)
-                    last_out = (last_linv_rescaled * last_linv) * last_out + \
-                              (chunk_linv_rescaled * last_linv) * chunk_out
-                    last_m = new_m
+                last_out, last_m, last_linv = self._merge_chunk(last_out, last_m, last_linv, chunk_out, chunk_m,
+                                                                chunk_linv)
 
                 self.maybe_break_graph()
 
@@ -349,34 +333,45 @@ class SlicedFusedSDPA(SlicedFusedSDPABase):
 
                 self.maybe_break_graph()
 
-                chunk_res = torch.ops.hpu.sdpa_recomp_fwd(
-                    q_chunk,
-                    k_chunk,
-                    v_chunk,
-                    mask_chunk,
-                    dropout_p,
-                    scale,
-                    False,  # is_causal
-                    True,  # requires_backward
-                    softmax_mode,
-                    None,  # valid_seq_len
-                    'right',  # padding_side
-                )
-                chunk_out, chunk_m, chunk_linv = ((gqa_output_reshape(x) if gqa else x).to(torch.float32)
-                                                  for x in chunk_res[:3])
+                chunk_out, chunk_m, chunk_linv = chunk_kernel_fn(q_chunk, k_chunk, v_chunk, mask_chunk, dropout_p,
+                                                                 scale, False, softmax_mode)
 
                 assert not (last_out is None or last_m is None or last_linv is None)
-                new_m = torch.maximum(last_m, chunk_m)
-                last_linv_rescaled = (1.0 / last_linv) * torch.exp(last_m - new_m)
-                chunk_linv_rescaled = (1.0 / chunk_linv) * torch.exp(chunk_m - new_m)
-                last_linv = 1.0 / (last_linv_rescaled + chunk_linv_rescaled)
-                last_out = (last_linv_rescaled * last_linv) * last_out + (chunk_linv_rescaled * last_linv) * chunk_out
-                last_m = new_m
+                last_out, last_m, last_linv = self._merge_chunk(last_out, last_m, last_linv, chunk_out, chunk_m,
+                                                                chunk_linv)
 
                 self.maybe_break_graph()
             chunk_outputs.append(last_out)
         chunk_outputs = list(reversed(chunk_outputs))
-        output = torch.cat(chunk_outputs, dim=-2)
+        return torch.cat(chunk_outputs, dim=-2)
+
+
+class SlicedFusedSDPA(SlicedFusedSDPABase):
+    """Standalone module for BF16 sliced FusedSDPA.
+
+    Extracting the sliced attention path into its own ``nn.Module`` allows it
+    to be wrapped with ``torch.compile``, ``ht.hpu.wrap_in_hpu_graph``, or
+    any other module-level wrapper independently of the dispatch logic in
+    :class:`ModuleFusedSDPA`.
+    """
+
+    def forward(self, query, key, value, attn_mask, dropout_p, is_causal, scale, softmax_mode):
+        assert is_causal and attn_mask is not None
+
+        from habana_frameworks.torch.hpex.kernels.FusedSDPA import is_gqa, gqa_input_reshape_fwd, gqa_output_reshape
+        gqa = is_gqa(query, key)
+        if gqa:
+            q, k, v, attn_mask = gqa_input_reshape_fwd(query, key, value, attn_mask)
+        else:
+            q, k, v, attn_mask = (query, key, value, attn_mask)
+        if scale is None:
+            scale = 1.0 / (query.shape[-1]**0.5)
+
+        def chunk_kernel(q_c, k_c, v_c, mask_c, dp, sc, is_c, sm):
+            res = torch.ops.hpu.sdpa_recomp_fwd(q_c, k_c, v_c, mask_c, dp, sc, is_c, True, sm, None, 'right')
+            return tuple((gqa_output_reshape(x) if gqa else x).to(torch.float32) for x in res[:3])
+
+        output = self._chunked_attention(q, k, v, attn_mask, dropout_p, scale, softmax_mode, chunk_kernel)
         return output.to(q.dtype)
 
 
@@ -447,10 +442,10 @@ class SlicedFP8FusedSDPA(SlicedFusedSDPABase):
         # to avoid circular module graph while sharing scale tensors.
         object.__setattr__(self, '_parent', parent)
 
-    def dequant_output(self, output):
+    def _dequant_output(self, output):
         return torch.ops.hpu.cast_from_fp8(output, self._parent.d_scale_output, torch.bfloat16)
 
-    def fp8_fsdpa_fwd(self, q, k, v, attn_mask, dropout_p, scale, is_causal, softmax_mode):
+    def _fp8_fsdpa_fwd(self, q, k, v, attn_mask, dropout_p, scale, is_causal, softmax_mode):
         results = torch.ops.hpu.fp8_sdpa_recomp_fwd(
             q,
             k,
@@ -470,9 +465,9 @@ class SlicedFP8FusedSDPA(SlicedFusedSDPABase):
             False,  # is_amax_s
             False,  # is_amax_o
             None,  # valid_seq_len
-            "right",
-            (-1, -1),
-            None,
+            "right",  # padding_side
+            (-1, -1),  # window_size
+            None,  # sinks
         )
         return results
 
@@ -485,98 +480,19 @@ class SlicedFP8FusedSDPA(SlicedFusedSDPABase):
             q, k, v, attn_mask = gqa_input_reshape_fwd(query, key, value, attn_mask)
         else:
             q, k, v, attn_mask = (query, key, value, attn_mask)
-        q_len = query.shape[-2]
-        kv_len = key.shape[-2]
-        prefix_len = kv_len - q_len
         softmax_mode = softmax_mode if softmax_mode == "fp32" else "fast"
         if scale is None:
             scale = 1.0 / (query.shape[-1]**0.5)
 
-        chunk_outputs = []
-        num_q_chunks = math.ceil(q_len / self.chunk_size)
-        num_prefix_chunks = math.ceil(prefix_len / self.chunk_size)
-        for q_chunk_idx in range(num_q_chunks):
-            q_start = q_len - (q_chunk_idx + 1) * self.chunk_size
-            q_start = max(q_start, 0)
-            q_end = q_len - q_chunk_idx * self.chunk_size
-            q_chunk_size = q_end - q_start
-            q_chunk = q[..., q_start:q_end, :].contiguous()
+        def chunk_kernel(q_c, k_c, v_c, mask_c, dp, sc, is_c, sm):
+            res = self._fp8_fsdpa_fwd(q_c, k_c, v_c, mask_c, dp, sc, is_c, sm)
+            out, m, linv = (gqa_output_reshape(x) if gqa else x for x in res[:3])
+            m = m.to(torch.float32)
+            linv = linv.to(torch.float32) * (128.0 if sm == "fast" else 1.0)
+            out = self._dequant_output(out).to(torch.float32)
+            return out, m, linv
 
-            last_out = None
-            last_m = None
-            last_linv = None
-
-            # the causal part
-            for kv_chunk_idx in range(0, num_q_chunks - q_chunk_idx):
-                kv_start = prefix_len + q_end - (kv_chunk_idx + 1) * self.chunk_size
-                kv_start = max(kv_start, prefix_len)
-                kv_end = prefix_len + q_end - kv_chunk_idx * self.chunk_size
-                kv_chunk_size = kv_end - kv_start
-                k_chunk = k[..., kv_start:kv_end, :].contiguous()
-                v_chunk = v[..., kv_start:kv_end, :].contiguous()
-
-                is_causal_chunk = kv_chunk_idx == 0 and q_chunk_idx >= self.num_padded_query_chunks
-                is_causal_chunk = is_causal_chunk and q_chunk_size % 1024 == 0 and kv_chunk_size % 1024 == 0
-                mask_chunk = (attn_mask[..., q_start:q_end, kv_start:kv_end].contiguous()
-                              if kv_chunk_idx < self.num_padded_query_chunks and not is_causal_chunk else None)
-
-                self.maybe_break_graph()
-
-                chunk_res = self.fp8_fsdpa_fwd(q_chunk, k_chunk, v_chunk, mask_chunk, dropout_p, scale, is_causal_chunk,
-                                               softmax_mode)
-
-                chunk_out, chunk_m, chunk_linv = (gqa_output_reshape(x) if gqa else x for x in chunk_res[:3])
-                chunk_m = chunk_m.to(torch.float32)
-                chunk_linv = chunk_linv.to(torch.float32) * (128.0 if softmax_mode == "fast" else 1.0)
-                chunk_out = self.dequant_output(chunk_out).to(torch.float32)
-
-                if last_out is None or last_m is None or last_linv is None:
-                    last_out = chunk_out
-                    last_m = chunk_m
-                    last_linv = chunk_linv
-                else:
-                    new_m = torch.maximum(last_m, chunk_m)
-                    last_linv_rescaled = (1.0 / last_linv) * torch.exp(last_m - new_m)
-                    chunk_linv_rescaled = (1.0 / chunk_linv) * torch.exp(chunk_m - new_m)
-                    last_linv = 1.0 / (last_linv_rescaled + chunk_linv_rescaled)
-                    last_out = (last_linv_rescaled * last_linv) * last_out + \
-                              (chunk_linv_rescaled * last_linv) * chunk_out
-                    last_m = new_m
-
-                self.maybe_break_graph()
-
-            # the context part
-            for kv_chunk_idx in range(num_prefix_chunks):
-                kv_start = prefix_len - (kv_chunk_idx + 1) * self.chunk_size
-                kv_start = max(kv_start, 0)
-                kv_end = prefix_len - kv_chunk_idx * self.chunk_size
-                k_chunk = k[..., kv_start:kv_end, :].contiguous()
-                v_chunk = v[..., kv_start:kv_end, :].contiguous()
-                mask_chunk = (attn_mask[..., q_start:q_end, kv_start:kv_end].contiguous()
-                              if kv_chunk_idx < self.num_padded_ctx_chunks else None)
-
-                self.maybe_break_graph()
-
-                chunk_res = self.fp8_fsdpa_fwd(q_chunk, k_chunk, v_chunk, mask_chunk, dropout_p, scale, False,
-                                               softmax_mode)
-                chunk_out, chunk_m, chunk_linv = (gqa_output_reshape(x) if gqa else x for x in chunk_res[:3])
-                chunk_m = chunk_m.to(torch.float32)
-                chunk_linv = chunk_linv.to(torch.float32) * (128.0 if softmax_mode == "fast" else 1.0)
-                chunk_out = self.dequant_output(chunk_out).to(torch.float32)
-
-                assert not (last_out is None or last_m is None or last_linv is None)
-                new_m = torch.maximum(last_m, chunk_m)
-                last_linv_rescaled = (1.0 / last_linv) * torch.exp(last_m - new_m)
-                chunk_linv_rescaled = (1.0 / chunk_linv) * torch.exp(chunk_m - new_m)
-                last_linv = 1.0 / (last_linv_rescaled + chunk_linv_rescaled)
-                last_out = (last_linv_rescaled * last_linv) * last_out + (chunk_linv_rescaled * last_linv) * chunk_out
-                last_m = new_m
-
-                self.maybe_break_graph()
-
-            chunk_outputs.append(last_out)
-        chunk_outputs = list(reversed(chunk_outputs))
-        return torch.cat(chunk_outputs, dim=-2)
+        return self._chunked_attention(q, k, v, attn_mask, dropout_p, scale, softmax_mode, chunk_kernel)
 
 
 class ModuleFP8FusedSDPA(torch.nn.Module):

--- a/vllm_gaudi/extension/utils.py
+++ b/vllm_gaudi/extension/utils.py
@@ -254,11 +254,10 @@ class SlicedFusedSDPABase(torch.nn.Module):
         """Online softmax rescaling merge of two attention chunks."""
         if last_out is None or last_m is None or last_linv is None:
             return chunk_out, chunk_m, chunk_linv
-        eps = 1e-8
         new_m = torch.maximum(last_m, chunk_m)
-        last_linv_rescaled = (1.0 / (last_linv + eps)) * torch.exp(last_m - new_m)
-        chunk_linv_rescaled = (1.0 / (chunk_linv + eps)) * torch.exp(chunk_m - new_m)
-        new_linv = 1.0 / (last_linv_rescaled + chunk_linv_rescaled + eps)
+        last_linv_rescaled = (1.0 / last_linv) * torch.exp(last_m - new_m)
+        chunk_linv_rescaled = (1.0 / chunk_linv) * torch.exp(chunk_m - new_m)
+        new_linv = 1.0 / (last_linv_rescaled + chunk_linv_rescaled)
         new_out = (last_linv_rescaled * new_linv) * last_out + (chunk_linv_rescaled * new_linv) * chunk_out
         return new_out, new_m, new_linv
 

--- a/vllm_gaudi/extension/utils.py
+++ b/vllm_gaudi/extension/utils.py
@@ -256,10 +256,8 @@ class SlicedFusedSDPABase(torch.nn.Module):
             return chunk_out, chunk_m, chunk_linv
         eps = 1e-8
         new_m = torch.maximum(last_m, chunk_m)
-        # When both m values are -inf (fully masked rows), the diff -inf - (-inf) = NaN.
-        # Replace NaN with -inf so that exp(-inf) = 0, giving zero contribution.
-        last_linv_rescaled = (1.0 / (last_linv + eps)) * torch.exp(torch.nan_to_num(last_m - new_m, float('-inf')))
-        chunk_linv_rescaled = (1.0 / (chunk_linv + eps)) * torch.exp(torch.nan_to_num(chunk_m - new_m, float('-inf')))
+        last_linv_rescaled = (1.0 / (last_linv + eps)) * torch.exp(last_m - new_m)
+        chunk_linv_rescaled = (1.0 / (chunk_linv + eps)) * torch.exp(chunk_m - new_m)
         new_linv = 1.0 / (last_linv_rescaled + chunk_linv_rescaled + eps)
         new_out = (last_linv_rescaled * new_linv) * last_out + (chunk_linv_rescaled * new_linv) * chunk_out
         return new_out, new_m, new_linv
@@ -375,11 +373,6 @@ class SlicedFusedSDPA(SlicedFusedSDPABase):
         def chunk_kernel(q_c, k_c, v_c, mask_c, dp, sc, is_c, sm):
             res = torch.ops.hpu.sdpa_recomp_fwd(q_c, k_c, v_c, mask_c, dp, sc, is_c, True, sm, None, 'right')
             out, m, linv = tuple((gqa_output_reshape(x) if gqa else x).to(torch.float32) for x in res[:3])
-            # Sanitize NaN from fully-masked rows: the kernel returns NaN when all
-            # attention scores are -inf (padding positions).  Replace with safe
-            # defaults so the online-softmax merge treats them as zero-contribution.
-            out = torch.nan_to_num(out, 0.0)
-            linv = torch.nan_to_num(linv, 0.0)
             return out, m, linv
 
         output = self._chunked_attention(q, k, v, attn_mask, dropout_p, scale, softmax_mode, chunk_kernel)
@@ -499,9 +492,6 @@ class SlicedFP8FusedSDPA(SlicedFusedSDPABase):
             m = m.to(torch.float32)
             linv = linv.to(torch.float32) * (128.0 if sm == "fast" else 1.0)
             out = self._dequant_output(out).to(torch.float32)
-            # Sanitize NaN from fully-masked rows (same as BF16 path).
-            out = torch.nan_to_num(out, 0.0)
-            linv = torch.nan_to_num(linv, 0.0)
             return out, m, linv
 
         return self._chunked_attention(q, k, v, attn_mask, dropout_p, scale, softmax_mode, chunk_kernel)

--- a/vllm_gaudi/ops/hpu_compressed_tensors.py
+++ b/vllm_gaudi/ops/hpu_compressed_tensors.py
@@ -1018,9 +1018,6 @@ class HPUCompressedTensorsKVCacheMethod(CompressedTensorsKVCacheMethod):
         layer.impl.fused_scaled_dot_product_attention.d_scale_q = 1 / q_scale.detach()
         layer.impl.fused_scaled_dot_product_attention.d_scale_k = 1 / k_scale.detach()
         layer.impl.fused_scaled_dot_product_attention.d_scale_v = 1 / v_scale.detach()
-        sync_sliced_scales = getattr(layer.impl.fused_scaled_dot_product_attention, "_sync_sliced_module_scales", None)
-        if callable(sync_sliced_scales):
-            sync_sliced_scales()
 
         # Note: The following steps are important to avoid compiling each decoding layer into a different gc recipe
         # Step 1: Remove deprecated scale attributes

--- a/vllm_gaudi/ops/hpu_compressed_tensors.py
+++ b/vllm_gaudi/ops/hpu_compressed_tensors.py
@@ -1018,6 +1018,9 @@ class HPUCompressedTensorsKVCacheMethod(CompressedTensorsKVCacheMethod):
         layer.impl.fused_scaled_dot_product_attention.d_scale_q = 1 / q_scale.detach()
         layer.impl.fused_scaled_dot_product_attention.d_scale_k = 1 / k_scale.detach()
         layer.impl.fused_scaled_dot_product_attention.d_scale_v = 1 / v_scale.detach()
+        sync_sliced_scales = getattr(layer.impl.fused_scaled_dot_product_attention, "_sync_sliced_module_scales", None)
+        if callable(sync_sliced_scales):
+            sync_sliced_scales()
 
         # Note: The following steps are important to avoid compiling each decoding layer into a different gc recipe
         # Step 1: Remove deprecated scale attributes


### PR DESCRIPTION
FusedSDPA can be split into smaller chunks to improve performance while using the padding-aware bucketing strategy which guarantees the max absolute padding in the sequence and context dimensions.

## Usage
| Parameter name                           | Description                                                                                  | Default value                               |
| ---------------------------------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------- |
| `VLLM_HPU_FSDPA_SLICE_ENABLED`           | Enable the slicing.                                                                          | `True` for padding-aware bucketing strategy |
| `VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD`      | KV length threshold above which slicing is applied.                                          | `min(max_num_batched_tokens, 8192)`         |
| `VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE`        | Chunk size for `q_len` and `kv_len` in each chunk. Rounded up to the next multiple of 1024.  | `VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD // 2`    |
| `VLLM_HPU_FSDPA_SLICE_WITH_GRAPH_BREAKS` | Places each chunk in a separate graph to reduce compilation time.                            | `true` for lazy mode and `false` otherwise  |

> [!IMPORTANT]
> These parameters are effective only with the padding-aware bucketing strategy set by `VLLM_BUCKETING_STRATEGY="pad"`.


## Implementation
Take the prefix-prefill with `[bs, query, context] = [1, 9037, 8832]` as an example. The prefill shape will first be padded to `[1, 10880, 11008]` by the bucketing. The attention mask will be looks like:
![fsdpa_apc_b1_s9037_c8832_pb1_ps10880_pc11008_attention_mask](https://github.com/user-attachments/assets/f11540c1-0c5d-4e5d-92d6-4b3b42b473f0)

> Not that there are padding in query and context dimensions.

The original implementation pass the full attention mask to the FusedSDPA kernel.

This PR introduced an implementation to calculate the FSDPA in chunks by slicing the `Q`, `K` and `V` as below:
![fsdpa_apc_b1_s9037_c8832_pb1_ps10880_pc11008_bf16_SliceQKV](https://github.com/user-attachments/assets/a830612a-3e46-48a0-9b1a-3c9102598a2e)

Where the color of the rectangles differentiate the `is_causal` and `attn_mask` parameters passed to the FusedSDPA kernel:
- `rgb(255,0,0)`: `is_causal=False` and `attn_mask is not None`
- `rgb(255,255,0)`: `is_causal=True` and `attn_mask=None`
- `rgb(255,0,255)`: `is_causal=False` and `attn_mask=None`

In this way, most of the chunks call the FusedSDPA without attention mask to get better performance, and the graph for the chunks might be reused across different buckets to reduce the warmup duration.

## Dependencies
- https://github.com/vllm-project/vllm-gaudi/pull/762 as the number of chunks with padding is determined by the `PAD_MAX` for the query and context.

---
### Thanks @Wei-Lin-Intel for the original idea and the detailed behavior of the FusedSDPA kernel.