### PR TITLE
Add Gaudi 1.24.0 support to vLLM 0.17.1

### DIFF
--- a/docs/getting_started/compatibility_matrix.md
+++ b/docs/getting_started/compatibility_matrix.md
@@ -3,9 +3,40 @@ title: Compatibility Matrix
 ---
 [](){ #compatibility-matrix }
 
-The following table detail the supported vLLM versions for Intel® Gaudi® 2 and Intel® Gaudi® 3 AI accelerators.
+The following table detail the supported vLLM versions for Intel® Gaudi® 2 and Intel® Gaudi® 3 AI accelerators. The versions marked as unsupported may still work, but they have not been thoroughly tested.
 
-| Intel Gaudi Software | vLLM v0.11.2 | vLLM v0.13.0 |  vLLM v0.14.1  | vLLM v0.15.1    |  vLLM v0.16.0  |  vLLM v0.17.1  |
-| :------------------- | :----------: | :----------: | :------------: |  :------------: | :------------: | :------------: |
-| 1.22.2               |       ✅     |      ❌      |       ❌      |       ❌       |      ❌        |      ❌        |
-| 1.23.0               |       ✅     |      ✅      |       ✅      |       ✅       |      ✅        |      ✅        |
+<div class="compatibility-matrix">
+<table>
+  <thead>
+    <tr>
+      <th rowspan="2">vLLM<br>version</th>
+      <th colspan="3">Intel Gaudi software version</th>
+    </tr>
+    <tr>
+      <th>1.22.2</th>
+      <th>1.23.0</th>
+      <th>1.24.0</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>0.11.2</td><td>✅</td><td>✅</td><td>❌</td>
+    </tr>
+    <tr>
+      <td>0.13.0</td><td>❌</td><td>✅</td><td>❌</td>
+    </tr>
+    <tr>
+      <td>0.14.1</td><td>❌</td><td>✅</td><td>❌</td>
+    </tr>
+    <tr>
+      <td>0.15.1</td><td>❌</td><td>✅</td><td>❌</td>
+    </tr>
+    <tr>
+      <td>0.16.0</td><td>❌</td><td>✅</td><td>❌</td>
+    </tr>
+    <tr>
+      <td>0.17.1</td><td>❌</td><td>✅</td><td>✅</td>
+    </tr>
+  </tbody>
+</table>
+</div>

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -4,7 +4,7 @@ This document provides an overview of the features, changes, and fixes introduce
 
 ## 0.17.1
 
-This version is based on [vLLM 0.17.1](https://github.com/vllm-project/vllm/releases/tag/v0.17.1) and supports [Intel® Gaudi® Software v1.23.0](https://docs.habana.ai/en/v1.23.0/Release_Notes/GAUDI_Release_Notes.html).
+This version is based on [vLLM 0.17.1](https://github.com/vllm-project/vllm/releases/tag/v0.17.1) and supports [Intel® Gaudi® Software v1.23.0](https://docs.habana.ai/en/v1.23.0/Release_Notes/GAUDI_Release_Notes.html) and [Intel® Gaudi® Software v1.24.0](https://docs.habana.ai/en/v1.24.0/Release_Notes/GAUDI_Release_Notes.html).
 
 This release adds validated support for Ernie4.5-VL, GPT-OSS (20B/120B), and reranking models (Bert, Roberta, Qwen3-based), introduces MxFP4 weight loading and dequantization, and delivers major Mamba/Granite 4.0-h improvements including prefix caching, custom depthwise conv1d TPC kernels, and precision enhancements. It also introduces RowParallel NIC chunking for distributed inference, logprobs output functionality, and Granite tool calling accuracy improvements. Stability was improved through grammar bitmask corruption fixes.
 

--- a/docs/release_notes_v0.17.1.md
+++ b/docs/release_notes_v0.17.1.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This release is based on [vLLM v0.17.1](https://github.com/vllm-project/vllm/releases/tag/v0.17.1) and supports [Intel® Gaudi® Software v1.23.0](https://docs.habana.ai/en/v1.23.0/Release_Notes/GAUDI_Release_Notes.html).
+This release is based on [vLLM v0.17.1](https://github.com/vllm-project/vllm/releases/tag/v0.17.1) and supports [Intel® Gaudi® Software v1.23.0](https://docs.habana.ai/en/v1.23.0/Release_Notes/GAUDI_Release_Notes.html) and [Intel® Gaudi® Software v1.24.0](https://docs.habana.ai/en/v1.24.0/Release_Notes/GAUDI_Release_Notes.html).
 
 ---
 

--- a/docs/styles/custom.css
+++ b/docs/styles/custom.css
@@ -29,3 +29,19 @@
   border-bottom: 1px solid #0000001a;
   transition: box-shadow 0.4s ease, border-bottom-color 0.4s ease, border-bottom-width 0.4s ease;
 }
+
+.md-typeset .compatibility-matrix table,
+.md-typeset .compatibility-matrix table th,
+.md-typeset .compatibility-matrix table td {
+    border: 1px solid var(--md-default-fg-color--lightest);
+}
+
+.compatibility-matrix table th,
+.compatibility-matrix table td {
+    text-align: center !important;
+}
+
+.compatibility-matrix table td:first-child {
+    text-align: left !important;
+}
+


### PR DESCRIPTION
This PR needs to be merged **after the Gaudi 1.24.0 release**.

This PR also refactors the support matrix to reduce clutter and improve visibility across multiple vLLM versions. To avoid repeating “Intel Gaudi” in each column and to optimize space usage, the table has been restructured with two header rows. This required switching to an HTML table format and applying custom styling, including vertical separators, to preserve readability.
<img width="500" alt="image" src="https://github.com/user-attachments/assets/1bf74111-6699-4abe-bf36-13f302b696e6" />
