### PR TITLE
[FIX_FOR_VLLM_LATEST] adapt to upstream OffloadingSpec kv_cache_config refactor (GAUDISW-247307)

### DIFF
--- a/tests/unit_tests/kv_offload/test_offloading_connector.py
+++ b/tests/unit_tests/kv_offload/test_offloading_connector.py
@@ -110,7 +110,7 @@ class MockOffloadingSpec(OffloadingSpec):
 
         self.manager = MagicMock(spec=OffloadingManager)
         self.manager.lookup.return_value = 0
-        self.manager.prepare_load = lambda block_hashes: MockLoadStoreSpec(block_hashes)
+        self.manager.prepare_load = lambda block_hashes: (MockLoadStoreSpec(block_hashes))
         self.handler = MockOffloadingHandler()
 
     def get_manager(self) -> OffloadingManager:
@@ -349,7 +349,7 @@ class RequestRunner:
 
             self.scheduler.update_from_output(scheduler_output, model_runner_output)
 
-            if prev_token_id is EOS_TOKEN_ID and prev_token_id != token_id and self.scheduler.requests:
+            if (prev_token_id is EOS_TOKEN_ID and prev_token_id != token_id and self.scheduler.requests):
                 # continue for one more step to allow offloading to kick off
                 continue
 
@@ -463,7 +463,7 @@ def test_offloading_connector(request_runner):
     # 3 blocks, store just the middle block (skip first and last)
     # blocks = [0, 1, 2], [3, 4, 5], [6, 7, 8]
     runner.new_request(token_ids=[0] * offloaded_block_size * 3)
-    runner.manager.prepare_store.side_effect = lambda block_hashes: generate_store_output(list(block_hashes)[1:2])
+    runner.manager.prepare_store.side_effect = (lambda block_hashes: generate_store_output(list(block_hashes)[1:2]))
     runner.run(decoded_tokens=[0])
 
     # add block missing 1 token -> no offload
@@ -479,11 +479,11 @@ def test_offloading_connector(request_runner):
     runner.manager.prepare_store.assert_called()
 
     # 1 more block, now set block_hashes_to_store = []
-    runner.manager.prepare_store.side_effect = lambda block_hashes: generate_store_output([])
+    runner.manager.prepare_store.side_effect = (lambda block_hashes: generate_store_output([]))
     runner.run(decoded_tokens=[0] * offloaded_block_size)
 
     # 1 more block, now check touch was called with all 6 blocks
-    runner.manager.prepare_store.side_effect = lambda block_hashes: generate_store_output(block_hashes)
+    runner.manager.prepare_store.side_effect = (lambda block_hashes: generate_store_output(block_hashes))
     runner.run(decoded_tokens=[0] * offloaded_block_size)
     runner.manager.touch.assert_called()
     block_hashes1 = list(runner.manager.touch.call_args.args[0])
@@ -514,13 +514,13 @@ def test_offloading_connector(request_runner):
 
     # full_block_tokens - num_computed_tokens < offloaded_block_size
     runner.new_request(token_ids=[0] * gpu_block_size + [1] * (offloaded_block_size - gpu_block_size))
-    runner.manager.prepare_store.side_effect = lambda block_hashes: generate_store_output([])
+    runner.manager.prepare_store.side_effect = (lambda block_hashes: generate_store_output([]))
     runner.run(decoded_tokens=[EOS_TOKEN_ID])
     runner.manager.lookup.assert_not_called()
 
     # single block lookup with no hits
     runner.new_request(token_ids=[1] * offloaded_block_size)
-    runner.manager.prepare_store.side_effect = lambda block_hashes: generate_store_output([])
+    runner.manager.prepare_store.side_effect = (lambda block_hashes: generate_store_output([]))
     runner.run(decoded_tokens=[EOS_TOKEN_ID])
     runner.manager.lookup.assert_called()
     assert len(list(runner.manager.lookup.call_args.args[0])) == 1
@@ -528,13 +528,13 @@ def test_offloading_connector(request_runner):
     # single block lookup with a hit
     runner.scheduler.reset_prefix_cache()
     runner.new_request(token_ids=[0] * offloaded_block_size)
-    runner.manager.prepare_store.side_effect = lambda block_hashes: generate_store_output([])
+    runner.manager.prepare_store.side_effect = (lambda block_hashes: generate_store_output([]))
     runner.manager.lookup.return_value = 1
     runner.run(decoded_tokens=[EOS_TOKEN_ID], expected_loaded_gpu_block_indexes=(0, 1, 2))
 
     # single block lookup with a hit in a middle block
     runner.new_request(token_ids=[0] * offloaded_block_size * 2 + [1] * offloaded_block_size)
-    runner.manager.prepare_store.side_effect = lambda block_hashes: generate_store_output([])
+    runner.manager.prepare_store.side_effect = (lambda block_hashes: generate_store_output([]))
     runner.manager.lookup.return_value = 1
     runner.run(decoded_tokens=[EOS_TOKEN_ID], expected_loaded_gpu_block_indexes=(3, 4, 5))
 
@@ -581,14 +581,14 @@ def test_request_preemption(request_runner):
     # 2 blocks, store all, without flushing
     # blocks = [0, 1, 2], [3, 4, 5]
     runner.new_request(token_ids=[0] * offloaded_block_size * 2)
-    runner.manager.prepare_store.side_effect = lambda block_hashes: generate_store_output(block_hashes)
+    runner.manager.prepare_store.side_effect = (lambda block_hashes: generate_store_output(block_hashes))
     runner.run(
         decoded_tokens=[0],
         complete_transfers=False,
     )
 
     # decode 2 more blocks - 1 gpu block, storing [6, 7, 8] (no flush)
-    runner.manager.prepare_store.side_effect = lambda block_hashes: generate_store_output(block_hashes)
+    runner.manager.prepare_store.side_effect = (lambda block_hashes: generate_store_output(block_hashes))
     runner.run(
         decoded_tokens=[0] * (2 * offloaded_block_size - gpu_block_size),
         complete_transfers=False,
@@ -612,7 +612,7 @@ def test_request_preemption(request_runner):
     # request should now return from preemption
     # re-load [0, ..., 8] from the CPU and store [9, 10, 11]
     runner.manager.lookup.return_value = 3
-    runner.manager.prepare_store.side_effect = lambda block_hashes: generate_store_output(block_hashes)
+    runner.manager.prepare_store.side_effect = (lambda block_hashes: generate_store_output(block_hashes))
     runner.run(
         decoded_tokens=[0] * gpu_block_size,
         expected_loaded_gpu_block_indexes=(0, 1, 2, 3, 4, 5, 6, 7, 8),
@@ -637,7 +637,7 @@ def test_concurrent_lookups_of_the_same_prefix(request_runner):
 
     # store 1 blocks
     runner.new_request(token_ids=[0] * offloaded_block_size)
-    runner.manager.prepare_store.side_effect = lambda block_hashes: generate_store_output(block_hashes)
+    runner.manager.prepare_store.side_effect = (lambda block_hashes: generate_store_output(block_hashes))
     runner.run(
         decoded_tokens=[EOS_TOKEN_ID],
         expected_stored_gpu_block_indexes=(0, 1, 2),
@@ -668,7 +668,7 @@ def test_concurrent_lookups_of_the_same_prefix(request_runner):
     assert transfer_jobs == list(runner.offloading_spec.handler.transfer_specs)
 
     # complete transfers
-    runner.manager.prepare_store.side_effect = lambda block_hashes: generate_store_output([])
+    runner.manager.prepare_store.side_effect = (lambda block_hashes: generate_store_output([]))
     runner.run(
         decoded_tokens=[EOS_TOKEN_ID],
         expected_loaded_gpu_block_indexes=(0, 1, 2),

--- a/vllm_gaudi/v1/kv_offload/worker/cpu_hpu.py
+++ b/vllm_gaudi/v1/kv_offload/worker/cpu_hpu.py
@@ -21,7 +21,7 @@ from vllm.v1.kv_offload.worker.worker import (
 from vllm.v1.kv_offload.cpu import CPUOffloadingSpec
 from vllm.v1.kv_offload.abstract import LoadStoreSpec
 from vllm.v1.kv_offload.mediums import CPULoadStoreSpec, GPULoadStoreSpec
-from vllm.v1.kv_offload.worker.cpu_gpu import SingleDirectionOffloadingHandler, CpuGpuOffloadingHandlers
+from vllm.v1.kv_offload.worker.cpu_gpu import (SingleDirectionOffloadingHandler, CpuGpuOffloadingHandlers)
 
 logger = init_logger(__name__)
 
@@ -35,8 +35,8 @@ class Transfer:
     num_bytes: int
 
 
-is_hetero = os.getenv("PT_HPU_ENABLE_RESTORE_KV_LAYOUT", "0") == "1"
-block_factor = int(os.getenv("PT_HPU_BLOCK_SIZE_FACTOR", "1"))
+is_hetero = os.getenv('PT_HPU_ENABLE_RESTORE_KV_LAYOUT', '0') == '1'
+block_factor = int(os.getenv('PT_HPU_BLOCK_SIZE_FACTOR', '1'))
 
 
 def swap_blocks(
@@ -76,31 +76,31 @@ def swap_blocks(
             block_idx = src_block_ids[0]
             num_blocks = len(src_block_ids)
             dst_kv_caches[0][block_idx * block_size:(num_blocks + block_idx) *
-                             block_size] = (key_cache[block_idx * block_size:(num_blocks + block_idx) *
-                                                      block_size].reshape(num_blocks * block_factor, n_kv_heads,
-                                                                          remote_block_size,
-                                                                          head_dim).permute(0, 2, 1,
-                                                                                            3).contiguous().reshape(
-                                                                                                num_blocks * block_size,
-                                                                                                n_kv_heads, head_dim))
+                             block_size] = key_cache[block_idx * block_size:(num_blocks + block_idx) *
+                                                     block_size].reshape(num_blocks * block_factor, n_kv_heads,
+                                                                         remote_block_size,
+                                                                         head_dim).permute(0, 2, 1,
+                                                                                           3).contiguous().reshape(
+                                                                                               num_blocks * block_size,
+                                                                                               n_kv_heads, head_dim)
             dst_kv_caches[1][block_idx * block_size:(num_blocks + block_idx) *
-                             block_size] = (value_cache[block_idx *
-                                                        block_size:(num_blocks + block_idx) * block_size].reshape(
-                                                            num_blocks * block_factor, n_kv_heads, remote_block_size,
-                                                            head_dim).permute(0, 2, 1, 3).contiguous().reshape(
-                                                                num_blocks * block_size, n_kv_heads, head_dim))
+                             block_size] = value_cache[block_idx *
+                                                       block_size:(num_blocks + block_idx) * block_size].reshape(
+                                                           num_blocks * block_factor, n_kv_heads, remote_block_size,
+                                                           head_dim).permute(0, 2, 1, 3).contiguous().reshape(
+                                                               num_blocks * block_size, n_kv_heads, head_dim)
 
         for block_idx in src_block_ids:
             dst_kv_caches[0][block_idx * block_size:(1 + block_idx) *
-                             block_size] = (key_cache[block_idx * block_size:(1 + block_idx) * block_size].reshape(
+                             block_size] = key_cache[block_idx * block_size:(1 + block_idx) * block_size].reshape(
                                  block_factor, n_kv_heads, remote_block_size,
                                  head_dim).permute(0, 2, 1, 3).contiguous().reshape(block_size, n_kv_heads,
-                                                                                    head_dim).to("hpu"))
+                                                                                    head_dim).to("hpu")
             dst_kv_caches[1][block_idx * block_size:(1 + block_idx) *
-                             block_size] = (value_cache[block_idx * block_size:(1 + block_idx) * block_size].reshape(
+                             block_size] = value_cache[block_idx * block_size:(1 + block_idx) * block_size].reshape(
                                  block_factor, n_kv_heads, remote_block_size,
                                  head_dim).permute(0, 2, 1, 3).contiguous().reshape(block_size, n_kv_heads,
-                                                                                    head_dim).to("hpu"))
+                                                                                    head_dim).to("hpu")
     else:
         dst_kv_caches[0].index_put_((dst_block_ids, ), key_cache.index_select(0, src_block_ids).to(target_device))
         dst_kv_caches[1].index_put_((dst_block_ids, ), value_cache.index_select(0, src_block_ids).to(target_device))
@@ -110,14 +110,8 @@ def swap_blocks(
     logger.debug(
         "swap_blocks: copy takes %s|direction=%s|pid=%s|block_size=%s|"
         "src_block_ids_len=%s|dst_block_ids_len=%s|src_kv_caches_len=%s|",
-        time.perf_counter() - start,
-        direction,
-        os.getpid(),
-        block_size,
-        len(src_block_ids),
-        len(dst_block_ids),
-        len(src_kv_caches),
-    )
+        time.perf_counter() - start, direction, os.getpid(), block_size, len(src_block_ids), len(dst_block_ids),
+        len(src_kv_caches))
 
 
 def expand_block_ids(
@@ -225,8 +219,8 @@ def transfer_async(self, job_id: int, transfer_spec: TransferSpec) -> bool:
     src_to_dst_tensor = torch.from_numpy(src_to_dst)
 
     stream = self._stream_pool.pop() if self._stream_pool else torch.hpu.Stream()
-    start_event = self._event_pool.pop() if self._event_pool else torch.Event(enable_timing=True)
-    end_event = self._event_pool.pop() if self._event_pool else torch.Event(enable_timing=True)
+    start_event = (self._event_pool.pop() if self._event_pool else torch.Event(enable_timing=True))
+    end_event = (self._event_pool.pop() if self._event_pool else torch.Event(enable_timing=True))
 
     if self.gpu_to_cpu:
         # wait for model computation to finish before offloading
@@ -243,7 +237,7 @@ def transfer_async(self, job_id: int, transfer_spec: TransferSpec) -> bool:
                 self.dst_tensors,
                 self.block_size_in_bytes,
         ):
-            swap_blocks(src_tensor, dst_tensor, src_to_dst_tensor,
+            swap_blocks(src_tensor, dst_tensor, src_to_dst_tensor, \
                         "d2h" if self.src_tensors[0].device.type == "hpu" else "h2d")
         end_event.record(stream)
 
@@ -280,9 +274,8 @@ def CpuGpuOffloadingHandlers_init_(
     for layer_name, gpu_tensor in gpu_caches.items():
         gpu_shape = gpu_tensor.shape
         attn_backend = attn_backends[layer_name]
-        test_shape = attn_backend.get_kv_cache_shape(
-            num_blocks=1234, block_size=128, num_kv_heads=8,
-            head_size=256)  # (num_blocks * block_size, num_kv_heads, head_size)
+        test_shape = attn_backend.get_kv_cache_shape(num_blocks=1234, block_size=128, num_kv_heads=8,
+                                                     head_size=256)  #(num_blocks * block_size, num_kv_heads, head_size)
         test_shape = (2, test_shape[0] // 128, 128, test_shape[1], test_shape[2])
 
         has_layers_dim = False


### PR DESCRIPTION
## Summary

Adapts vllm-gaudi to upstream vLLM commit `cfaf4668f` (PR [#36610](https://github.com/vllm-project/vllm/pull/36610) "[kv_offload+HMA][1/N]: Support multiple KV groups in OffloadingSpec") which introduced breaking changes to the offloading connector APIs.

## Changes

### 1. `tests/unit_tests/kv_offload/test_offloading_connector.py`
- Create a `KVCacheConfig` and pass it to `OffloadingConnector` constructor (now required by upstream assertion)

### 2. `vllm_gaudi/v1/kv_offload/worker/cpu_hpu.py`
- Update monkey-patched `get_handlers` to use new attribute names:
  - `self.gpu_block_size` is now `tuple[int, ...]` → extract with `self.gpu_block_size[0]`
  - `self.offloaded_block_size` removed → compute as `gpu_block_size * self.block_size_factor`

## Verified on HPU
- **offloading_connector tests**: 9 passed on Gaudi 3 (g3)
- **CPU offloading engine init**: LLM initialized successfully on Gaudi 3 (g3)

## CI Run (Failure)
https://github.com/vllm-project/vllm-gaudi/actions/runs/23042890934

## Jira
[GAUDISW-247307](https://jira.devtools.intel.com/browse/GAUDISW-247307)