### PR TITLE
Fix INC FP8 dynamic quantization for MoE models on HPU

### DIFF
--- a/tests/models/language/generation/inc_maxabs_dynamic_quant_moe.json
+++ b/tests/models/language/generation/inc_maxabs_dynamic_quant_moe.json
@@ -1,0 +1,28 @@
+{
+    "mode": "QUANTIZE",
+    "observer": "maxabs",
+    "scale_method": "ACT_MAXABS_PCS_POW2_WEIGHT_MAXABS_PTS_POW2_HW",
+    "dynamic_quantization": "True",
+    "scale_format": "CONST",
+    "allowlist": {
+        "types": [],
+        "names": [
+            "q_a_proj",
+            "q_b_proj",
+            "kv_a_proj_with_mqa",
+            "o_proj",
+            "qkv_proj",
+            "mlp"
+        ]
+    },
+    "blocklist": {
+        "types": [
+        ],
+        "names": [
+            "lm_head",
+            "visual",
+            "gate"
+        ]
+    },
+    "dump_stats_path": ""
+}

--- a/vllm_gaudi/ops/hpu_fp8.py
+++ b/vllm_gaudi/ops/hpu_fp8.py
@@ -5,6 +5,7 @@ import torch
 from vllm_gaudi import envs
 from torch.nn.parameter import Parameter
 from vllm.model_executor.layers.fused_moe.layer import FusedMoE
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 
 from vllm.model_executor.layers.quantization import fp8
 from vllm.model_executor.layers.quantization.fp8 import (Fp8LinearMethod as OrigFp8LinearMethod, Fp8MoEMethod,
@@ -226,7 +227,7 @@ class HPUFp8MoEMethod(Fp8MoEMethod):
             topk_ids,
             topk_weights,
             permuted_weights=True,
-            activation=layer.activation,
+            activation=layer.activation if not isinstance(layer.activation, MoEActivation) else layer.activation.value,
         )
         return output.view(*(output.size(0), *input_shape[1:]))
 

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -172,6 +172,33 @@ def _override_platform_device_type(device_type: str):
         current_platform.device_type = original
 
 
+def _move_remaining_tensors_to_device(model: torch.nn.Module, device: str) -> None:
+    """Move non-Parameter/non-buffer tensors left on the wrong device.
+
+    ``nn.Module.to()`` only traverses ``_parameters``, ``_buffers`` and
+    child ``_modules``.  Tensors stored as plain attributes or inside
+    Python lists/tuples (e.g. INC scale inverses, deepstack embeds,
+    dynamic-KV-quant range scalars) are invisible to it.  This helper
+    walks every module's ``__dict__`` and moves stray tensors in-place.
+    """
+    target_type = torch.device(device).type
+    moved = 0
+    for mod in model.modules():
+        for attr_name in list(mod.__dict__.keys()):
+            obj = mod.__dict__[attr_name]
+            if isinstance(obj, torch.Tensor) and obj.device.type != target_type:
+                mod.__dict__[attr_name] = obj.to(device)
+                moved += 1
+            elif isinstance(obj, list):
+                for i, item in enumerate(obj):
+                    if isinstance(item, torch.Tensor) \
+                            and item.device.type != target_type:
+                        obj[i] = item.to(device)
+                        moved += 1
+    if moved:
+        logger.info("Moved %d stray tensors to %s", moved, device)
+
+
 class BucketingFailedException(Exception):
     pass
 
@@ -4332,6 +4359,10 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
                     raise ValueError("Unknown quantization config mode,"
                                      "please validate quantization config file")
                 self._sync_shared_moe_gates()
+                if not is_fake_hpu():
+                    self.model = self.model.to("hpu")
+                    _move_remaining_tensors_to_device(self.model, "hpu")
+                    htorch.core.mark_step()
                 if not disable_mark_scales_as_const:
                     htcore.hpu_initialize(self.model, mark_only_scales_as_const=True)
             self.inc_initialized_successfully = True
@@ -4608,6 +4639,20 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
         _apply_inc_patch()
         self._detached_moe_gates: set[int] = set()
         self._remove_duplicate_submodules()
+        # INC's PatchedMixtralMoE.maybe_all_reduce_tensor_model_parallel
+        # accesses use_pplx_kernels / use_deepep_ht_kernels /
+        # use_deepep_ll_kernels directly on the wrapped module. These
+        # attributes were removed from upstream vLLM FusedMoE (moved to
+        # moe_parallel_config). Add compatibility shims so INC doesn't
+        # crash.  On HPU none of these EP/pplx backends are used.
+        for mod in self.model.modules():
+            if isinstance(mod, FusedMoE):
+                if not hasattr(mod, "use_pplx_kernels"):
+                    mod.use_pplx_kernels = False
+                if not hasattr(mod, "use_deepep_ht_kernels"):
+                    mod.use_deepep_ht_kernels = False
+                if not hasattr(mod, "use_deepep_ll_kernels"):
+                    mod.use_deepep_ll_kernels = False
 
     def log_graph_warmup_summary(self, buckets, is_prompt, total_mem):
         phase = f'Graph/{"Prompt" if is_prompt else "Decode"}'


### PR DESCRIPTION
Same PR as https://github.com/vllm-project/vllm-gaudi/pull/1183 but for 0.17.1 release.

Three issues prevented INC (Intel Neural Compressor) FP8 dynamic
quantization from working on Qwen3-VL MoE models:

MoEActivation enum vs string: HPU fused MoE op expected a string
activation name (e.g. "silu") but upstream vLLM now wraps it in a
MoEActivation enum. Extract .value when the activation is an enum.

FusedMoE missing attributes: INC's PatchedMixtralMoE accesses
use_pplx_kernels, use_deepep_ht_kernels, and use_deepep_ll_kernels
directly on the module, but upstream vLLM moved these to
moe_parallel_config. Add False shims in _inc_preprocess() since
none of these EP/pplx backends apply on HPU.

Stray CPU tensors after INC conversion: INC stores scale inverses,
deepstack embeddings, and dynamic-KV-quant range scalars as plain
dict attributes or inside Python lists, which nn.Module.to()
does not traverse. Add _move_remaining_tensors_to_device() helper
to walk every module's dict and move tensors to HPU, followed
by model.to("hpu") and mark_step() after INC conversion.

User should add these to their command.
VLLM_DYNAMIC_KV_QUANT=1 \
QUANT_CONFIG="inc_maxabs_dynamic_quant_moe.json" \