### PR TITLE
Separate conv1d for Granite 4.0 (v0.17.1-style)

### DIFF
--- a/vllm_gaudi/ops/granite_causal_conv1d.py
+++ b/vllm_gaudi/ops/granite_causal_conv1d.py
@@ -1,0 +1,195 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+# Copyright (c) 2024, Tri Dao.
+# Adapted from https://github.com/Dao-AILab/causal-conv1d/blob/main/causal_conv1d/causal_conv1d_interface.py
+"""Granite 4.0 specific causal conv1d implementation.
+
+This is a simplified conv1d implementation based on the v0.17.1 code,
+adapted for the v0.19.0 metadata interface (single cache_indices instead
+of separate load/store indices).  It processes one sequence at a time
+(padded_batch == 1) and does not support prefix caching.
+
+Used exclusively by hpu_mamba_mixer2.py (Granite 4.0).  Other models
+continue to use causal_conv1d_pytorch.py.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from vllm_gaudi.ops.causal_conv1d_pytorch import (
+    _apply_activation,
+    _depthwise_conv1d_tpc,
+    _ensure_query_start_loc,
+    _flatten_inputs_for_update,
+    _normalize_activation,
+)
+
+
+def granite_causal_conv1d_fn(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    conv_states: torch.Tensor | None,
+    query_start_loc: torch.Tensor,
+    cache_indices: torch.Tensor | None = None,
+    has_initial_state: torch.Tensor | None = None,
+    activation: str | None = "silu",
+    metadata=None,
+    validate_data: bool = False,
+    is_prompt: bool = True,
+):
+    activation = _normalize_activation(activation)
+    original_dtype = x.dtype
+    work_dtype = conv_states.dtype if conv_states is not None else x.dtype
+    x_work = x.to(work_dtype)
+    weight_work = weight.to(work_dtype)
+    bias_work = bias.to(work_dtype) if bias is not None else None
+
+    assert conv_states is not None
+    if conv_states.device != x_work.device:
+        raise ValueError("'conv_states' must reside on the same device as 'x'.")
+
+    qsl = _ensure_query_start_loc(query_start_loc)
+    assert qsl is not None
+
+    padded_batch = qsl.numel() - 1
+    if padded_batch != 1:
+        raise ValueError(f"'padded_batch' must be 1 but we get {padded_batch}")
+    dim, cu_seqlen = x_work.shape
+    _, width = weight_work.shape
+    state_len = max(width - 1, 0)
+
+    if validate_data:
+        if x_work.dim() != 2:
+            raise ValueError("'x' must be 2-D (dim, cu_seq_len).")
+        if weight_work.shape != (dim, width):
+            raise ValueError("'weight' must have shape (dim, width).")
+        if bias_work is not None and bias_work.shape != (dim, ):
+            raise ValueError("'bias' must match the feature dimension.")
+        if not ((x_work.stride(0) == 1) or (x_work.stride(1) == 1)):
+            raise ValueError("Input tensor must be in channel-last or "
+                             "channel-first memory layout.")
+        if has_initial_state is not None \
+                and has_initial_state.numel() != padded_batch:
+            raise ValueError("'has_initial_state' must align with 'query_start_loc'.")
+
+    seq_x = x_work[:, :]
+
+    # Get init_state for all batch
+    if has_initial_state is not None:
+        init_state = torch.where(has_initial_state, conv_states[cache_indices, -state_len:, :],
+                                 torch.zeros(padded_batch, state_len, dim, device=x_work.device, dtype=work_dtype))
+    else:
+        init_state = torch.zeros(padded_batch, state_len, dim, device=x_work.device, dtype=work_dtype)
+    init_state = init_state.transpose(-1, -2)
+    init_state = init_state.squeeze()
+
+    seq_input = torch.cat([init_state, seq_x], dim=1)
+
+    # Store new state at the end of the sequence
+    end = qsl[-1]
+    idx = torch.arange(state_len, device=x_work.device) + end
+    new_state = seq_input.index_select(dim=1, index=idx)
+    conv_states[cache_indices, -state_len:, :] = new_state.transpose(-1, -2)
+
+    # Apply depthwise convolution using element-wise TPC ops.
+    seq_input = seq_input.unsqueeze(0)
+    seq_out = _depthwise_conv1d_tpc(seq_input, weight_work, bias_work)
+    seq_out = _apply_activation(seq_out, activation)
+
+    return seq_out.squeeze(0).to(original_dtype)
+
+
+def granite_causal_conv1d_update(
+    x: torch.Tensor,
+    conv_state: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    activation: bool | str | None = None,
+    conv_state_indices: torch.Tensor | None = None,
+    query_start_loc: torch.Tensor | None = None,
+    validate_data: bool = False,
+):
+    activation = _normalize_activation(activation)
+    dim = weight.size(0)
+
+    flat_x, qsl, reshape_spec = _flatten_inputs_for_update(x, query_start_loc, dim)
+
+    result = granite_causal_conv1d_fn_update(
+        flat_x,
+        weight,
+        bias,
+        conv_state,
+        qsl,
+        cache_indices=conv_state_indices,
+        has_initial_state=None,
+        activation=activation,
+        metadata=None,
+        validate_data=validate_data,
+        is_prompt=False,
+    )
+
+    return reshape_spec.reshape_fn(result)
+
+
+def granite_causal_conv1d_fn_update(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    conv_states: torch.Tensor | None,
+    query_start_loc: torch.Tensor,
+    cache_indices: torch.Tensor | None = None,
+    has_initial_state: torch.Tensor | None = None,
+    activation: str | None = "silu",
+    metadata=None,
+    validate_data: bool = False,
+    is_prompt: bool = True,
+):
+    activation = _normalize_activation(activation)
+    original_dtype = x.dtype
+    work_dtype = conv_states.dtype if conv_states is not None else x.dtype
+    x_work = x.to(work_dtype)
+    weight_work = weight.to(work_dtype)
+    bias_work = bias.to(work_dtype) if bias is not None else None
+
+    assert conv_states is not None
+    if conv_states.device != x_work.device:
+        raise ValueError("'conv_states' must reside on the same device as 'x'.")
+
+    qsl = _ensure_query_start_loc(query_start_loc)
+    assert qsl is not None
+
+    padded_batch = qsl.numel() - 1
+    _, dim, cu_seqlen = x_work.shape
+    _, width = weight_work.shape
+    state_len = max(width - 1, 0)
+
+    if validate_data:
+        if x_work.dim() != 2:
+            raise ValueError("'x' must be 2-D (dim, cu_seq_len).")
+        if weight_work.shape != (dim, width):
+            raise ValueError("'weight' must have shape (dim, width).")
+        if bias_work is not None and bias_work.shape != (dim, ):
+            raise ValueError("'bias' must match the feature dimension.")
+        if not ((x_work.stride(0) == 1) or (x_work.stride(1) == 1)):
+            raise ValueError("Input tensor must be in channel-last or "
+                             "channel-first memory layout.")
+        if has_initial_state is not None \
+                and has_initial_state.numel() != padded_batch:
+            raise ValueError("'has_initial_state' must align with 'query_start_loc'.")
+
+    init_state = conv_states[cache_indices, -state_len:, :]
+    init_state = init_state.transpose(-1, -2)
+
+    seq_input = torch.cat([init_state, x_work], dim=2)
+    new_state = seq_input[:, :, -state_len:]
+    # Use element-wise TPC depthwise conv to avoid the MME
+    # spatial_convolution input1 weight-transpose stall.
+    seq_out = _depthwise_conv1d_tpc(seq_input, weight_work, bias_work)
+    seq_out = _apply_activation(seq_out, activation)
+
+    conv_states[cache_indices, -state_len:, :] = new_state.transpose(-1, -2)
+
+    return seq_out.to(original_dtype)

--- a/vllm_gaudi/ops/hpu_mamba_mixer2.py
+++ b/vllm_gaudi/ops/hpu_mamba_mixer2.py
@@ -36,9 +36,9 @@ from vllm.model_executor.model_loader.weight_utils import (
 )
 from vllm.model_executor.utils import set_weight_attrs
 
-from vllm_gaudi.ops.causal_conv1d_pytorch import (
-    hpu_causal_conv1d_fn,
-    hpu_causal_conv1d_update,
+from vllm_gaudi.ops.granite_causal_conv1d import (
+    granite_causal_conv1d_fn,
+    granite_causal_conv1d_update,
 )
 from vllm_gaudi.ops.ssd_combined import hpu_mamba_chunk_scan_combined_varlen
 from vllm_gaudi.ops.ops_selector import get_selective_state_update_impl
@@ -370,7 +370,6 @@ class HPUMambaMixer2(MambaMixer2):
         attn_metadata: AttentionMetadata = forward_context.attn_metadata
 
         assert self.cache_config is not None
-        mamba_block_size = self.cache_config.mamba_block_size
         assert not self.cache_config.enable_prefix_caching
         if attn_metadata is not None:
             self_kv_cache = self.kv_cache
@@ -397,32 +396,15 @@ class HPUMambaMixer2(MambaMixer2):
         has_prefill = attn_metadata.is_prompt
         has_decode = not attn_metadata.is_prompt
 
-        block_idx_last_computed_token = None
-        block_idx_last_scheduled_token = None
-        block_idx_first_scheduled_token_p = None
-        num_computed_tokens_p = None
-
         # Process prefill requests
         if has_prefill:
             # 2. Convolution sequence transformation
-            # - It will read the initial states for every sequence,
-            #   that has "has_initial_states_p" == True,
-            #   from "cache_indices", using "state_indices_tensor".
-            # - It updates the "conv_state" cache in positions pointed
-            #   to by "state_indices_tensor".
-            #   In particular, it will always write the state at the
-            #   sequence end.
-            #   In addition, "block_idx_first_scheduled_token_p" and
-            #   "block_idx_last_computed_token"
-            #   are provided (which are pointers into
-            #   "state_indices_tensor"), it will write additional cache
-            #   states aligned at "block_size_to_align".
             assert padding_mask_flat is not None
             x = hidden_states_B_C.transpose(0, 1)  # this is the form that causal-conv see
             hidden_states_B_C = hidden_states_B_C * padding_mask_flat
             dt = dt * padding_mask_flat
 
-            hidden_states_B_C = hpu_causal_conv1d_fn(
+            hidden_states_B_C = granite_causal_conv1d_fn(
                 x,
                 self.conv_weights,
                 self.conv1d.bias,
@@ -430,11 +412,6 @@ class HPUMambaMixer2(MambaMixer2):
                 conv_states=conv_state,
                 has_initial_state=has_initial_states_p,
                 cache_indices=state_indices_tensor,
-                block_idx_first_scheduled_token=block_idx_first_scheduled_token_p,
-                block_idx_last_scheduled_token=block_idx_last_scheduled_token,
-                initial_state_idx=block_idx_last_computed_token,
-                num_computed_tokens=num_computed_tokens_p,
-                block_size_to_align=mamba_block_size,
                 metadata=attn_metadata,
                 query_start_loc=query_start_loc_p,
                 is_prompt=True,
@@ -480,15 +457,13 @@ class HPUMambaMixer2(MambaMixer2):
         # Process decode requests
         if has_decode:
             # 2. Convolution sequence transformation
-            hidden_states_B_C = hpu_causal_conv1d_update(
+            hidden_states_B_C = granite_causal_conv1d_update(
                 hidden_states_B_C,
                 conv_state,
                 self.conv_weights,
                 self.conv1d.bias,
                 self.activation,
                 conv_state_indices=state_indices_tensor,
-                block_idx_last_scheduled_token=block_idx_last_computed_token,
-                initial_state_idx=block_idx_last_computed_token,
                 query_start_loc=query_start_loc_p,
             )
 


### PR DESCRIPTION
Granite 4.0 (hpu_mamba_mixer2) needs a simpler single-sequence conv1d implementation matching v0.17.1 behavior. The current causal_conv1d_pytorch.py was refactored in v0.19.0 to support batched prefill with prefix-caching metadata, which is not needed by Granite 4.0.

Changes:
- Add granite_causal_conv1d.py with granite_causal_conv1d_fn and granite_causal_conv1d_update — simplified conv1d that processes one sequence at a time (padded_batch == 1) without prefix-caching support.
- Update hpu_mamba_mixer2.py to import and call the Granite-specific conv1d functions instead of the generic hpu_causal_conv1d_fn/update.
- Remove unused variables (mamba_block_size, block_idx_* placeholders) from the Granite mixer forward path.

The existing causal_conv1d_pytorch.py is left intact for other models.