### PR TITLE
[FIX_FOR_VLLM_CUSTOM=e31915063da3f6d6be6080040de28f5bb6945acd] Fix GraphCaptureOutput stub and MultiModalDataDict import path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,11 @@ setup(
     install_requires=get_requirements(),
     ext_modules=ext_modules,
     extras_require={},
+    data_files=[
+        # Install a .pth file so the torch compat shim runs at Python startup,
+        # before ``import vllm`` triggers env_override.py.
+        (".", ["vllm_gaudi_torch_compat.pth"]),
+    ],
     entry_points={
         "vllm.platform_plugins": ["hpu = vllm_gaudi:register"],
         "vllm.general_plugins": [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Root-level conftest – ensures torch compatibility shims are applied
+before any ``import vllm`` happens during the test session.
+"""
+
+import vllm_gaudi._torch_compat  # noqa: F401  -- side-effect: patches GraphCaptureOutput alias

--- a/vllm_gaudi/_torch_compat.py
+++ b/vllm_gaudi/_torch_compat.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Torch compatibility shim for Gaudi's custom PyTorch builds.
+
+Gaudi's PyTorch build (2.9+hpu) cherry-picked the builtins fix from
+upstream PyTorch (pytorch/177558), which renamed ``GraphCaptureOutput``
+to ``CaptureOutput`` and removed the ``get_runtime_env`` method.
+
+vLLM's ``env_override.py`` (guarded by ``not is_torch_equal_or_newer("2.12.0")``)
+tries to import ``GraphCaptureOutput`` and patch its ``get_runtime_env``.
+On Gaudi's build this block must be skipped because the fix is already applied.
+
+We inject a stub ``GraphCaptureOutput`` class with a ``get_runtime_env``
+class-method so that ``env_override.py`` can import and "patch" it without
+error.  The patched method is never actually called because the underlying
+PyTorch code already contains the fix.
+
+This module is loaded:
+* In tests  – via ``tests/conftest.py`` (runs before any ``import vllm``).
+* At runtime – via a ``.pth`` file installed into site-packages so that
+  the shim is in place before *any* Python code imports ``vllm``.
+"""
+
+try:
+    import torch._dynamo.convert_frame as _cf
+
+    if not hasattr(_cf, "GraphCaptureOutput"):
+        # The Gaudi PyTorch build already has the builtins fix applied;
+        # create a stub so that env_override.py can import and monkey-patch
+        # it harmlessly.
+
+        class _GraphCaptureOutputStub:
+            """Stub standing in for the removed GraphCaptureOutput class."""
+
+            def get_runtime_env(self):  # type: ignore[override]
+                """No-op — the real fix is already in this PyTorch build."""
+                return None
+
+        _cf.GraphCaptureOutput = _GraphCaptureOutputStub  # type: ignore[attr-defined]
+except Exception:
+    # If torch._dynamo.convert_frame is unavailable, there is nothing
+    # to patch – silently continue.
+    pass

--- a/vllm_gaudi/models/deepseek_ocr.py
+++ b/vllm_gaudi/models/deepseek_ocr.py
@@ -10,7 +10,7 @@ from vllm.sequence import IntermediateTensors
 from vllm.config import VllmConfig
 from vllm.config.multimodal import BaseDummyOptions
 from vllm.multimodal import MULTIMODAL_REGISTRY
-from vllm.multimodal.inputs import MultiModalDataDict
+from vllm.inputs import MultiModalDataDict
 from vllm.model_executor.models.deepseek_ocr import (
     DeepseekOCRForCausalLM,
     DeepseekOCRMultiModalProcessor,

--- a/vllm_gaudi_torch_compat.pth
+++ b/vllm_gaudi_torch_compat.pth
@@ -1,0 +1,1 @@
+import vllm_gaudi._torch_compat


### PR DESCRIPTION
## Summary

Fixes two import errors introduced by recent upstream vLLM changes that break all CI tests on Gaudi HPU.

### Bug 1: `GraphCaptureOutput` ImportError (blocks all tests)

Upstream vLLM PR [#37234](https://github.com/vllm-project/vllm/pull/37234) (commit `e31915063da`) added a monkey-patch in `env_override.py` guarded by `not is_torch_equal_or_newer("2.12.0")` that imports `GraphCaptureOutput` from `torch._dynamo.convert_frame` and patches its `get_runtime_env` method.

Gaudi's PyTorch build (2.9.0+hpu) cherry-picked the upstream PyTorch fix ([pytorch/177558](https://github.com/pytorch/pytorch/pull/177558)) which:
- Renamed `GraphCaptureOutput` → `CaptureOutput`
- Removed the `get_runtime_env` method (the class is now empty)

Since Gaudi's torch reports version < 2.12.0, vLLM's guard activates and the import fails.

**Fix:** Add a `_torch_compat.py` shim that creates a stub `GraphCaptureOutput` class with a no-op `get_runtime_env` method. The stub satisfies `env_override.py`'s import and monkey-patching without error. The patched method is never called at runtime because Gaudi's PyTorch already contains the underlying fix. The shim is loaded:
- In tests: via `tests/conftest.py` (before any `import vllm`)
- At runtime: via a `.pth` file installed into site-packages

### Bug 2: `MultiModalDataDict` ImportError (affects deepseek_ocr)

Upstream vLLM PR [#35182](https://github.com/vllm-project/vllm/pull/35182) (commit `ba2f0acc2`) moved `MultiModalDataDict` from `vllm.multimodal.inputs` to `vllm.inputs`.

**Fix:** Update the import path in `vllm_gaudi/models/deepseek_ocr.py`.

## Files Changed

| File | Change |
|------|--------|
| `vllm_gaudi/_torch_compat.py` | **NEW** — Torch compat shim with `GraphCaptureOutput` stub |
| `tests/conftest.py` | **NEW** — Root conftest that loads the shim before vLLM imports |
| `vllm_gaudi_torch_compat.pth` | **NEW** — `.pth` file for runtime shim loading |
| `setup.py` | Added `data_files` for `.pth` installation |
| `vllm_gaudi/models/deepseek_ocr.py` | Fixed `MultiModalDataDict` import path |

## HPU Verification

Tested on Gaudi3 pod (torch `2.9.0+hpu_1.23.0`, Python 3.12):
- ✅ `import vllm` succeeds (was crashing before)
- ✅ `pytest tests/unit_tests/ops/test_hpu_fused_moe.py` — 1 passed
- ✅ `deepseek_ocr.py` import reaches past the fixed line

Jira: Related to hourly CI triage findings.
