### PR TITLE
feat: reduce torch.compile warmup recompilations for Qwen3 MoE

### DIFF
--- a/docs/configuration/env_variables.md
+++ b/docs/configuration/env_variables.md
@@ -24,6 +24,7 @@ This document lists the supported diagnostic and profiling, as well as performan
 | `VLLM_BUCKETING_FROM_FILE`   | Enables reading bucket configuration from file | `None`        |
 | `VLLM_ROW_PARALLEL_CHUNKS`   | Number of chunks to split input into for pipelining matmul with all-reduce in RowParallelLinear layers. Setting to a value greater than 1 enables chunking. See [Row-Parallel Chunking](../features/row_parallel_chunking.md). | `1` (disabled) |
 | `VLLM_ROW_PARALLEL_CHUNK_THRESHOLD` | Minimum number of tokens required to activate row-parallel chunking. Inputs below this threshold use the standard non-chunked path. | `8192` |
+| `VLLM_MOE_GRAPH_BREAK`   | Inserts a `torch._dynamo.graph_break()` between attention and MLP in MoE decoder layers. Reduces `torch.compile` warmup recompilations at the cost of additional graph-break overhead at runtime. | `false`        |
 
 ## Developer Mode Parameters
 

--- a/vllm_gaudi/extension/features.py
+++ b/vllm_gaudi/extension/features.py
@@ -40,6 +40,9 @@ def get_user_flags():
         Env('PT_HPU_WEIGHT_SHARING', str),
         Env('RUNTIME_SCALE_PATCHING', str),
 
+        # Graph break controls
+        Env('VLLM_MOE_GRAPH_BREAK', boolean),
+
         # Sliding window flags
         Env('PT_HPU_SDPA_QKV_SLICE_MODE_FWD', boolean),
         Env('PT_HPU_SDPA_BC_FACTOR', int),
@@ -100,6 +103,7 @@ def get_features():
         Value('moe_chunk', "", env_var='VLLM_MOE_CHUNK', env_var_type=list_of(int)),
         Value('moe_token_boundary', "", env_var='VLLM_MOE_TOKEN_BOUNDARY', env_var_type=list_of(int)),
         Value('split_moe_compilation', False, env_var='VLLM_SPLIT_MOE_COMPILATION', env_var_type=boolean),
+        Value('moe_graph_break', False, env_var='VLLM_MOE_GRAPH_BREAK', env_var_type=boolean),
         Value('row_parallel_chunks', 1, env_var='VLLM_ROW_PARALLEL_CHUNKS', env_var_type=int),
         Value('row_parallel_chunk_threshold', 8192, env_var='VLLM_ROW_PARALLEL_CHUNK_THRESHOLD', env_var_type=int),
         Value('use_dispatch_fn',

--- a/vllm_gaudi/models/__init__.py
+++ b/vllm_gaudi/models/__init__.py
@@ -41,6 +41,9 @@ def register_model():
     from vllm_gaudi.models.seed_oss import HpuSeedOssForCausalLM  # noqa: F401
     ModelRegistry.register_model("SeedOssForCausalLM", "vllm_gaudi.models.seed_oss:HpuSeedOssForCausalLM")
 
+    from vllm_gaudi.models.qwen3_moe import HpuQwen3MoeForCausalLM  # noqa: F401
+    ModelRegistry.register_model("Qwen3MoeForCausalLM", "vllm_gaudi.models.qwen3_moe:HpuQwen3MoeForCausalLM")
+
     import vllm_gaudi.models.deepseek_v2  # noqa: F401
 
     from vllm_gaudi.models.deepseek_ocr import HpuDeepseekOCRForCausalLM  # noqa: F401

--- a/vllm_gaudi/models/qwen3_moe.py
+++ b/vllm_gaudi/models/qwen3_moe.py
@@ -1,10 +1,20 @@
 import torch
 from torch import nn
 
+from vllm.config import VllmConfig
+from vllm.distributed import get_pp_group, tensor_model_parallel_all_gather
 from vllm.model_executor.models.qwen3_moe import (
-    Qwen3MoeSparseMoeBlock as UpstreamQwen3MoeSparseMoeBlock, )
+    Qwen3MoeDecoderLayer as UpstreamQwen3MoeDecoderLayer,
+    Qwen3MoeForCausalLM as UpstreamQwen3MoeForCausalLM,
+    Qwen3MoeModel as UpstreamQwen3MoeModel,
+    Qwen3MoeSparseMoeBlock as UpstreamQwen3MoeSparseMoeBlock,
+)
 from vllm.model_executor.models.utils import sequence_parallel_chunk
-from vllm.distributed import tensor_model_parallel_all_gather
+from vllm.sequence import IntermediateTensors
+
+from vllm_gaudi.extension.runtime import get_config
+
+_moe_graph_break: bool = False
 
 
 class HpuQwen3MoeSparseMoeBlock(UpstreamQwen3MoeSparseMoeBlock):
@@ -54,7 +64,38 @@ class HpuQwen3MoeSparseMoeBlock(UpstreamQwen3MoeSparseMoeBlock):
         return out.reshape(*orig_shape[:-1], hidden_dim)
 
 
+class HpuQwen3MoeDecoderLayer(UpstreamQwen3MoeDecoderLayer):
+    """Insert graph_break between attention and MLP in MoE decoder layers."""
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if residual is None:
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+        else:
+            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+        hidden_states = self.self_attn(
+            positions=positions,
+            hidden_states=hidden_states,
+        )
+
+        if _moe_graph_break:
+            torch._dynamo.graph_break()
+
+        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+        hidden_states = self.mlp(hidden_states)
+
+        return hidden_states, residual
+
+
 def upgrade_qwen3_moe_blocks_inplace(language_model: nn.Module) -> int:
+    global _moe_graph_break
+    _moe_graph_break = get_config().moe_graph_break
+
     lm_model = getattr(language_model, "model", None)
     layers = getattr(lm_model, "layers", None)
     if layers is None:
@@ -67,11 +108,60 @@ def upgrade_qwen3_moe_blocks_inplace(language_model: nn.Module) -> int:
             continue
 
         if isinstance(mlp, HpuQwen3MoeSparseMoeBlock):
-            continue
-
-        if isinstance(mlp, UpstreamQwen3MoeSparseMoeBlock):
+            pass
+        elif isinstance(mlp, UpstreamQwen3MoeSparseMoeBlock):
             mlp.__class__ = HpuQwen3MoeSparseMoeBlock
             mlp._hpu_accept_3d_installed = True
             upgraded += 1
 
+        if isinstance(layer, UpstreamQwen3MoeDecoderLayer) and not isinstance(layer, HpuQwen3MoeDecoderLayer):
+            layer.__class__ = HpuQwen3MoeDecoderLayer
+            upgraded += 1
+
     return upgraded
+
+
+class HpuQwen3MoeModel(UpstreamQwen3MoeModel):
+    """Initialize residual as zeros instead of None to eliminate Dynamo type guard."""
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+    ) -> torch.Tensor | IntermediateTensors | tuple[torch.Tensor, list[torch.Tensor]]:
+        if get_pp_group().is_first_rank:
+            hidden_states = inputs_embeds if inputs_embeds is not None else self.embed_input_ids(input_ids)
+            residual = torch.zeros_like(hidden_states)
+        else:
+            assert intermediate_tensors is not None
+            hidden_states = intermediate_tensors["hidden_states"]
+            residual = intermediate_tensors["residual"]
+
+        aux_hidden_states = []
+        for layer_idx, layer in enumerate(
+                self.layers[self.start_layer:self.end_layer],
+                start=self.start_layer,
+        ):
+            if layer_idx in self.aux_hidden_state_layers:
+                aux_hidden_state = hidden_states + residual
+                aux_hidden_states.append(aux_hidden_state)
+            hidden_states, residual = layer(positions, hidden_states, residual)
+
+        if not get_pp_group().is_last_rank:
+            return IntermediateTensors({"hidden_states": hidden_states, "residual": residual})
+        hidden_states, _ = self.norm(hidden_states, residual)
+
+        if len(aux_hidden_states) > 0:
+            return hidden_states, aux_hidden_states
+        return hidden_states
+
+
+class HpuQwen3MoeForCausalLM(UpstreamQwen3MoeForCausalLM):
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__(vllm_config=vllm_config, prefix=prefix)
+        upgrade_qwen3_moe_blocks_inplace(self)
+        if hasattr(self, "model") and isinstance(self.model, UpstreamQwen3MoeModel):
+            self.model.__class__ = HpuQwen3MoeModel

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -579,6 +579,13 @@ class HpuModelAdapter(torch.nn.Module, HpuKVConnectorModelRunnerMixin):
                                                                                input_ids.size(0), input_ids.size(1),
                                                                                input_ids.device, self.dtype,
                                                                                model_has_chunked_attention)
+        # Avoid 0/1 size specialization on block_list dim 0 for MoE models.
+        # Must be outside compiled regions — mark_unbacked is a forbidden callable.
+        if self.flatten_input:
+            attn_md = kwargs.get('attn_metadata')
+            if (attn_md is not None and getattr(attn_md, 'is_prompt', False)
+                    and getattr(attn_md, 'block_list', None) is not None):
+                _mark_unbacked_dim0(attn_md.block_list)
         if self._rotary_prepare_cos_sin is not None:
             self._rotary_prepare_cos_sin(kwargs['positions'], recompute_cos_sin=self.recompute_cos_sin)
         attn_meta = kwargs.pop('attn_metadata', None)
@@ -628,6 +635,11 @@ class HpuModelAdapter(torch.nn.Module, HpuKVConnectorModelRunnerMixin):
     # @property
     # def sampler(self):
     #    return self.model.sampler
+
+
+@torch.compiler.disable
+def _mark_unbacked_dim0(tensor: torch.Tensor):
+    torch._dynamo.decorators.mark_unbacked(tensor, 0)
 
 
 def _maybe_wrap_in_hpu_graph(*args, **kwargs):


### PR DESCRIPTION
## Summary

Add HPU-specific Qwen3 MoE model classes that reduce `torch.compile` warmup time by eliminating unnecessary recompilations.

## Changes

- **HpuQwen3MoeModel**: Use `torch.zeros_like(hidden_states)` instead of `residual=None` to avoid type guard failures at every decoder layer
- **HpuQwen3MoeSparseMoeBlock**: Handle 3D tensor reshaping and tuple returns from SharedFusedMoE  
- **HpuQwen3MoeDecoderLayer**: Optional `torch._dynamo.graph_break()` between attention and MLP, controlled by `VLLM_MOE_GRAPH_BREAK` env var (boolean, default: `false`)
- **mark_unbacked**: Scope `mark_unbacked` on block_list dim 0 to `flatten_input` (MoE) models only, wrapped in `torch.compiler.disable()` to avoid compilation errors
- **Config**: Register `VLLM_MOE_GRAPH_BREAK` in the config system via `Value()` and `Env()`
- **Docs**: Document `VLLM_MOE_GRAPH_BREAK` in env_variables.md

## Motivation

MoE models like Qwen3-30B-A3B suffer from excessive recompilations during `torch.compile` warmup due to:
1. `residual=None` at the first decoder layer causing type guard failures at every layer boundary
2. Block list tensor size specializations triggering recompilations

This PR reduces warmup recompilations by ~23% and guard failures by ~68% with the residual fix alone. The optional graph break (`VLLM_MOE_GRAPH_BREAK=true`) can further reduce warmup time at the cost of ~9% TPOT overhead at low concurrency.

## Review fixes from #1257

Addresses all feedback from the previous PR (#1257 on releases/v0.17.1):
- ✅ **Copilot + Artur**: Wrapped `mark_unbacked` in `torch.compiler.disable()` to prevent compilation errors
- ✅ **Copilot**: Replaced `os.getenv()` at import time with `get_config().moe_graph_break` from the config system
- ✅ **Copilot**: Fixed PR description to accurately describe `torch._dynamo.graph_break()` (not `torch.compiler.disable()`)
- ✅ **Michał**: Replaced `islice` with standard list slicing for clarity
- ✅ **Michał**: Fixed env var description from `inside/after/none` to `true/false` (boolean)

## Testing

- Validated with Qwen3-30B-A3B (TP=2, EP) on Gaudi3
- Zero runtime recompiles confirmed
- `ruff check` and pre-commit hooks pass