### PR TITLE
[FIX_FOR_VLLM_LATEST] Rename get_eagle3_aux_hidden_state_layers to get_eagle3_default_aux_hidden_state_layers

### DIFF
--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -4370,7 +4370,7 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
                 if self.use_aux_hidden_state_outputs:
                     if supports_eagle3(self.model.model):
                         self.model.model.set_aux_hidden_state_layers(
-                            self.model.model.get_eagle3_aux_hidden_state_layers())
+                            self.model.model.get_eagle3_default_aux_hidden_state_layers())
                     else:
                         raise RuntimeError("Model does not support EAGLE3 interface but "
                                            "aux_hidden_state_outputs was requested")


### PR DESCRIPTION
## Summary

Upstream vLLM commit 8b346309a (`[Refactor] Consolidate SupportsEagle (#36063)`) renamed `get_eagle3_aux_hidden_state_layers()` to `get_eagle3_default_aux_hidden_state_layers()`. This broke all eagle3 spec decode tests in hourly CI.

## Changes

- `vllm_gaudi/v1/worker/hpu_model_runner.py`: Rename method call to match upstream API change.

## Verification

- **HPU verified**: Eagle3 spec decode test passed on Gaudi3 (1 card) with `meta-llama/Meta-Llama-3-8B-Instruct` + `yuhuili/EAGLE3-LLaMA3.1-Instruct-8B`.
- Fixes CI jobs: `run_spec_decode_eagle3_test`, `run_UA_spec_decode_eagle3_test`, `run_spec_decode_eagle3_num_spec_2_test`.

## Related

- Breaking upstream commit: https://github.com/vllm-project/vllm/commit/8b346309a

Signed-off-by: Tomasz Zielinski <tomasz.zielinski@intel.com>