### PR TITLE
[FIX_FOR_VLLM_CUSTOM=d3af8c18317c0dc008d42e4367fbb9045cfb7bf6] Add hf_config parameter to HPU quantization config overrides

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -620,28 +620,28 @@ jobs:
             echo "Nixl Dockerfile was NOT modified"
           fi
 
-#  build_nixl_dockerfile:
-#    needs: [check_dockerfile_changes, discover_runner, retrieve_head_sha]
-#    if: needs.check_dockerfile_changes.outputs.nixl_changed == 'true'
-#    runs-on: ${{ needs.discover_runner.outputs.runner_name }}
-#    steps:
-#      - name: Checkout repository
-#        uses: actions/checkout@v4
-#        with:
-#          ref: ${{ needs.retrieve_head_sha.outputs.head_sha }}
-#          clean: true
-#      - name: Build nixl Dockerfile (validation only)
-#        run: |
-#          echo "Building .cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest to verify it builds correctly..."
-#          docker build \
-#            --no-cache \
-#            -t nixl-dockerfile-build-test \
-#            -f .cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest \
-#            .
-#          echo "Nixl Dockerfile build succeeded."
-#      - name: Cleanup test image
-#        if: always()
-#        run: docker rmi -f nixl-dockerfile-build-test || true
+  build_nixl_dockerfile:
+    needs: [check_dockerfile_changes, discover_runner, retrieve_head_sha]
+    if: needs.check_dockerfile_changes.outputs.nixl_changed == 'true'
+    runs-on: ${{ needs.discover_runner.outputs.runner_name }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.retrieve_head_sha.outputs.head_sha }}
+          clean: true
+      - name: Build nixl Dockerfile (validation only)
+        run: |
+          echo "Building .cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest to verify it builds correctly..."
+          docker build \
+            --no-cache \
+            -t nixl-dockerfile-build-test \
+            -f .cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest \
+            .
+          echo "Nixl Dockerfile build succeeded."
+      - name: Cleanup test image
+        if: always()
+        run: docker rmi -f nixl-dockerfile-build-test || true
 
   pre_merge_hpu_test:
     # --- UPDATED: Add discover_runner dependency ---

--- a/vllm_gaudi/ops/hpu_awq.py
+++ b/vllm_gaudi/ops/hpu_awq.py
@@ -92,7 +92,7 @@ class AWQHPUConfig(QuantizationConfig):
         return cls(weight_bits, group_size, zero_point, modules_to_not_convert)
 
     @classmethod
-    def override_quantization_method(cls, hf_quant_cfg, user_quant) -> Optional[str]:
+    def override_quantization_method(cls, hf_quant_cfg, user_quant, hf_config=None) -> Optional[str]:
 
         is_valid_user_quant = user_quant == "awq_hpu"
 

--- a/vllm_gaudi/ops/hpu_gptq.py
+++ b/vllm_gaudi/ops/hpu_gptq.py
@@ -102,7 +102,7 @@ class GPTQHPUConfig(QuantizationConfig):
         return cls(weight_bits, group_size, desc_act, lm_head_quantized)
 
     @classmethod
-    def override_quantization_method(cls, hf_quant_cfg, user_quant) -> Optional[str]:
+    def override_quantization_method(cls, hf_quant_cfg, user_quant, hf_config=None) -> Optional[str]:
 
         is_valid_user_quant = user_quant == "gptq_hpu"
 


### PR DESCRIPTION
## Summary

Fixes a regression introduced by upstream vLLM that breaks all quantization tests using HPU-specific GPTQ and AWQ backends (e.g. `run_qwen3_inc_dynamic_load_generate_test`).

## Changes

1. **Add `hf_config` parameter to `override_quantization_method()` in `GPTQHPUConfig` and `AWQHPUConfig`** — upstream changed the call site in `vllm/config/model.py` to pass `hf_config=self.hf_config`, but plugin implementations still used the old 2-parameter signature, causing `TypeError`.
2. **Re-enable `build_nixl_dockerfile` CI test** in pre-merge workflow.

## Upstream PR that introduced the regression

- https://github.com/vllm-project/vllm/pull/39604 — added `hf_config` keyword argument to `override_quantization_method()` call and updated all upstream implementations, but plugin implementations were not updated.