### PR TITLE
[FIX_FOR_VLLM_CUSTOM=0e39202ca911319c7747a2f9d5a0c162fdff4fd9] Fix requirements paths and nixl_connector imports after upstream restructuring

### DIFF
--- a/.cd/Dockerfile.rhel.ubi.vllm
+++ b/.cd/Dockerfile.rhel.ubi.vllm
@@ -209,7 +209,7 @@ RUN set -e && \
     git remote add upstream $VLLM_REPO && \
     git fetch upstream --tags && \
     git checkout ${VLLM_PROJECT_COMMIT} && \
-    pip install --no-cache-dir -r <(sed '/^torch/d' requirements/build.txt) && \
+    pip install --no-cache-dir -r <(sed '/^torch/d' requirements/build/cuda.txt) && \
     VLLM_TARGET_DEVICE=empty pip install --no-cache-dir --no-build-isolation . && \
     cd $VLLM_PATH2 && \
     git checkout ${VLLM_GAUDI_COMMIT} && \

--- a/.cd/Dockerfile.ubuntu.pytorch.vllm
+++ b/.cd/Dockerfile.ubuntu.pytorch.vllm
@@ -56,7 +56,7 @@ RUN \
     git fetch upstream --tags || true && \
     git checkout ${VLLM_PROJECT_COMMIT} && \
     # Install vllm-project/vllm
-    bash -c "pip install -r <(sed '/^torch/d' requirements/build.txt)" && \
+    bash -c "pip install -r <(sed '/^torch/d' requirements/build/cuda.txt)" && \
     VLLM_TARGET_DEVICE=empty pip install --no-build-isolation . && \
     # Install vllm-gaudi plugin
     cd $VLLM_PATH2 && \

--- a/.cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest
+++ b/.cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest
@@ -55,7 +55,7 @@ RUN \
     git fetch upstream --tags || true && \
     git checkout ${VLLM_PROJECT_COMMIT} && \
     # Install vllm-project/vllm
-    bash -c 'pip install -r <(sed "/^torch/d" requirements/build/cuda.txt)' && \
+    bash -c 'pip install -r <(sed "/^torch/d" requirements/build.txt)' && \
     VLLM_TARGET_DEVICE=empty pip install --no-build-isolation . && \
     # Install vllm-gaudi plugin
     cd $VLLM_PATH2 && \

--- a/.cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest
+++ b/.cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest
@@ -55,7 +55,7 @@ RUN \
     git fetch upstream --tags || true && \
     git checkout ${VLLM_PROJECT_COMMIT} && \
     # Install vllm-project/vllm
-    bash -c 'pip install -r <(sed "/^torch/d" requirements/build.txt)' && \
+    bash -c 'pip install -r <(sed "/^torch/d" requirements/build/cuda.txt)' && \
     VLLM_TARGET_DEVICE=empty pip install --no-build-isolation . && \
     # Install vllm-gaudi plugin
     cd $VLLM_PATH2 && \

--- a/.github/Dockerfile.ci
+++ b/.github/Dockerfile.ci
@@ -27,7 +27,7 @@ ENV no_proxy=localhost,127.0.0.1
 ENV PT_HPU_ENABLE_LAZY_COLLECTIVES=true
 
 # Install vLLM build requirements (excluding torch, already in base image)
-RUN bash -c 'pip install -r <(sed "/^torch/d" requirements/build.txt)'
+RUN bash -c 'pip install -r <(sed "/^torch/d" requirements/build/cuda.txt)'
 RUN VLLM_TARGET_DEVICE=empty pip install --no-build-isolation .
 
 # Install development dependencies (for testing)

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -620,28 +620,28 @@ jobs:
             echo "Nixl Dockerfile was NOT modified"
           fi
 
-#  build_nixl_dockerfile:
-#    needs: [check_dockerfile_changes, discover_runner, retrieve_head_sha]
-#    if: needs.check_dockerfile_changes.outputs.nixl_changed == 'true'
-#    runs-on: ${{ needs.discover_runner.outputs.runner_name }}
-#    steps:
-#      - name: Checkout repository
-#        uses: actions/checkout@v4
-#        with:
-#          ref: ${{ needs.retrieve_head_sha.outputs.head_sha }}
-#          clean: true
-#      - name: Build nixl Dockerfile (validation only)
-#        run: |
-#          echo "Building .cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest to verify it builds correctly..."
-#          docker build \
-#            --no-cache \
-#            -t nixl-dockerfile-build-test \
-#            -f .cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest \
-#            .
-#          echo "Nixl Dockerfile build succeeded."
-#      - name: Cleanup test image
-#        if: always()
-#        run: docker rmi -f nixl-dockerfile-build-test || true
+  build_nixl_dockerfile:
+    needs: [check_dockerfile_changes, discover_runner, retrieve_head_sha]
+    if: needs.check_dockerfile_changes.outputs.nixl_changed == 'true'
+    runs-on: ${{ needs.discover_runner.outputs.runner_name }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.retrieve_head_sha.outputs.head_sha }}
+          clean: true
+      - name: Build nixl Dockerfile (validation only)
+        run: |
+          echo "Building .cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest to verify it builds correctly..."
+          docker build \
+            --no-cache \
+            -t nixl-dockerfile-build-test \
+            -f .cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest \
+            .
+          echo "Nixl Dockerfile build succeeded."
+      - name: Cleanup test image
+        if: always()
+        run: docker rmi -f nixl-dockerfile-build-test || true
 
   pre_merge_hpu_test:
     # --- UPDATED: Add discover_runner dependency ---

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -620,28 +620,28 @@ jobs:
             echo "Nixl Dockerfile was NOT modified"
           fi
 
-  build_nixl_dockerfile:
-    needs: [check_dockerfile_changes, discover_runner, retrieve_head_sha]
-    if: needs.check_dockerfile_changes.outputs.nixl_changed == 'true'
-    runs-on: ${{ needs.discover_runner.outputs.runner_name }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.retrieve_head_sha.outputs.head_sha }}
-          clean: true
-      - name: Build nixl Dockerfile (validation only)
-        run: |
-          echo "Building .cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest to verify it builds correctly..."
-          docker build \
-            --no-cache \
-            -t nixl-dockerfile-build-test \
-            -f .cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest \
-            .
-          echo "Nixl Dockerfile build succeeded."
-      - name: Cleanup test image
-        if: always()
-        run: docker rmi -f nixl-dockerfile-build-test || true
+#  build_nixl_dockerfile:
+#    needs: [check_dockerfile_changes, discover_runner, retrieve_head_sha]
+#    if: needs.check_dockerfile_changes.outputs.nixl_changed == 'true'
+#    runs-on: ${{ needs.discover_runner.outputs.runner_name }}
+#    steps:
+#      - name: Checkout repository
+#        uses: actions/checkout@v4
+#        with:
+#          ref: ${{ needs.retrieve_head_sha.outputs.head_sha }}
+#          clean: true
+#      - name: Build nixl Dockerfile (validation only)
+#        run: |
+#          echo "Building .cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest to verify it builds correctly..."
+#          docker build \
+#            --no-cache \
+#            -t nixl-dockerfile-build-test \
+#            -f .cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest \
+#            .
+#          echo "Nixl Dockerfile build succeeded."
+#      - name: Cleanup test image
+#        if: always()
+#        run: docker rmi -f nixl-dockerfile-build-test || true
 
   pre_merge_hpu_test:
     # --- UPDATED: Add discover_runner dependency ---

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,8 +36,8 @@ repos:
   rev: 0.6.17
   hooks:
     - id: pip-compile
-      args: [requirements/test.in, -o, requirements/test.txt, --index-strategy, unsafe-best-match, --torch-backend, cu128]
-      files: ^requirements/test\.(in|txt)$
+      args: [requirements/test/cuda.in, -o, requirements/test/cuda.txt, --index-strategy, unsafe-best-match, --torch-backend, cu128]
+      files: ^requirements/test/cuda\.(in|txt)$
 - repo: local
   hooks:
   - id: mypy-local

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The vLLM Hardware Plugin for Intel® Gaudi® integrates [Intel® Gaudi® AI acce
     git clone https://github.com/vllm-project/vllm
     cd vllm
     git checkout $VLLM_COMMIT_HASH
-    pip install -r <(sed '/^torch/d' requirements/build.txt)
+    pip install -r <(sed '/^torch/d' requirements/build/cuda.txt)
     VLLM_TARGET_DEVICE=empty pip install --no-build-isolation -e .
     cd ..
     ```

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -122,7 +122,7 @@ There are two ways to install vLLM Hardware Plugin for Intel Gaudi from source: 
         git clone https://github.com/vllm-project/vllm
         cd vllm
         git checkout $VLLM_COMMIT_HASH
-        pip install -r <(sed '/^torch/d' requirements/build.txt)
+        pip install -r <(sed '/^torch/d' requirements/build/cuda.txt)
         VLLM_TARGET_DEVICE=empty pip install --no-build-isolation -e .
         cd ..
   
@@ -173,7 +173,7 @@ To install vLLM Hardware Plugin for Intel Gaudi and NIXL using a Dockerfile:
         git clone https://github.com/vllm-project/vllm
         cd vllm
         git checkout $VLLM_COMMIT_HASH
-        pip install -r <(sed '/^torch/d' requirements/build.txt)
+        pip install -r <(sed '/^torch/d' requirements/build/cuda.txt)
         VLLM_TARGET_DEVICE=empty pip install --no-build-isolation -e .
         cd ..
 

--- a/tests/pytorch_ci_hud_benchmark/Dockerfile.hpu
+++ b/tests/pytorch_ci_hud_benchmark/Dockerfile.hpu
@@ -44,7 +44,7 @@ RUN VLLM_STABLE_COMMIT=$(curl -s https://raw.githubusercontent.com/vllm-project/
     git remote add upstream https://github.com/vllm-project/vllm.git && \
     git fetch upstream --tags || true && \
     git checkout $VLLM_COMMIT_TO_USE && \
-    bash -c "pip install -r <(sed '/^torch/d' requirements/build.txt)" && \
+    bash -c "pip install -r <(sed '/^torch/d' requirements/build/cuda.txt)" && \
     VLLM_TARGET_DEVICE=empty pip install --no-build-isolation .
 
 # Clone the vllm-gaudi repository and install inside the container

--- a/vllm_gaudi/distributed/kv_transfer/kv_connector/v1/hetero_hpu_nixl_connector.py
+++ b/vllm_gaudi/distributed/kv_transfer/kv_connector/v1/hetero_hpu_nixl_connector.py
@@ -12,12 +12,23 @@ from concurrent.futures import Future, ThreadPoolExecutor
 import msgspec
 import numpy as np
 
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector import (TransferHandle, ReqId, ReqMeta,
-                                                                         _NIXL_SUPPORTED_DEVICE, NixlAgentMetadata,
-                                                                         NixlConnector, NixlConnectorWorker,
-                                                                         NixlConnectorScheduler, NixlConnectorMetadata,
-                                                                         NixlHandshakePayload, NixlKVConnectorStats,
-                                                                         compute_nixl_compatibility_hash)
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl import (
+    NixlAgentMetadata,
+    NixlConnector,
+    NixlConnectorMetadata,
+    NixlConnectorScheduler,
+    NixlConnectorWorker,
+    NixlHandshakePayload,
+    NixlKVConnectorStats,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
+    TransferHandle,
+    ReqId,
+    ReqMeta,
+    compute_nixl_compatibility_hash,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl.utils import (
+    _NIXL_SUPPORTED_DEVICE, )
 from vllm_gaudi.platform import logger
 
 from vllm import envs

--- a/vllm_gaudi/distributed/kv_transfer/kv_connector/v1/hpu_nixl_connector.py
+++ b/vllm_gaudi/distributed/kv_transfer/kv_connector/v1/hpu_nixl_connector.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import torch
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector import (NixlConnectorWorker)
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl import NixlConnectorWorker
 from vllm.distributed.kv_transfer.kv_connector.utils import TpKVTopology
 from vllm_gaudi.platform import logger
 import habana_frameworks.torch.utils.experimental as htexp

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -109,7 +109,7 @@ from vllm.model_executor.models import supports_lora, supports_multimodal
 from vllm_gaudi.extension.ops import LoraMask as LoraMask
 from vllm.distributed.kv_transfer.kv_connector.utils import copy_kv_blocks
 from vllm.distributed.kv_transfer.kv_connector.v1.multi_connector import MultiKVConnectorMetadata
-from vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector import NixlConnectorMetadata
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl import NixlConnectorMetadata
 from vllm.distributed.kv_transfer.kv_connector.v1.offloading_connector import OffloadingConnectorMetadata
 from vllm.distributed.kv_transfer.kv_connector.base import KVConnectorBase
 from vllm.v1.core.sched.output import GrammarOutput


### PR DESCRIPTION
## Summary

Fixes two regressions introduced by recent upstream vLLM directory restructurings that break Docker builds, pre-commit hooks, and HPU unit tests.

## Changes

1. **Update requirements paths in Dockerfiles, README, docs and pre-commit config** — upstream moved `requirements/build.txt` → `requirements/build/cuda.txt` and `requirements/test.in` → `requirements/test/cuda.in`
2. **Update nixl_connector imports in HPU model runner and NIXL connectors** — upstream split monolithic `nixl_connector.py` into a `nixl/` package with sub-modules (`connector.py`, `metadata.py`, `scheduler.py`, `stats.py`, `utils.py`, `worker.py`)

## Upstream PRs that introduced these regressions

- https://github.com/vllm-project/vllm/pull/39024 — restructured `requirements/` directory layout (fix 1)
- https://github.com/vllm-project/vllm/pull/39354 — reorganized NIXL connector into its own directory (fix 2)