### PR TITLE
Fix for proper KV cache slot addressing for Hybrid models

### DIFF
--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -2203,7 +2203,7 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
                                                        seq_num_scheduled_tokens].tolist()
 
             num_blocks = round_up(seq_num_computed_tokens + seq_num_scheduled_tokens,
-                                  self.block_size) // self.block_size
+                                  self.attn_block_size) // self.attn_block_size
             blocks = block_table_cpu_tensor[batch_idx, :num_blocks].tolist()
             if not warmup:
                 blocks = [self._resolve_block(b) for b in blocks]
@@ -2254,7 +2254,7 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
         dtype = self.dtype
         is_causal = True  # TODO: add support for non-causal tasks
         context_groups = torch.tensor(context_groups, device='cpu', dtype=torch.int16)
-        context_groups = context_groups.repeat_interleave(self.block_size, dim=-1)
+        context_groups = context_groups.repeat_interleave(self.attn_block_size, dim=-1)
         context_len = context_groups.size(-1)
         token_groups = torch.tensor(token_groups, device='cpu', dtype=torch.int16)
         num_queries = token_groups.size(-1)
@@ -2281,16 +2281,31 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
 
         token_positions = [list(range(cl, cl + ql)) for cl, ql in zip(context_lens, query_lens)]
 
-        block_assignment = [[divmod(pos, self.block_size) for pos in positions] for positions in token_positions]
+        # Use attn_block_size for KV cache slot addressing so that the
+        # slot indices match the InputBatch block_table which is keyed
+        # by kernel_block_size (= attn_block_size on HPU).  self.block_size
+        # may be larger for hybrid models after page-size unification.
+        slot_block_size = self.attn_block_size
+        block_assignment = [[divmod(pos, slot_block_size) for pos in positions] for positions in token_positions]
 
-        token_slots = [[blocks[bi] * self.block_size + bo for bi, bo in assignment]
+        token_slots = [[blocks[bi] * slot_block_size + bo for bi, bo in assignment]
                        for blocks, assignment in zip(contents.blocks, block_assignment)]
         token_groups = [[i] * len(tid) for i, tid in enumerate(token_ids)]
-        num_context_blocks = [round_up(ctx_len, self.block_size) // self.block_size for ctx_len in context_lens]
+        # num_context_blocks for block_table indexing uses attn_block_size
+        # (matches kernel_block_size / InputBatch).
+        num_context_blocks = [round_up(ctx_len, slot_block_size) // slot_block_size for ctx_len in context_lens]
         context_blocks: list = [blocks[:num] for blocks, num in zip(contents.blocks, num_context_blocks)]
         num_context_blocks = [len(b) for b in context_blocks]
         context_groups = [[i] * b for i, b in enumerate(num_context_blocks)]
-        target_bs, target_seq, target_blocks = self._get_prompt_bucketing_fn()(query_lens, num_context_blocks)
+        # Bucketing uses self.block_size so that file-based buckets
+        # (generated at the original block_size) continue to match.
+        bucketing_ctx_blocks = [round_up(ctx_len, self.block_size) // self.block_size for ctx_len in context_lens]
+        target_bs, target_seq, target_blocks = self._get_prompt_bucketing_fn()(query_lens, bucketing_ctx_blocks)
+        # target_blocks is in self.block_size units (from the bucket file).
+        # Scale to attn_block_size units so context_blocks padding matches the
+        # block_table entries which use kernel_block_size = attn_block_size.
+        if self.attn_block_size != self.block_size:
+            target_blocks = target_blocks * (self.block_size // self.attn_block_size)
 
         target_bs += self.get_dp_padding(target_bs)
         target_seq += self.get_dp_padding(target_seq)
@@ -2486,7 +2501,7 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
         query_len = 1 if has_kv_transfer_group() else 128
         prompt_tokens = 128
         token_ids = list(int(i) for i in range(query_len))
-        num_blocks = round_up(context_len + query_len, self.block_size) // self.block_size
+        num_blocks = round_up(context_len + query_len, self.attn_block_size) // self.attn_block_size
         blocks = [0] * num_blocks
         num_output_logits = context_len + query_len - prompt_tokens + 1
         logits_positions = list(range(query_len - num_output_logits, query_len))
@@ -5879,7 +5894,7 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
             self.bucketing_manager.num_hpu_blocks = num_blocks
 
         self._PAD_BLOCK_ID = num_blocks
-        self._PAD_SLOT_ID = num_blocks * self.block_size
+        self._PAD_SLOT_ID = num_blocks * self.attn_block_size
         self._MAMBA_PAD_BLOCK_ID = num_blocks
         self._dummy_num_blocks = num_blocks
 


### PR DESCRIPTION
## Summary

Fix KV cache slot addressing mismatch in prefill path for hybrid (Mamba + Attention) models such as Granite4.0.

## Problem

For hybrid models, the logical `block_size` is inflated beyond the HPU paged-attention kernel's native block size (128) during page-size unification with Mamba layers. After the Qwen3.5 enablement commit, `self.attn_block_size` was introduced to track the actual kernel block size and was correctly applied in the **decode** path. However, the **prefill** path continued using the larger `self.block_size` for slot index arithmetic.

This caused prefill and decode to compute different physical KV cache positions for the same token:

- **Prefill** wrote KV entries at `block_table[block_id] * block_size + offset` (using the inflated size)
- **Decode** read KV entries at `block_table[block_id] * attn_block_size + offset` (using the kernel size)

Since these addresses differ, decode reads stale or unrelated data from the KV cache, producing incorrect attention outputs.

Pure Transformer models are **not affected** because their `block_size` and `attn_block_size` are always equal (both 128 on HPU).

## Fix

Use `self.attn_block_size` (the HPU paged-attention kernel block size) instead of `self.block_size` (the logical/hybrid-inflated block size) for all prefill-path KV cache slot addressing. The decode path already uses `self.attn_block_size` via `decode_block_size` and is not changed.

Changed locations in `vllm_gaudi/v1/worker/hpu_model_runner.py` (5 hunks):

| Location | Change |
|----------|--------|
| `_get_new_batch_contents` | Block count for block_table indexing now uses `attn_block_size` |
| `_make_attn_bias` | `repeat_interleave` expansion of context groups now uses `attn_block_size` |
| `_form_prefill_batch` | `divmod` block assignment, `token_slots` computation, and `num_context_blocks` for block_table slicing now use `attn_block_size` |
| `_create_dummy_prefill_batch_contents` | Dummy prefill block count now uses `attn_block_size` |
| `_PAD_SLOT_ID` | Padding slot sentinel now uses `attn_block_size` |

Bucketing is kept on `self.block_size` so that file-based bucket configurations (generated at the original block size) continue to match. When the two sizes differ, `target_blocks` returned by the bucketing function is scaled from `block_size` units to `attn_block_size` units for correct context_blocks padding.
