### PR TITLE
Fix Synapse GC compile failure for FP8-quantized models

### DIFF
--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -249,6 +249,8 @@ def _move_remaining_tensors_to_device(model: torch.nn.Module, device: str) -> No
 
     moved = 0
     for mod in model.modules():
+        # Compute once per module; None if not an INC-patched module.
+        scale_members = getattr(mod, "scale_members", None)
         for attr_name in list(mod.__dict__.keys()):
             # Skip PyTorch's internal registry dicts and registered
             # parameters, buffers, and child modules — all of these
@@ -256,6 +258,10 @@ def _move_remaining_tensors_to_device(model: torch.nn.Module, device: str) -> No
             if attr_name in _SKIP_ATTRS:
                 continue
             if attr_name in mod._parameters or attr_name in mod._buffers or attr_name in mod._modules:
+                continue
+            # Skip INC FP8 scale tensors - they must remain on CPU
+            # as H2D const tensors for runtime scale patching.
+            if scale_members is not None and attr_name in scale_members:
                 continue
             obj = mod.__dict__[attr_name]
             new_obj, cnt, changed = _move_obj(obj)


### PR DESCRIPTION
Pull changes from main (https://github.com/vllm-project/vllm-gaudi/pull/1324)

GC compile error(verifyConvertScale: expected H2D convert scale tensor) was introduced after https://github.com/vllm-project/vllm-gaudi/pull/1183 for all the models quantized via Intel Neural Compressor with scale_format: const: LLaMA, DeepSeek-R1, Qwen, Mixtral, and other.  This is due to we are also moving all scale tensors. This change is to skip them. 