### PR TITLE
[FIX_FOR_VLLM_CUSTOM=dd9342e6bc92a52a4674a3e472318c241cb18fe1] Fix Pixtral, MoE and Granite regressions

### DIFF
--- a/tests/unit_tests/ops/test_hpu_compressed_tensors.py
+++ b/tests/unit_tests/ops/test_hpu_compressed_tensors.py
@@ -388,7 +388,7 @@ def test_compressed_tensors_wna16_moe_method(default_vllm_config: None, dist_ini
     mock_ctx = MagicMock(spec=["dp_metadata"])
     mock_ctx.dp_metadata = None
     with override_forward_context(mock_ctx):
-        out = oot_op.runner.forward_impl(oot_op, hidden_states, router_logits, hidden_states)
+        out = oot_op.runner.forward_dispatch(oot_op, hidden_states, router_logits, hidden_states)
 
     # Check correctness
     torch.testing.assert_close(ref_output, out, atol=1e-4, rtol=1e-4)

--- a/tests/unit_tests/ops/test_hpu_fused_moe.py
+++ b/tests/unit_tests/ops/test_hpu_fused_moe.py
@@ -41,7 +41,7 @@ def test_unquantized_fused_moe_method(default_vllm_config: None, dist_init):
     mock_ctx = MagicMock(spec=["dp_metadata"])
     mock_ctx.dp_metadata = None
     with override_forward_context(mock_ctx):
-        out = oot_op.runner.forward_impl(oot_op, hidden_states, router_logits, hidden_states)
+        out = oot_op.runner.forward_dispatch(oot_op, hidden_states, router_logits, hidden_states)
 
     # Check correctness
     torch.testing.assert_close(ref_output, out, atol=1e-4, rtol=1e-4)

--- a/vllm_gaudi/attention/backends/hpu_attn.py
+++ b/vllm_gaudi/attention/backends/hpu_attn.py
@@ -17,7 +17,7 @@ from vllm_gaudi.extension.utils import (FP8Matmul, Matmul, B2BMatmul, ModuleFuse
                                         VLLMFP8KVCache, VLLMKVCache)
 
 from vllm.v1.attention.backend import (AttentionBackend, AttentionImpl, AttentionLayer, AttentionMetadata,
-                                       AttentionType)
+                                       AttentionType, MultipleOf)
 from vllm.model_executor.layers.attention.mla_attention import (MLACommonImpl)
 from vllm_gaudi.attention.ops.hpu_paged_attn import (HPUPagedAttention, HPUPagedAttentionMetadata,
                                                      HPUPagedAttentionMetadataBuilder)
@@ -71,6 +71,10 @@ class HPUAttentionBackend(AttentionBackend):
         src_to_dsts: torch.Tensor,
     ) -> None:
         HPUPagedAttention.copy_blocks(kv_caches, src_to_dsts)
+
+    @staticmethod
+    def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
+        return [128]
 
 
 @register_backend(AttentionBackendEnum.CUSTOM, "HPU_MLA")

--- a/vllm_gaudi/models/pixtral.py
+++ b/vllm_gaudi/models/pixtral.py
@@ -98,7 +98,8 @@ class HPUAttention(Attention):
     def forward(self, x: torch.Tensor, mask: torch.Tensor, cos_sin_cache: torch.Tensor) -> torch.Tensor:
         batch, patches, _ = x.shape
 
-        q, k, v = self.wq(x), self.wk(x), self.wv(x)
+        qkv, _ = self.qkv_proj(x)
+        q, k, v = qkv.chunk(3, dim=-1)
         q = q.reshape(batch, patches, self.n_heads, self.head_dim)
         k = k.reshape(batch, patches, self.n_heads, self.head_dim)
         v = v.reshape(batch, patches, self.n_heads, self.head_dim)
@@ -112,7 +113,8 @@ class HPUAttention(Attention):
         out = out.transpose(1, 2)
 
         out = out.reshape(batch, patches, self.n_heads * self.head_dim)
-        return self.wo(out)
+        out, _ = self.o_proj(out)
+        return out
 
 
 class HPUTransformerBlock(TransformerBlock):

--- a/vllm_gaudi/ops/hpu_compressed_tensors.py
+++ b/vllm_gaudi/ops/hpu_compressed_tensors.py
@@ -22,6 +22,10 @@ from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tenso
     SparsityCompressionConfig,
 )
 from vllm.model_executor.layers.quantization.compressed_tensors import (compressed_tensors_moe)
+from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe import (
+    compressed_tensors_moe_wna16,
+    compressed_tensors_moe_wna16_marlin,
+)
 from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (  # noqa: E501
     CompressedTensorsScheme, CompressedTensorsWNA16)
 from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_wNa16 import (  # noqa
@@ -1007,6 +1011,10 @@ compressed_tensors_moe.CompressedTensorsWNA16MoEMethod = \
     HPUCompressedTensorsWNA16MoEMethod
 compressed_tensors_moe.CompressedTensorsWNA16MarlinMoEMethod = \
     HPUCompressedTensorsWNA16MoEMethod # Override default WNA16 MoE method
+compressed_tensors_moe_wna16.CompressedTensorsWNA16MoEMethod = \
+    HPUCompressedTensorsWNA16MoEMethod
+compressed_tensors_moe_wna16_marlin.CompressedTensorsWNA16MarlinMoEMethod = \
+    HPUCompressedTensorsWNA16MoEMethod
 compressed_tensors.CompressedTensorsConfig = HPUCompressedTensorsConfig
 
 # support weight_loader_v2

--- a/vllm_gaudi/ops/hpu_compressed_tensors.py
+++ b/vllm_gaudi/ops/hpu_compressed_tensors.py
@@ -27,8 +27,10 @@ from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
 from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_wNa16 import (  # noqa
     WNA16_SUPPORTED_TYPES_MAP)
 from vllm.model_executor.layers.quantization.compressed_tensors.utils import (find_matched_target)
-from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe import (  # noqa: E501
-    CompressedTensorsW8A8Fp8MoEMethod, CompressedTensorsWNA16MarlinMoEMethod)
+from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe_w8a8_fp8 import (  # noqa: E501
+    CompressedTensorsW8A8Fp8MoEMethod)
+from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe_wna16_marlin import (  # noqa: E501
+    CompressedTensorsWNA16MarlinMoEMethod)
 from vllm.model_executor.kernels.linear.mixed_precision import (
     MPLinearKernel,
     MPLinearLayerConfig,

--- a/vllm_gaudi/ops/hpu_compressed_tensors.py
+++ b/vllm_gaudi/ops/hpu_compressed_tensors.py
@@ -23,6 +23,7 @@ from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tenso
 )
 from vllm.model_executor.layers.quantization.compressed_tensors import (compressed_tensors_moe)
 from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe import (
+    compressed_tensors_moe_w8a8_fp8,
     compressed_tensors_moe_wna16,
     compressed_tensors_moe_wna16_marlin,
 )
@@ -1006,6 +1007,8 @@ class HPUCompressedTensorsConfig(CompressedTensorsConfig):
 compressed_tensors.CompressedTensorsLinearMethod = \
     HPUCompressedTensorsLinearMethod
 compressed_tensors_moe.CompressedTensorsW8A8Fp8MoEMethod = \
+    HPUCompressedTensorsW8A8Fp8MoEMethod
+compressed_tensors_moe_w8a8_fp8.CompressedTensorsW8A8Fp8MoEMethod = \
     HPUCompressedTensorsW8A8Fp8MoEMethod
 compressed_tensors_moe.CompressedTensorsWNA16MoEMethod = \
     HPUCompressedTensorsWNA16MoEMethod

--- a/vllm_gaudi/ops/hpu_fused_moe.py
+++ b/vllm_gaudi/ops/hpu_fused_moe.py
@@ -22,6 +22,8 @@ from vllm.model_executor.layers.fused_moe.router.fused_topk_router import (
     FusedTopKRouter, )
 from vllm.model_executor.layers.fused_moe.router.grouped_topk_router import (
     GroupedTopKRouter, )
+from vllm.model_executor.layers.fused_moe.runner.moe_runner_base import (
+    get_layer_from_name, )
 from vllm.model_executor.layers.fused_moe.router.router_factory import (
     EMPTY_EPLB_STATE, )
 from vllm.model_executor.layers.fused_moe.router.routing_simulator_router import (
@@ -274,7 +276,8 @@ def patched_fused_moe_forward(
     hidden_states, og_hidden_dims = self._maybe_pad_hidden_states(shared_experts_input, hidden_states)
 
     if self.moe_config.dp_size == 1:
-        fused_output = self.forward_dispatch(self.layer, hidden_states, router_logits, shared_experts_input)
+        layer = get_layer_from_name(self.layer_name)
+        fused_output = self.forward_dispatch(layer, hidden_states, router_logits, shared_experts_input)
     else:
         fused_output = self.forward_entry(hidden_states, router_logits, shared_experts_input, self._encode_layer_name())
 
@@ -439,7 +442,7 @@ def create_fused_moe_router(
 
 
 # Apply patches
-# Ensure DefaultMoERunner keeps a reference to its layer for defensive redirects.
+# Keep runner forward patch compatible with upstream layer_name-based dispatch.
 _orig_default_moe_runner_init = DefaultMoERunner.__init__
 _orig_default_moe_runner_forward = DefaultMoERunner.forward
 
@@ -450,9 +453,8 @@ _orig_default_moe_runner_forward = DefaultMoERunner.forward
 _MOE_COMPILE = os.getenv("HPU_FUSED_MOE", "1") == "1"
 
 
-def _patched_default_moe_runner_init(self, layer, *args, **kwargs):
-    self.layer = layer
-    return _orig_default_moe_runner_init(self, layer, *args, **kwargs)
+def _patched_default_moe_runner_init(self, layer_name, *args, **kwargs):
+    return _orig_default_moe_runner_init(self, layer_name, *args, **kwargs)
 
 
 def _patched_default_moe_runner_forward(self, *args, **kwargs):

--- a/vllm_gaudi/ops/hpu_fused_moe.py
+++ b/vllm_gaudi/ops/hpu_fused_moe.py
@@ -269,38 +269,16 @@ def patched_fused_moe_forward(
     hidden_states: torch.Tensor,
     router_logits: torch.Tensor,
 ) -> Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
-    """
-    Patched forward method that bypasses the custom op to avoid recompilation issues.
-    """
-    og_hidden_states = hidden_states.shape[-1]
-    original_hidden_states = hidden_states
-    if self.moe_config.hidden_dim != og_hidden_states:
-        hidden_states = torch.nn.functional.pad(hidden_states, (0, self.hidden_size - og_hidden_states),
-                                                mode='constant',
-                                                value=0.0)
+    """Patched forward with upstream-aligned MoE dispatch flow."""
+    hidden_states, shared_experts_input = self.apply_routed_input_transform(hidden_states)
+    hidden_states, og_hidden_dims = self._maybe_pad_hidden_states(shared_experts_input, hidden_states)
 
-    use_direct_implementation = self.moe_config.dp_size == 1
-    if self.shared_experts is None:
-        if use_direct_implementation:
-            fused_output = self.layer.runner.forward_impl(self.layer, hidden_states, router_logits,
-                                                          original_hidden_states)
-            assert not isinstance(fused_output, tuple)
-            return reduce_output(self, fused_output)[..., :og_hidden_states]
-        else:
-            fused_output = torch.ops.vllm.moe_forward(hidden_states, router_logits, original_hidden_states,
-                                                      self.layer_name)
-
-        return fused_output[..., :og_hidden_states]
+    if self.moe_config.dp_size == 1:
+        fused_output = self.forward_dispatch(self.layer, hidden_states, router_logits, shared_experts_input)
     else:
-        if use_direct_implementation:
-            shared_output, fused_output = self.layer.runner.forward_impl(self.layer, hidden_states, router_logits,
-                                                                         original_hidden_states)
-            shared_output = reduce_output(self, shared_output)
-            fused_output = reduce_output(self, fused_output)
-        else:
-            shared_output, fused_output = torch.ops.vllm.moe_forward_shared(hidden_states, router_logits,
-                                                                            original_hidden_states, self.layer_name)
-        return (shared_output[..., :og_hidden_states], fused_output[..., :og_hidden_states])
+        fused_output = self.forward_entry(hidden_states, router_logits, shared_experts_input, self._encode_layer_name())
+
+    return self._maybe_reduce_output(fused_output, og_hidden_dims)
 
 
 def get_compressed_expert_map(expert_map: torch.Tensor) -> str:

--- a/vllm_gaudi/platform.py
+++ b/vllm_gaudi/platform.py
@@ -240,9 +240,7 @@ class HpuPlatform(Platform):
 
     @classmethod
     def update_block_size_for_backend(cls, vllm_config: "VllmConfig") -> None:
-        # TODO: HPU still sets block_size in check_and_update_config.
-        # Move that logic here so block_size is chosen by the backend.
-        pass
+        super().update_block_size_for_backend(vllm_config)
 
     @classmethod
     def is_pin_memory_available(cls):


### PR DESCRIPTION
## Summary
This PR fixes a set of regressions introduced by recent upstream changes and observed in vLLM-Gaudi hourly validation.

The branch now includes:
- Pixtral HPUAttention projection path fix,
- MoE dispatch and method override alignment updates for fused MoE and compressed tensors,
- unit test updates to match the new MoE runner API usage,
- fix hybrid model page size alignment for Granite 4.0-H.

## Related upstream PRs that introduced the regressions
- https://github.com/vllm-project/vllm/pull/37234
- https://github.com/vllm-project/vllm/pull/35153
- https://github.com/vllm-project/vllm/pull/36963
- https://github.com/vllm-project/vllm/pull/38960
- https://github.com/vllm-project/vllm/pull/35326
- https://github.com/vllm-project/vllm/pull/37467

