### PR TITLE
Fix Synapse GC compile failure for FP8-quantized models

### DIFF
--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -249,6 +249,8 @@ def _move_remaining_tensors_to_device(model: torch.nn.Module, device: str) -> No
 
     moved = 0
     for mod in model.modules():
+        # Compute once per module; None if not an INC-patched module.
+        scale_members = getattr(mod, "scale_members", None)
         for attr_name in list(mod.__dict__.keys()):
             # Skip PyTorch's internal registry dicts and registered
             # parameters, buffers, and child modules — all of these
@@ -259,7 +261,6 @@ def _move_remaining_tensors_to_device(model: torch.nn.Module, device: str) -> No
                 continue
             # Skip INC FP8 scale tensors - they must remain on CPU
             # as H2D const tensors for runtime scale patching.
-            scale_members = getattr(mod, "scale_members", None)
             if scale_members is not None and attr_name in scale_members:
                 continue
             obj = mod.__dict__[attr_name]

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -257,6 +257,11 @@ def _move_remaining_tensors_to_device(model: torch.nn.Module, device: str) -> No
                 continue
             if attr_name in mod._parameters or attr_name in mod._buffers or attr_name in mod._modules:
                 continue
+            # Skip INC FP8 scale tensors - they must remain on CPU
+            # as H2D const tensors for runtime scale patching.
+            scale_members = getattr(mod, "scale_members", None)
+            if scale_members is not None and attr_name in scale_members:
+                continue
             obj = mod.__dict__[attr_name]
             new_obj, cnt, changed = _move_obj(obj)
             if cnt:


### PR DESCRIPTION
When serving FP8-quantized models with PT_HPU_LAZY_MODE=0, graph compilation fails with:
`verifyConvertScale: expected H2D convert scale tensor`

Fix

Skip any attribute listed in `mod.scale_members` — INC's per-module registry of scale tensor names, populated by register_scale() — inside `_move_remaining_tensors_to_device()`. All other stray tensors (MLA weights W_UK_T/W_UV, KV-quant range scalars, etc.) are still moved to HPU as before.

Affected models

Any model quantized via Intel Neural Compressor with scale_format: const: LLaMA, DeepSeek-R1, Qwen, Mixtral, and others.
