### PR TITLE
avoid using pip show to get habana-torch-plugin version

### DIFF
--- a/vllm_gaudi/extension/environment.py
+++ b/vllm_gaudi/extension/environment.py
@@ -4,7 +4,10 @@
 # This source code is licensed under the Apache 2.0 license found in the
 # LICENSE file in the root directory of this source tree.
 ###############################################################################
+import importlib
 import os
+
+from contextlib import suppress
 
 from .logger import logger
 from .config import Value, boolean, split_values_and_flags, Any, Disabled, Enabled
@@ -52,17 +55,12 @@ def _get_vllm_hash(_):
 
 
 def _get_build(_):
-    import re
-    import subprocess
-    output = subprocess.run("pip show habana-torch-plugin",
-                            shell=True,
-                            text=True,
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE)
-    version_re = re.compile(r'Version:\s*(?P<version>.*)')
-    match = version_re.search(output.stdout)
-    if output.returncode == 0 and match:
-        return match.group('version')
+    with suppress(importlib.metadata.PackageNotFoundError):
+        metadata = importlib.metadata.metadata("habana-torch-plugin")
+        version = metadata.get("Version")
+        if version:
+            return version
+
     # In cpu-test environment we don't have access to habana-torch-plugin
     from vllm_gaudi.extension.utils import is_fake_hpu
     result = '0.0.0.0' if is_fake_hpu() else None


### PR DESCRIPTION
When `pip` is not installed, the `subprocess` call will fail, and the plugin will fail to initialize.

`importlib.metadata` is a cleaner way to get plugin version info.
