### PR TITLE
feat: fix guard breaks and improve warmup time for Qwen3 MoE

### DIFF
--- a/vllm_gaudi/models/__init__.py
+++ b/vllm_gaudi/models/__init__.py
@@ -41,6 +41,9 @@ def register_model():
     from vllm_gaudi.models.seed_oss import HpuSeedOssForCausalLM  # noqa: F401
     ModelRegistry.register_model("SeedOssForCausalLM", "vllm_gaudi.models.seed_oss:HpuSeedOssForCausalLM")
 
+    from vllm_gaudi.models.qwen3_moe import HpuQwen3MoeForCausalLM  # noqa: F401
+    ModelRegistry.register_model("Qwen3MoeForCausalLM", "vllm_gaudi.models.qwen3_moe:HpuQwen3MoeForCausalLM")
+
     import vllm_gaudi.models.deepseek_v2  # noqa: F401
 
     from vllm_gaudi.models.deepseek_ocr import HpuDeepseekOCRForCausalLM  # noqa: F401

--- a/vllm_gaudi/models/qwen3_moe.py
+++ b/vllm_gaudi/models/qwen3_moe.py
@@ -1,10 +1,15 @@
 import torch
 from torch import nn
 
+from vllm.config import VllmConfig
+from vllm.distributed import get_pp_group, tensor_model_parallel_all_gather
 from vllm.model_executor.models.qwen3_moe import (
-    Qwen3MoeSparseMoeBlock as UpstreamQwen3MoeSparseMoeBlock, )
+    Qwen3MoeForCausalLM as UpstreamQwen3MoeForCausalLM,
+    Qwen3MoeModel as UpstreamQwen3MoeModel,
+    Qwen3MoeSparseMoeBlock as UpstreamQwen3MoeSparseMoeBlock,
+)
 from vllm.model_executor.models.utils import sequence_parallel_chunk
-from vllm.distributed import tensor_model_parallel_all_gather
+from vllm.sequence import IntermediateTensors
 
 
 class HpuQwen3MoeSparseMoeBlock(UpstreamQwen3MoeSparseMoeBlock):
@@ -75,3 +80,49 @@ def upgrade_qwen3_moe_blocks_inplace(language_model: nn.Module) -> int:
             upgraded += 1
 
     return upgraded
+
+
+class HpuQwen3MoeModel(UpstreamQwen3MoeModel):
+    """Initialize residual as zeros instead of None to eliminate Dynamo type guard."""
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+    ) -> torch.Tensor | IntermediateTensors | tuple[torch.Tensor, list[torch.Tensor]]:
+        if get_pp_group().is_first_rank:
+            hidden_states = inputs_embeds if inputs_embeds is not None else self.embed_input_ids(input_ids)
+            residual = torch.zeros_like(hidden_states)
+        else:
+            assert intermediate_tensors is not None
+            hidden_states = intermediate_tensors["hidden_states"]
+            residual = intermediate_tensors["residual"]
+
+        aux_hidden_states = []
+        for layer_idx, layer in enumerate(
+                self.layers[self.start_layer:self.end_layer],
+                start=self.start_layer,
+        ):
+            if layer_idx in self.aux_hidden_state_layers:
+                aux_hidden_state = hidden_states + residual
+                aux_hidden_states.append(aux_hidden_state)
+            hidden_states, residual = layer(positions, hidden_states, residual)
+
+        if not get_pp_group().is_last_rank:
+            return IntermediateTensors({"hidden_states": hidden_states, "residual": residual})
+        hidden_states, _ = self.norm(hidden_states, residual)
+
+        if len(aux_hidden_states) > 0:
+            return hidden_states, aux_hidden_states
+        return hidden_states
+
+
+class HpuQwen3MoeForCausalLM(UpstreamQwen3MoeForCausalLM):
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__(vllm_config=vllm_config, prefix=prefix)
+        upgrade_qwen3_moe_blocks_inplace(self)
+        if hasattr(self, "model") and isinstance(self.model, UpstreamQwen3MoeModel):
+            self.model.__class__ = HpuQwen3MoeModel

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -694,6 +694,13 @@ class HpuModelAdapter(torch.nn.Module, HpuKVConnectorModelRunnerMixin):
                                                                                input_ids.size(0), input_ids.size(1),
                                                                                input_ids.device, self.dtype,
                                                                                model_has_chunked_attention)
+        # Avoid 0/1 size specialization on block_list dim 0 for MoE models.
+        # Must be outside compiled regions — mark_unbacked is a forbidden callable.
+        if self.flatten_input:
+            attn_md = kwargs.get('attn_metadata')
+            if (attn_md is not None and getattr(attn_md, 'is_prompt', False)
+                    and getattr(attn_md, 'block_list', None) is not None):
+                _mark_unbacked_dim0(attn_md.block_list)
         if self._rotary_prepare_cos_sin is not None:
             self._rotary_prepare_cos_sin(kwargs['positions'], recompute_cos_sin=self.recompute_cos_sin)
         attn_meta = kwargs.pop('attn_metadata', None)
@@ -743,6 +750,11 @@ class HpuModelAdapter(torch.nn.Module, HpuKVConnectorModelRunnerMixin):
     # @property
     # def sampler(self):
     #    return self.model.sampler
+
+
+@torch.compiler.disable
+def _mark_unbacked_dim0(tensor: torch.Tensor):
+    torch._dynamo.decorators.mark_unbacked(tensor, 0)
 
 
 def _maybe_wrap_in_hpu_graph(*args, **kwargs):


### PR DESCRIPTION
- Initialize residual as zeros instead of None in HpuQwen3MoeModel to eliminate Dynamo type guard recompilations
- Add _mark_unbacked_dim0 to avoid 0/1 size specialization on block_list dim 0 for MoE models during prefill
- Register HpuQwen3MoeForCausalLM to apply model-level patches