### PR TITLE
enable GPT-OSS-120B single-card inference

### DIFF
--- a/vllm_gaudi/extension/ops.py
+++ b/vllm_gaudi/extension/ops.py
@@ -651,8 +651,13 @@ class VllmMixtureOfExpertsOp(VllmMixtureOfExpertsOpBase):
         """Build and cache weight/bias *views only* (no torch.stack / no extra allocation)."""
         experts_range = range(self.num_experts)
 
-        self._cached_w13_views = tuple(self.w13_list[i].weight.squeeze() for i in experts_range)
-        self._cached_w2_views = tuple(self.w2_list[i].weight.squeeze() for i in experts_range)
+        # MXFP4 path: weights are not set in MoeMatmul (dequantized at runtime)
+        if hasattr(self.w13_list[0], 'weight') and self.w13_list[0].weight is not None:
+            self._cached_w13_views = tuple(self.w13_list[i].weight.squeeze() for i in experts_range)
+            self._cached_w2_views = tuple(self.w2_list[i].weight.squeeze() for i in experts_range)
+        else:
+            self._cached_w13_views = None
+            self._cached_w2_views = None
 
         # optional bias views (no copy)
         if self.bias is not None:

--- a/vllm_gaudi/models/gptoss_mxfp4.py
+++ b/vllm_gaudi/models/gptoss_mxfp4.py
@@ -38,6 +38,7 @@ def convert_moe_packed_tensors(
     scales,
     *,
     dtype: torch.dtype = torch.bfloat16,
+    out: torch.Tensor | None = None,
     # Large default chosen to process many rows per kernel launch and reduce overhead;
     # lower this if you need to limit peak memory usage.
     rows_per_chunk: int = 32768 * 1024,
@@ -45,6 +46,10 @@ def convert_moe_packed_tensors(
     """
     Convert the mxfp4 weights, dequantize and make them compatible with the forward
     pass of GPT_OSS.
+
+    Args:
+        out: Optional pre-allocated output tensor. When provided, dequantized
+             values are written directly into it, avoiding an intermediate copy.
     """
     import math
 
@@ -82,7 +87,10 @@ def convert_moe_packed_tensors(
     blocks = blocks.reshape(rows_total, B)
     scales = scales.reshape(rows_total, 1)
 
-    out = torch.empty(rows_total, B * 2, dtype=dtype, device=blocks.device)
+    if out is not None:
+        out_buf = out.reshape(rows_total, B * 2)
+    else:
+        out_buf = torch.empty(rows_total, B * 2, dtype=dtype, device=blocks.device)
 
     for r0 in range(0, rows_total, rows_per_chunk):
         r1 = min(r0 + rows_per_chunk, rows_total)
@@ -90,20 +98,21 @@ def convert_moe_packed_tensors(
         blk = blocks[r0:r1]
         exp = scales[r0:r1]
 
-        # nibble indices -> int64
-        idx_lo = (blk & 0x0F).to(torch.long)
-        idx_hi = (blk >> 4).to(torch.long)
+        idx_lo = (blk & 0x0F).to(torch.int32)
+        idx_hi = (blk >> 4).to(torch.int32)
 
-        sub = out[r0:r1]
+        sub = out_buf[r0:r1]
         sub[:, 0::2] = lut[idx_lo]
         sub[:, 1::2] = lut[idx_hi]
 
         torch.ldexp(sub, exp, out=sub)
         del idx_lo, idx_hi, blk, exp, sub
 
-    out = out.reshape(*prefix_shape, G * B * 2).contiguous()
     del blocks, scales, lut
-    return out
+
+    if out is not None:
+        return out
+    return out_buf.reshape(*prefix_shape, G * B * 2).contiguous()
 
 
 def _load_weights_mxfp4_packed_hpu(
@@ -157,7 +166,7 @@ def _load_weights_mxfp4_packed_hpu(
             param_name = name.replace(".w13_weight_scale", ".w13_scales")
             param = params_dict[param_name]
             param.copy_(narrow.contiguous())
-            loaded_params.add(name)
+            loaded_params.add(param_name)
             continue
         elif ".w13_weight" in name:
             # Load packed FP4 blocks directly into w13_packed parameter
@@ -168,7 +177,7 @@ def _load_weights_mxfp4_packed_hpu(
             param_name = name.replace(".w13_weight", ".w13_packed")
             param = params_dict[param_name]
             param.copy_(narrow.contiguous())
-            loaded_params.add(name)
+            loaded_params.add(param_name)
             continue
         elif ".w2_weight_scale" in name:
             # Load scales directly into w2_scales parameter
@@ -179,7 +188,7 @@ def _load_weights_mxfp4_packed_hpu(
             param_name = name.replace(".w2_weight_scale", ".w2_scales")
             param = params_dict[param_name]
             param.copy_(narrow.contiguous())
-            loaded_params.add(name)
+            loaded_params.add(param_name)
             continue
         elif ".w2_weight" in name:
             # Load packed FP4 blocks directly into w2_packed parameter
@@ -190,7 +199,7 @@ def _load_weights_mxfp4_packed_hpu(
             param_name = name.replace(".w2_weight", ".w2_packed")
             param = params_dict[param_name]
             param.copy_(narrow.contiguous())
-            loaded_params.add(name)
+            loaded_params.add(param_name)
             continue
         elif ".w13_bias" in name:
             # Handle MLP gate and up projection biases (BF16, unchanged)

--- a/vllm_gaudi/models/gptoss_mxfp4.py
+++ b/vllm_gaudi/models/gptoss_mxfp4.py
@@ -106,7 +106,7 @@ def convert_moe_packed_tensors(
     return out
 
 
-def _load_weights_mxfp4_dequantize_hpu(
+def _load_weights_mxfp4_packed_hpu(
     self,
     ep_rank_end: int,
     ep_rank_start: int,
@@ -115,6 +115,11 @@ def _load_weights_mxfp4_dequantize_hpu(
     weights: Iterable[tuple[str, torch.Tensor]],
     stacked_params_mapping: list[tuple[str, ...]],
 ) -> set[str]:
+    """Load MXFP4 weights in packed format without dequantization.
+
+    Packed FP4 blocks and scales are stored directly as uint8 parameters.
+    Dequantization to BF16 happens at runtime in the MoE forward pass.
+    """
     params_dict = dict(self.named_parameters())
     loaded_params: set[str] = set()
 
@@ -138,76 +143,57 @@ def _load_weights_mxfp4_dequantize_hpu(
     tp_rank_start = tp_rank * per_rank_intermediate_size
     tp_rank_end = min((tp_rank + 1) * per_rank_intermediate_size, intermediate_size)
 
-    block_weight_dict = {}
-
     for name, weight in weights:
         # Skip layers on other devices.
         if is_pp_missing_parameter(name, self):
             continue
 
         if ".w13_weight_scale" in name:
-            # Handle MLP gate and up projection weights
-            # Extract gate and up projection parts
+            # Load scales directly into w13_scales parameter (no dequantization)
             if use_ep:
-                narrow_weight_scale = weight[ep_rank_start:ep_rank_end, ...]
+                narrow = weight[ep_rank_start:ep_rank_end, ...]
             else:
-                narrow_weight_scale = weight[:, 2 * tp_rank_start:2 * tp_rank_end, :]
-
-            narrow_weight_scale = narrow_weight_scale.contiguous()
-
-            # Read block weight
-            block_name = name.replace("weight_scale", "weight")
-            if block_name not in block_weight_dict:
-                raise ValueError(f"Expected block weight for {block_name} not found when processing {name}")
-            block_weight = block_weight_dict[block_name]
-            param = params_dict[block_name]
-
-            weight = convert_moe_packed_tensors(block_weight, narrow_weight_scale)
-            param[:, :2 * (tp_rank_end - tp_rank_start), :] = weight
-            del block_weight_dict[block_name]
+                narrow = weight[:, 2 * tp_rank_start:2 * tp_rank_end, :]
+            param_name = name.replace(".w13_weight_scale", ".w13_scales")
+            param = params_dict[param_name]
+            param.copy_(narrow.contiguous())
             loaded_params.add(name)
             continue
         elif ".w13_weight" in name:
+            # Load packed FP4 blocks directly into w13_packed parameter
             if use_ep:
-                narrow_weight = weight[ep_rank_start:ep_rank_end, ...]
+                narrow = weight[ep_rank_start:ep_rank_end, ...]
             else:
-                narrow_weight = weight[:, 2 * tp_rank_start:2 * tp_rank_end, :, :]
-            narrow_weight = narrow_weight.contiguous()
-            block_weight_dict[name] = narrow_weight
+                narrow = weight[:, 2 * tp_rank_start:2 * tp_rank_end, :, :]
+            param_name = name.replace(".w13_weight", ".w13_packed")
+            param = params_dict[param_name]
+            param.copy_(narrow.contiguous())
             loaded_params.add(name)
             continue
         elif ".w2_weight_scale" in name:
-            # Handle MLP down projection weights
+            # Load scales directly into w2_scales parameter
             if use_ep:
-                narrow_weight_scale = weight[ep_rank_start:ep_rank_end, ...]
+                narrow = weight[ep_rank_start:ep_rank_end, ...]
             else:
-                narrow_weight_scale = weight[..., tp_rank_start // OCP_MX_BLOCK_SIZE:tp_rank_end // OCP_MX_BLOCK_SIZE]
-            narrow_weight_scale = narrow_weight_scale.contiguous()
-
-            # Read block weight
-            block_name = name.replace("weight_scale", "weight")
-            if block_name not in block_weight_dict:
-                raise ValueError(f"Expected block weight for {block_name} not found when processing {name}")
-            block_weight = block_weight_dict[block_name]
-            param = params_dict[block_name]
-
-            weight = convert_moe_packed_tensors(block_weight, narrow_weight_scale)
-            param[:, :, :(tp_rank_end - tp_rank_start)] = weight
-            del block_weight_dict[block_name]
+                narrow = weight[..., tp_rank_start // OCP_MX_BLOCK_SIZE:tp_rank_end // OCP_MX_BLOCK_SIZE]
+            param_name = name.replace(".w2_weight_scale", ".w2_scales")
+            param = params_dict[param_name]
+            param.copy_(narrow.contiguous())
             loaded_params.add(name)
             continue
         elif ".w2_weight" in name:
+            # Load packed FP4 blocks directly into w2_packed parameter
             if use_ep:
-                narrow_weight = weight[ep_rank_start:ep_rank_end, ...]
+                narrow = weight[ep_rank_start:ep_rank_end, ...]
             else:
-                narrow_weight = weight[:, :, tp_rank_start // OCP_MX_BLOCK_SIZE:tp_rank_end // OCP_MX_BLOCK_SIZE, :]
-            narrow_weight = narrow_weight.contiguous()
-            block_weight_dict[name] = narrow_weight
+                narrow = weight[:, :, tp_rank_start // OCP_MX_BLOCK_SIZE:tp_rank_end // OCP_MX_BLOCK_SIZE, :]
+            param_name = name.replace(".w2_weight", ".w2_packed")
+            param = params_dict[param_name]
+            param.copy_(narrow.contiguous())
             loaded_params.add(name)
             continue
         elif ".w13_bias" in name:
-            # Handle MLP gate and up projection biases
-            # Extract gate and up projection bias parts
+            # Handle MLP gate and up projection biases (BF16, unchanged)
             if use_ep:
                 narrow_weight = weight[ep_rank_start:ep_rank_end, ...]
             else:
@@ -219,7 +205,7 @@ def _load_weights_mxfp4_dequantize_hpu(
             loaded_params.add(name)
             continue
         elif ".w2_bias" in name:
-            # Handle MLP down projection bias
+            # Handle MLP down projection bias (BF16, unchanged)
             if use_ep:
                 weight = weight[ep_rank_start:ep_rank_end, ...]
             else:
@@ -287,7 +273,7 @@ def patched_load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> s
         ep_rank_start = ep_rank * experts_per_rank
         ep_rank_end = (ep_rank + 1) * experts_per_rank
 
-        return self._load_weights_mxfp4_dequantize_hpu(
+        return self._load_weights_mxfp4_packed_hpu(
             ep_rank_end,
             ep_rank_start,
             heads_per_rank,
@@ -303,5 +289,5 @@ def patched_load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> s
 # Apply monkey patches unconditionally
 # The wrappers check at runtime whether to use custom logic or delegate to original
 ModelArchConfigConvertorBase._normalize_quantization_config = _patched_normalize_quantization_config
-GptOssModel._load_weights_mxfp4_dequantize_hpu = _load_weights_mxfp4_dequantize_hpu
+GptOssModel._load_weights_mxfp4_packed_hpu = _load_weights_mxfp4_packed_hpu
 GptOssModel.load_weights = patched_load_weights

--- a/vllm_gaudi/ops/hpu_fused_moe.py
+++ b/vllm_gaudi/ops/hpu_fused_moe.py
@@ -31,12 +31,26 @@ from vllm.model_executor.layers.fused_moe.router.routing_simulator_router import
 from vllm_gaudi.extension.ops import (VllmMixtureOfExpertsOp)
 from vllm_gaudi.extension.runtime import get_config
 from vllm.model_executor.utils import set_weight_attrs
+from vllm.model_executor.layers.quantization.utils.ocp_mx_utils import OCP_MX_BLOCK_SIZE
 from vllm_gaudi.utils import has_quant_config
 from vllm_gaudi.v1.worker.hpu_dp_utils import dispatch_hidden_states, dispatch_tensor, get_hpu_dp_metadata
 
 
 def _normalize_moe_activation(activation):
     return activation.value if isinstance(activation, Enum) else activation
+
+
+def dequant_mxfp4_hpu(packed, scales, *, out):
+    """Dequantize MXFP4 packed weights on HPU into a pre-allocated output tensor.
+
+    Args:
+        packed: uint8 tensor of shape (E, rows, groups, block_half) — packed FP4 blocks
+        scales: uint8 tensor of shape (E, rows, groups) — per-group scales
+        out: pre-allocated BF16 tensor of shape (E, rows, groups * block_half * 2)
+    """
+    from vllm_gaudi.models.gptoss_mxfp4 import convert_moe_packed_tensors
+    result = convert_moe_packed_tensors(packed, scales, dtype=out.dtype)
+    out.copy_(result)
 
 
 @UnquantizedFusedMoEMethod.register_oot
@@ -81,6 +95,23 @@ class HPUUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
 
         bias = has_bias if has_bias is True else None
 
+        if self.is_mxfp4 and self.model_type in ["gpt_oss"]:
+            # MXFP4 path: create moe_op for metadata only, set bias but NOT weights.
+            # Weights are stored as packed uint8 and dequantized at runtime in forward.
+            layer.moe_op = VllmMixtureOfExpertsOp(layer.global_num_experts, num_experts, experts_min, experts_max, bias,
+                                                  dispatch_fn)
+
+            if has_bias:
+                for expert_id in range(layer.local_num_experts):
+                    layer.moe_op.w13_list[expert_id].set_bias(layer.w13_bias.data[expert_id])
+                    layer.moe_op.w2_list[expert_id].set_bias(layer.w2_bias.data[expert_id])
+
+            # Pre-build bias tuples for direct torch.ops.hpu.mixture_of_experts calls
+            E = layer.local_num_experts
+            layer._w13_bias_tuple = tuple(layer.w13_bias.data[i] for i in range(E))
+            layer._w2_bias_tuple = tuple(layer.w2_bias.data[i] for i in range(E))
+            return
+
         is_bf16 = getattr(layer, 'w13_weight', None) is not None and layer.w13_weight.dtype == torch.bfloat16
 
         model_config = None
@@ -111,32 +142,45 @@ class HPUUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
 
         if self.model_type in ["gpt_oss"] and self.is_mxfp4:
             from vllm.utils.math_utils import round_up
-            # Fused gate_up_proj (column parallel)
-            w13_weight = torch.nn.Parameter(torch.zeros(num_experts,
-                                                        2 * round_up(intermediate_size_per_partition, 32),
-                                                        hidden_size,
-                                                        dtype=params_dtype),
-                                            requires_grad=False)
-            layer.register_parameter("w13_weight", w13_weight)
-            set_weight_attrs(w13_weight, extra_weight_attrs)
+            groups_h = hidden_size // OCP_MX_BLOCK_SIZE
+            groups_i = intermediate_size_per_partition // OCP_MX_BLOCK_SIZE
+            block_half = OCP_MX_BLOCK_SIZE // 2  # 2 FP4 values packed per byte
 
-            w13_bias = torch.nn.Parameter(torch.zeros(num_experts,
-                                                      2 * round_up(intermediate_size_per_partition, 32),
-                                                      dtype=params_dtype),
-                                          requires_grad=False)
+            # Packed FP4 blocks for fused gate_up_proj (column parallel)
+            w13_packed = torch.nn.Parameter(torch.zeros(
+                num_experts, 2 * intermediate_size_per_partition, groups_h, block_half,
+                dtype=torch.uint8), requires_grad=False)
+            layer.register_parameter("w13_packed", w13_packed)
+            set_weight_attrs(w13_packed, extra_weight_attrs)
+
+            w13_scales = torch.nn.Parameter(torch.zeros(
+                num_experts, 2 * intermediate_size_per_partition, groups_h,
+                dtype=torch.uint8), requires_grad=False)
+            layer.register_parameter("w13_scales", w13_scales)
+            set_weight_attrs(w13_scales, extra_weight_attrs)
+
+            # Packed FP4 blocks for down_proj (row parallel)
+            w2_packed = torch.nn.Parameter(torch.zeros(
+                num_experts, hidden_size, groups_i, block_half,
+                dtype=torch.uint8), requires_grad=False)
+            layer.register_parameter("w2_packed", w2_packed)
+            set_weight_attrs(w2_packed, extra_weight_attrs)
+
+            w2_scales = torch.nn.Parameter(torch.zeros(
+                num_experts, hidden_size, groups_i,
+                dtype=torch.uint8), requires_grad=False)
+            layer.register_parameter("w2_scales", w2_scales)
+            set_weight_attrs(w2_scales, extra_weight_attrs)
+
+            # Bias stays BF16 (small ~2 MB/layer)
+            w13_bias = torch.nn.Parameter(torch.zeros(
+                num_experts, 2 * round_up(intermediate_size_per_partition, 32),
+                dtype=params_dtype), requires_grad=False)
             layer.register_parameter("w13_bias", w13_bias)
             set_weight_attrs(w13_bias, extra_weight_attrs)
 
-            # down_proj (row parallel)
-            w2_weight = torch.nn.Parameter(torch.zeros(num_experts,
-                                                       hidden_size,
-                                                       round_up(intermediate_size_per_partition, 32),
-                                                       dtype=params_dtype),
-                                           requires_grad=False)
-            layer.register_parameter("w2_weight", w2_weight)
-            set_weight_attrs(w2_weight, extra_weight_attrs)
-
-            w2_bias = torch.nn.Parameter(torch.zeros(num_experts, hidden_size, dtype=params_dtype), requires_grad=False)
+            w2_bias = torch.nn.Parameter(torch.zeros(
+                num_experts, hidden_size, dtype=params_dtype), requires_grad=False)
             layer.register_parameter("w2_bias", w2_bias)
             set_weight_attrs(w2_bias, extra_weight_attrs)
         else:
@@ -183,6 +227,32 @@ class HPUUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
 
         topk_ids = topk_ids.view(-1, topk_ids.shape[-1])
         topk_weights = topk_weights.view(-1, topk_weights.shape[-1])
+
+        if self.is_mxfp4 and hasattr(layer, '_shared_w13_workspace'):
+            # MXFP4 path: dequantize packed weights into shared workspace,
+            # then call HPU MoE op directly.
+            dequant_mxfp4_hpu(layer.w13_packed, layer.w13_scales,
+                              out=layer._shared_w13_workspace)
+            dequant_mxfp4_hpu(layer.w2_packed, layer.w2_scales,
+                              out=layer._shared_w2_workspace)
+
+            E = layer.local_num_experts
+            w13_list = tuple(layer._shared_w13_workspace[i] for i in range(E))
+            w2_list = tuple(layer._shared_w2_workspace[i] for i in range(E))
+
+            output = torch.ops.hpu.mixture_of_experts.bias_fused_weights(
+                hidden_states=x,
+                expert_routing_table=topk_ids,
+                router_weights=topk_weights,
+                w12=w13_list,
+                w3=w2_list,
+                w12_bias=layer._w13_bias_tuple,
+                w3_bias=layer._w2_bias_tuple,
+                permuted_weights=True,
+                experts_min=layer.moe_op.experts_min,
+                experts_max=layer.moe_op.experts_max,
+            )
+            return output.view(*input_shape)
 
         output = layer.moe_op(
             x,
@@ -236,6 +306,32 @@ class HPUUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
 
         topk_ids = topk_ids.view(-1, topk_ids.shape[-1])
         topk_weights = topk_weights.view(-1, topk_weights.shape[-1])
+
+        if self.is_mxfp4 and hasattr(layer, '_shared_w13_workspace'):
+            # MXFP4 path: dequantize packed weights into shared workspace,
+            # then call HPU MoE op directly.
+            dequant_mxfp4_hpu(layer.w13_packed, layer.w13_scales,
+                              out=layer._shared_w13_workspace)
+            dequant_mxfp4_hpu(layer.w2_packed, layer.w2_scales,
+                              out=layer._shared_w2_workspace)
+
+            E = layer.local_num_experts
+            w13_list = tuple(layer._shared_w13_workspace[i] for i in range(E))
+            w2_list = tuple(layer._shared_w2_workspace[i] for i in range(E))
+
+            output = torch.ops.hpu.mixture_of_experts.bias_fused_weights(
+                hidden_states=x,
+                expert_routing_table=topk_ids.to(torch.int64),
+                router_weights=topk_weights.to(x.dtype),
+                w12=w13_list,
+                w3=w2_list,
+                w12_bias=layer._w13_bias_tuple,
+                w3_bias=layer._w2_bias_tuple,
+                permuted_weights=True,
+                experts_min=layer.moe_op.experts_min,
+                experts_max=layer.moe_op.experts_max,
+            )
+            return output.view(*input_shape)
 
         if self.model_type in ["gpt_oss"]:
             return layer.moe_op(

--- a/vllm_gaudi/ops/hpu_fused_moe.py
+++ b/vllm_gaudi/ops/hpu_fused_moe.py
@@ -40,6 +40,7 @@ def _normalize_moe_activation(activation):
     return activation.value if isinstance(activation, Enum) else activation
 
 
+@torch.compiler.disable
 def dequant_mxfp4_hpu(packed, scales, *, out):
     """Dequantize MXFP4 packed weights on HPU into a pre-allocated output tensor.
 
@@ -49,8 +50,8 @@ def dequant_mxfp4_hpu(packed, scales, *, out):
         out: pre-allocated BF16 tensor of shape (E, rows, groups * block_half * 2)
     """
     from vllm_gaudi.models.gptoss_mxfp4 import convert_moe_packed_tensors
-    result = convert_moe_packed_tensors(packed, scales, dtype=out.dtype)
-    out.copy_(result)
+    # Single call for all experts; rows_per_chunk limits peak intermediate memory
+    convert_moe_packed_tensors(packed, scales, dtype=out.dtype, out=out, rows_per_chunk=8192)
 
 
 @UnquantizedFusedMoEMethod.register_oot
@@ -80,7 +81,9 @@ class HPUUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
         return True
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        super().process_weights_after_loading(layer)
+        # MXFP4 path has no w13_weight/w2_weight — skip parent's padding/setup
+        if not (self.is_mxfp4 and self.model_type in ["gpt_oss"]):
+            super().process_weights_after_loading(layer)
         # custom handling for HPU
         num_experts = layer.local_num_experts
         ep_shift = layer.ep_rank * num_experts
@@ -142,6 +145,11 @@ class HPUUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
 
         if self.model_type in ["gpt_oss"] and self.is_mxfp4:
             from vllm.utils.math_utils import round_up
+            assert hidden_size % OCP_MX_BLOCK_SIZE == 0, \
+                f"hidden_size ({hidden_size}) must be divisible by OCP_MX_BLOCK_SIZE ({OCP_MX_BLOCK_SIZE})"
+            assert intermediate_size_per_partition % OCP_MX_BLOCK_SIZE == 0, \
+                f"intermediate_size_per_partition ({intermediate_size_per_partition}) must be divisible by " \
+                f"OCP_MX_BLOCK_SIZE ({OCP_MX_BLOCK_SIZE})"
             groups_h = hidden_size // OCP_MX_BLOCK_SIZE
             groups_i = intermediate_size_per_partition // OCP_MX_BLOCK_SIZE
             block_half = OCP_MX_BLOCK_SIZE // 2  # 2 FP4 values packed per byte

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -593,12 +593,12 @@ def _init_mxfp4_shared_workspace(model):
     E, I2, groups_h, block_half = ref.w13_packed.shape
     H = groups_h * OCP_MX_BLOCK_SIZE
     _, _, groups_i, _ = ref.w2_packed.shape
-    I = groups_i * OCP_MX_BLOCK_SIZE
+    intermediate_dim = groups_i * OCP_MX_BLOCK_SIZE
     device = ref.w13_packed.device
 
     # Single shared workspace reused across all layers (layers execute sequentially)
     shared_w13_ws = torch.empty(E, I2, H, dtype=torch.bfloat16, device=device)
-    shared_w2_ws = torch.empty(E, H, I, dtype=torch.bfloat16, device=device)
+    shared_w2_ws = torch.empty(E, H, intermediate_dim, dtype=torch.bfloat16, device=device)
 
     for layer in moe_layers:
         layer._shared_w13_workspace = shared_w13_ws

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -574,11 +574,46 @@ def _init_mamba_split_weights(model):
             module._init_split_weights()
 
 
+def _init_mxfp4_shared_workspace(model):
+    """Allocate a shared BF16 workspace for MXFP4 MoE runtime dequantization.
+
+    Called after model.to("hpu"). All FusedMoE layers with MXFP4 packed weights
+    share a single workspace to minimize HBM usage (~5.94 GB instead of ~214 GB).
+    """
+    from vllm.model_executor.layers.fused_moe import FusedMoE
+    from vllm.model_executor.layers.quantization.utils.ocp_mx_utils import OCP_MX_BLOCK_SIZE
+
+    moe_layers = [m for m in model.modules()
+                  if isinstance(m, FusedMoE) and hasattr(m, 'w13_packed')]
+    if not moe_layers:
+        return
+
+    # All MoE layers have identical shapes — derive dimensions from the first
+    ref = moe_layers[0]
+    E, I2, groups_h, block_half = ref.w13_packed.shape
+    H = groups_h * OCP_MX_BLOCK_SIZE
+    _, _, groups_i, _ = ref.w2_packed.shape
+    I = groups_i * OCP_MX_BLOCK_SIZE
+    device = ref.w13_packed.device
+
+    # Single shared workspace reused across all layers (layers execute sequentially)
+    shared_w13_ws = torch.empty(E, I2, H, dtype=torch.bfloat16, device=device)
+    shared_w2_ws = torch.empty(E, H, I, dtype=torch.bfloat16, device=device)
+
+    for layer in moe_layers:
+        layer._shared_w13_workspace = shared_w13_ws
+        layer._shared_w2_workspace = shared_w2_ws
+
+    logger.info("MXFP4 shared workspace allocated: w13=%.2f GB, w2=%.2f GB (%d MoE layers sharing)",
+                shared_w13_ws.nbytes / 2**30, shared_w2_ws.nbytes / 2**30, len(moe_layers))
+
+
 def apply_model_specific_patches(model_runner):
     """The function applies model-specific monkey patches."""
     maybe_set_chunked_attention_layers(model_runner)
     patch_llama4_get_attn_scale(model_runner.model)
     _init_mamba_split_weights(model_runner.model)
+    _init_mxfp4_shared_workspace(model_runner.model)
 
 
 class HpuKVConnectorModelRunnerMixin(KVConnectorModelRunnerMixin):


### PR DESCRIPTION
Store MoE expert weights as packed MXFP4 in HBM instead of dequantizing to BF16 at load time. A single shared BF16 workspace (~6 GB) is allocated and reused across all 36 MoE layers for runtime dequantization, reducing weight memory from and enabling inference on a single card.