### PR TITLE
Fix -u flag requiring argument in calibrate_model.sh (#1121)

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -569,6 +569,26 @@ jobs:
           EXITCODE=$?
           echo "Test script exited with code: $EXITCODE"
 
+  calibration_arg_parsing_tests:
+    needs: [pre_merge_hpu_test_build, discover_runner, retrieve_head_sha]
+    runs-on: ${{ needs.discover_runner.outputs.runner_name }}
+    steps:
+      - name: Run calibration arg parsing tests
+        run: |
+          EXITCODE=1
+          CONTAINER_NAME="hpu-plugin-test-calibration-arg-parsing-${{ needs.retrieve_head_sha.outputs.head_sha }}"
+          remove_docker_containers() { docker rm -f $CONTAINER_NAME || true; }
+          trap 'remove_docker_containers; exit $EXITCODE;' EXIT
+          remove_docker_containers
+
+          echo "Running calibration arg parsing tests"
+          docker run --rm --name=$CONTAINER_NAME \
+             hpu-plugin-v1-test-env-pre-merge-${{ needs.retrieve_head_sha.outputs.head_sha }} \
+            /bin/bash "/workspace/vllm-gaudi/tests/calibration_tests/test_calibrate_model_arg_parsing.sh"
+
+          EXITCODE=$?
+          echo "Test script exited with code: $EXITCODE"
+
   # Build-test production Dockerfiles when they are modified
   check_dockerfile_changes:
     needs: [retrieve_head_sha]
@@ -620,7 +640,7 @@ jobs:
 
   pre_merge_hpu_test:
     # --- UPDATED: Add discover_runner dependency ---
-    needs: [hpu_unit_tests, e2e, hpu_perf_tests, calibration_tests, discover_runner]
+    needs: [hpu_unit_tests, e2e, hpu_perf_tests, calibration_tests, calibration_arg_parsing_tests, discover_runner]
     # --- UPDATED: Run on the specific node ---
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
     # This job is required to pass for pre-merge CI. By itself it does nothing, and will only pass if all jobs specified in "needs" list pass.
@@ -650,7 +670,7 @@ jobs:
   cleanup_docker_image:
     name: Cleanup Docker Image
     if: always()
-    needs: [discover_runner, hpu_unit_tests, hpu_pd_tests, hpu_perf_tests, hpu_dp_tests, e2e, calibration_tests]
+    needs: [discover_runner, hpu_unit_tests, hpu_pd_tests, hpu_perf_tests, hpu_dp_tests, e2e, calibration_tests, calibration_arg_parsing_tests]
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
     steps:
       - name: Remove Docker image to free up space

--- a/calibration/calibrate_model.sh
+++ b/calibration/calibrate_model.sh
@@ -95,7 +95,7 @@ MULTI_NODE_SETUP=false
 USE_EP=""
 ENFORCE_EAGER=false
 
-while getopts "m:b:l:t:d:h:o:r:u:e" OPT; do
+while getopts "m:b:l:t:d:h:o:r:ue" OPT; do
     case ${OPT} in
         m )
             MODEL_PATH="$OPTARG"

--- a/calibration/vlm-calibration/calibrate_model.sh
+++ b/calibration/vlm-calibration/calibrate_model.sh
@@ -79,7 +79,7 @@ TP_SIZE=1
 eager_mode="off"
 RANK=""
 USE_EP=""
-while getopts "m:b:l:t:d:h:o:r:u:e" OPT; do
+while getopts "m:b:l:t:d:h:o:r:ue" OPT; do
     case ${OPT} in
         m )
             MODEL_PATH="$OPTARG"

--- a/tests/calibration_tests/test_calibrate_model_arg_parsing.sh
+++ b/tests/calibration_tests/test_calibrate_model_arg_parsing.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+###############################################################################
+# Copyright (C) 2024 Habana Labs, Ltd. an Intel Company
+###############################################################################
+# Unit tests for calibrate_model.sh argument parsing.
+# These tests verify flags are correctly defined (boolean vs value-requiring)
+# without running actual calibration (no HPU required).
+###############################################################################
+
+set -e
+
+# Resolve the vllm-gaudi repo root from this test file's location
+# (tests/calibration_tests/ → ../../ = repo root)
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+SCRIPT="${REPO_ROOT}/calibration/calibrate_model.sh"
+VLM_SCRIPT="${REPO_ROOT}/calibration/vlm-calibration/calibrate_model.sh"
+
+PASS=0
+FAIL=0
+
+assert_flag_is_boolean() {
+    local script="$1"
+    local flag="$2"
+    local desc="$3"
+
+    # Run the script with only the boolean flag and no required args.
+    # A correct boolean flag must not produce "option requires an argument" error.
+    # The script will exit with a usage/missing-arg error, which is expected.
+    local err
+    err=$(bash "$script" "-${flag}" 2>&1 || true)
+
+    if echo "$err" | grep -q "option requires an argument -- ${flag}"; then
+        echo "❌ FAIL: ${desc} — flag '-${flag}' wrongly requires an argument"
+        FAIL=$((FAIL + 1))
+    else
+        echo "✅ PASS: ${desc} — flag '-${flag}' is correctly a boolean flag"
+        PASS=$((PASS + 1))
+    fi
+}
+
+assert_flag_requires_argument() {
+    local script="$1"
+    local flag="$2"
+    local desc="$3"
+
+    # A value-requiring flag passed alone must produce "option requires an argument".
+    local err
+    err=$(bash "$script" "-${flag}" 2>&1 || true)
+
+    if echo "$err" | grep -q "option requires an argument -- ${flag}"; then
+        echo "✅ PASS: ${desc} — flag '-${flag}' correctly requires an argument"
+        PASS=$((PASS + 1))
+    else
+        echo "❌ FAIL: ${desc} — flag '-${flag}' should require an argument but does not"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Check the getopts string in a script source file directly.
+# Boolean flags must appear WITHOUT a trailing colon; value flags WITH a colon.
+assert_flag_is_boolean_in_source() {
+    local script="$1"
+    local flag="$2"
+    local desc="$3"
+
+    local getopts_str
+    getopts_str=$(grep -oP '(?<=getopts ")[^"]+' "$script" | head -1)
+
+    # The flag character followed by ':' means "requires argument"
+    if echo "$getopts_str" | grep -qP "${flag}:"; then
+        echo "❌ FAIL: ${desc} — flag '-${flag}' wrongly has ':' (requires argument) in getopts string: '${getopts_str}'"
+        FAIL=$((FAIL + 1))
+    else
+        echo "✅ PASS: ${desc} — flag '-${flag}' is correctly a boolean flag in getopts string: '${getopts_str}'"
+        PASS=$((PASS + 1))
+    fi
+}
+
+assert_flag_requires_argument_in_source() {
+    local script="$1"
+    local flag="$2"
+    local desc="$3"
+
+    local getopts_str
+    getopts_str=$(grep -oP '(?<=getopts ")[^"]+' "$script" | head -1)
+
+    if echo "$getopts_str" | grep -qP "${flag}:"; then
+        echo "✅ PASS: ${desc} — flag '-${flag}' correctly requires an argument in getopts string: '${getopts_str}'"
+        PASS=$((PASS + 1))
+    else
+        echo "❌ FAIL: ${desc} — flag '-${flag}' should have ':' in getopts string but does not: '${getopts_str}'"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "=== Argument parsing tests for calibrate_model.sh ==="
+
+# Regression test for GAUDISW-247047: -u must be a boolean flag (no argument)
+assert_flag_is_boolean "$SCRIPT" "u" "calibrate_model.sh: -u (unify EP) is a boolean flag"
+
+# -e must also be a boolean flag
+assert_flag_is_boolean "$SCRIPT" "e" "calibrate_model.sh: -e (enforce_eager) is a boolean flag"
+
+# Sanity check: value-requiring flags must still require an argument
+assert_flag_requires_argument "$SCRIPT" "m" "calibrate_model.sh: -m (model path) requires an argument"
+assert_flag_requires_argument "$SCRIPT" "d" "calibrate_model.sh: -d (dataset) requires an argument"
+assert_flag_requires_argument "$SCRIPT" "o" "calibrate_model.sh: -o (output dir) requires an argument"
+assert_flag_requires_argument "$SCRIPT" "t" "calibrate_model.sh: -t (tensor parallel size) requires an argument"
+assert_flag_requires_argument "$SCRIPT" "r" "calibrate_model.sh: -r (rank) requires an argument"
+
+echo ""
+echo "=== Argument parsing tests for vlm-calibration/calibrate_model.sh ==="
+
+# Same regression test for the VLM variant.
+# The VLM script runs 'pip install' before getopts, so we verify the getopts
+# string statically from source to avoid dependency on the pip environment.
+assert_flag_is_boolean_in_source "$VLM_SCRIPT" "u" "vlm-calibration/calibrate_model.sh: -u (unify EP) is a boolean flag"
+
+assert_flag_is_boolean_in_source "$VLM_SCRIPT" "e" "vlm-calibration/calibrate_model.sh: -e (eager mode) is a boolean flag"
+
+assert_flag_requires_argument_in_source "$VLM_SCRIPT" "m" "vlm-calibration/calibrate_model.sh: -m (model path) requires an argument"
+assert_flag_requires_argument_in_source "$VLM_SCRIPT" "o" "vlm-calibration/calibrate_model.sh: -o (output dir) requires an argument"
+assert_flag_requires_argument_in_source "$VLM_SCRIPT" "t" "vlm-calibration/calibrate_model.sh: -t (tensor parallel size) requires an argument"
+
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+
+if [ "$FAIL" -ne 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
The -u flag in getopts was incorrectly defined as 'u:' (requiring an argument) instead of 'u' (a boolean flag). This caused the error: 'option requires an argument -- u' when running with -u flag.

---------