### PR TITLE
fix: include all sub-packages in setuptools package discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ Homepage = "https://github.com/vllm-project/vllm-gaudi"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["vllm_gaudi"]
+include = ["vllm_gaudi*"]
 
 [tool.yapf]
 column_limit = 120


### PR DESCRIPTION
## Summary

Fixes #1211

The `[tool.setuptools.packages.find]` section in `pyproject.toml` uses `include = ["vllm_gaudi"]`, which only matches the top-level package directory. In modern setuptools (77+), this declarative `pyproject.toml` configuration takes precedence over `setup.py`'s `find_packages()` during PEP 517 builds (`pip wheel`, `python -m build`).

The result is a wheel containing only the top-level `vllm_gaudi/` files (`__init__.py`, `_version.py`, `envs.py`, `platform.py`, `utils.py`), with **all 16 sub-packages silently excluded**:

- `vllm_gaudi.extension` (+ `bucketing`)
- `vllm_gaudi.attention` (+ `backends`, `ops`)
- `vllm_gaudi.distributed` (+ `device_communicators`, `kv_transfer`)
- `vllm_gaudi.models`
- `vllm_gaudi.ops`
- `vllm_gaudi.v1` (+ `attention`, `spec_decode`, `worker`, `kv_offload`)
- `vllm_gaudi.lora`

That's 95+ Python modules missing from the built wheel.

## Root Cause

In setuptools, the `include` patterns in `[tool.setuptools.packages.find]` are matched using `fnmatch`. The pattern `"vllm_gaudi"` matches only the literal string `vllm_gaudi` — it does **not** match dotted sub-package names like `vllm_gaudi.extension`.

While `setup.py` calls `find_packages(exclude=("docs", "examples", "tests*", "csrc"))` which correctly discovers all sub-packages, setuptools >= 61.0 gives `pyproject.toml` declarative configuration precedence over `setup.py` keyword arguments during PEP 517 builds.

This issue does not surface when:
- Building with older setuptools versions (< 61.0)
- Using `python setup.py bdist_wheel` directly (non-PEP 517 path)

## Fix

One-character change: `include = ["vllm_gaudi"]` → `include = ["vllm_gaudi*"]`. The glob wildcard correctly matches the top-level package and all nested sub-packages.

## Verification

```python
# Before fix: only top-level package included
>>> import fnmatch
>>> fnmatch.fnmatch("vllm_gaudi.extension", "vllm_gaudi")
False

# After fix: all sub-packages included
>>> fnmatch.fnmatch("vllm_gaudi.extension", "vllm_gaudi*")
True
```

Built and verified the wheel with the fix using setuptools 78.x — all 95+ modules across 16 sub-packages present.

Made with [Cursor](https://cursor.com)