### PR TITLE
fix: exclude non-attention caches from defragmenter for hybrid models (cherry-pick to 0.19.0)

### DIFF
--- a/vllm_gaudi/extension/defragmentation.py
+++ b/vllm_gaudi/extension/defragmentation.py
@@ -27,7 +27,7 @@ class CacheSwapUtils(torch.nn.Module):
         self.enable_prefix_caching = get_config().prefix_caching
         self.block_slots = torch.arange(0, block_size, dtype=torch.long, device=device)
 
-    def forward(self, srcs: torch.tensor, dsts: torch.tensor, caches: list[torch.tensor], block_size: int):
+    def forward(self, srcs: torch.Tensor, dsts: torch.Tensor, caches: list[torch.Tensor], block_size: int):
         """ Internal method wrapped in HPU/t.compile graphs"""
         htorch.core.mark_step()
         srcs = ((srcs * block_size).unsqueeze(-1) + self.block_slots).flatten()  # used
@@ -49,7 +49,7 @@ class CacheSwapUtils(torch.nn.Module):
 class OnlineDefragmenter:
     """ Keeps track of assigned block_ids and remaps them if necessary """
 
-    def __init__(self, kv_caches: tuple[tuple[torch.tensor, torch.tensor]], block_size: int):
+    def __init__(self, kv_caches: tuple[tuple[torch.Tensor, torch.Tensor]], block_size: int):
         config = get_config()
         self.threshold = with_default(config.VLLM_DEFRAG_THRESHOLD, 32)
         self.to_swap_pad_thresholds = [8, 16, 32, 64, 128, 256, 512]

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -3538,8 +3538,9 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
 
     @torch.inference_mode()
     def run_defragmenter(self, scheduler_output: "SchedulerOutput", warmup_mode: bool = False):
-        if not (getattr(self, 'defragmenter', None) and self.defragmenter.enabled and self.kv_caches
-                and not warmup_mode):
+        if self.defragmenter is None:
+            return
+        if not (self.defragmenter.enabled and self.kv_caches and not warmup_mode):
             return
 
         new = {req.req_id: flatten(req.block_ids) for req in scheduler_output.scheduled_new_reqs if req.block_ids}
@@ -5246,7 +5247,7 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
             )
 
         if not self.is_pooling_model and self.defrag_kv_caches:
-            self.defragmenter = OnlineDefragmenter(self.defrag_kv_caches, self.block_size)  # type: ignore[arg-type]
+            self.defragmenter = OnlineDefragmenter(self.defrag_kv_caches, self.block_size)
         # Profiling
         prompt_profile_cfg, decode_profile_cfg = self._read_profiling_cfg()
         if prompt_profile_cfg or decode_profile_cfg:
@@ -5329,7 +5330,7 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
         # reusing defragmenter used in warmup causes accuracy drops, which is why we re-create
         # and re-initialize it.
         if not self.is_pooling_model and self.defrag_kv_caches:
-            self.defragmenter = OnlineDefragmenter(self.defrag_kv_caches, self.block_size)  # type: ignore[arg-type]
+            self.defragmenter = OnlineDefragmenter(self.defrag_kv_caches, self.block_size)
 
     def shutdown_inc(self, suppress=suppress, finalize_calibration=finalize_calibration):
         global shutdown_inc_called

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -1208,6 +1208,8 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
         # WA for chunked attention support
         self.model_has_chunked_attention = False
         self.is_causal = False
+        self.defragmenter: OnlineDefragmenter | None = None
+        self.defrag_kv_caches: list | None = None
 
     def _resolve_block(self, block_id):
         if not getattr(self, 'defragmenter', None):
@@ -5243,8 +5245,8 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
                                               self.vllm_config.model_config.logits_processors),
             )
 
-        if not self.is_pooling_model:
-            self.defragmenter = OnlineDefragmenter(self.kv_caches, self.block_size)
+        if not self.is_pooling_model and self.defrag_kv_caches:
+            self.defragmenter = OnlineDefragmenter(self.defrag_kv_caches, self.block_size)
         # Profiling
         prompt_profile_cfg, decode_profile_cfg = self._read_profiling_cfg()
         if prompt_profile_cfg or decode_profile_cfg:
@@ -5326,8 +5328,8 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
         # NOTE(kzawora): This is a nasty workaround - for whatever cache_utils-related reason,
         # reusing defragmenter used in warmup causes accuracy drops, which is why we re-create
         # and re-initialize it.
-        if not self.is_pooling_model:
-            self.defragmenter = OnlineDefragmenter(self.kv_caches, self.block_size)
+        if not self.is_pooling_model and self.defrag_kv_caches:
+            self.defragmenter = OnlineDefragmenter(self.defrag_kv_caches, self.block_size)
 
     def shutdown_inc(self, suppress=suppress, finalize_calibration=finalize_calibration):
         global shutdown_inc_called
@@ -5874,6 +5876,23 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
                 kv_caches[layer_name] = kv_caches[target_layer_name]
         assert layer_names == set(kv_caches.keys()), "Some layers are not correctly initialized"
         bind_kv_cache(kv_caches, self.vllm_config.compilation_config.static_forward_context, self.kv_caches)
+
+        # Build filtered list of attention-only KV caches for defragmenter.
+        # GDN/mamba state tensors use per-block indexing (dim 0 = num_blocks+1)
+        # while defragmentation uses per-token indexing (block_id * block_size),
+        # making it incompatible with non-attention caches.
+        if self.num_mamba_like_layers > 0:
+            self.defrag_kv_caches = []
+            for group in kv_cache_config.kv_cache_groups:
+                if isinstance(group.kv_cache_spec, FullAttentionSpec):
+                    for layer_name in group.layer_names:
+                        if layer_name in kv_caches:
+                            self.defrag_kv_caches.append(kv_caches[layer_name])
+            if not self.defrag_kv_caches:
+                logger.warning("No FullAttentionSpec layers found for defragmenter; "
+                               "disabling defrag for this hybrid/mamba model.")
+        else:
+            self.defrag_kv_caches = self.kv_caches
 
         if self.enable_bucketing:
             self.bucketing_manager.num_hpu_blocks = num_blocks

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -1212,13 +1212,13 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
         self.defrag_kv_caches: list | None = None
 
     def _resolve_block(self, block_id):
-        if not getattr(self, 'defragmenter', None):
+        if self.defragmenter is None:
             return block_id
 
         return self.defragmenter.resolve(block_id)
 
     def _resolve_all_blocks(self, block_table_list: list[list[int]]) -> list[list[int]]:
-        if not getattr(self, 'defragmenter', None):
+        if self.defragmenter is None:
             return [[self._resolve_block(b) for b in bl] for bl in block_table_list]
 
         return self.defragmenter.resolve_all(block_table_list)
@@ -5246,7 +5246,7 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
             )
 
         if not self.is_pooling_model and self.defrag_kv_caches:
-            self.defragmenter = OnlineDefragmenter(self.defrag_kv_caches, self.block_size)
+            self.defragmenter = OnlineDefragmenter(self.defrag_kv_caches, self.block_size)  # type: ignore[arg-type]
         # Profiling
         prompt_profile_cfg, decode_profile_cfg = self._read_profiling_cfg()
         if prompt_profile_cfg or decode_profile_cfg:
@@ -5329,7 +5329,7 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
         # reusing defragmenter used in warmup causes accuracy drops, which is why we re-create
         # and re-initialize it.
         if not self.is_pooling_model and self.defrag_kv_caches:
-            self.defragmenter = OnlineDefragmenter(self.defrag_kv_caches, self.block_size)
+            self.defragmenter = OnlineDefragmenter(self.defrag_kv_caches, self.block_size)  # type: ignore[arg-type]
 
     def shutdown_inc(self, suppress=suppress, finalize_calibration=finalize_calibration):
         global shutdown_inc_called


### PR DESCRIPTION
Cherry-pick of #1294 to `releases/v0.19.0`.

## Problem

Enabling `VLLM_CONTIGUOUS_PA=true` + `VLLM_DEFRAG=true` causes **~32 GiB memory spikes** on hybrid models like Qwen3.5-9B (24 GDN/linear_attention + 8 full_attention layers), eventually crashing with OOM.

**Root cause:** `OnlineDefragmenter` receives ALL kv_caches including GDN/mamba state tensors. The defrag code uses per-token indexing (`block_id * block_size`), which is only valid for `FullAttentionSpec` KV caches. For GDN state tensors, these indices are wildly out of bounds, causing massive temporary memory allocations on HPU.

## Fix

Filter `kv_caches` passed to `OnlineDefragmenter` to include **only** `FullAttentionSpec` layer caches. Non-hybrid models are unaffected.

### Cherry-picked commits:
- `1580798` fix: exclude non-attention caches from defragmenter for hybrid models
- `b0122c3` fix: resolve mypy errors for defragmenter type annotations
- `5afcd18` Fix pre-commit

Fixes: GAUDISW-247457