### PR TITLE
Accept PEP 440 versions in build detection

### DIFF
--- a/vllm_gaudi/extension/environment.py
+++ b/vllm_gaudi/extension/environment.py
@@ -11,7 +11,7 @@ from contextlib import suppress
 
 from .logger import logger
 from .config import Value, boolean, split_values_and_flags, Any, Disabled, Enabled
-from .validation import choice, regex
+from .validation import choice, pep440_version
 
 _VLLM_VALUES = {}
 
@@ -105,8 +105,7 @@ def get_environment():
         Value('build',
               _get_build,
               env_var_type=str,
-              check=regex(r'^\d+\.\d+\.\d+\.\d+$',
-                          hint='You can override detected build by specifying VLLM_BUILD env variable')),
+              check=pep440_version(hint='You can override detected build by specifying VLLM_BUILD env variable')),
         Value('engine_version', _get_vllm_engine_version, env_var_type=str),
         Value('bridge_mode', _get_pt_bridge_mode, env_var_type=str, check=choice('eager', 'lazy')),
         VllmValue('model_type', str),

--- a/vllm_gaudi/extension/validation.py
+++ b/vllm_gaudi/extension/validation.py
@@ -44,6 +44,19 @@ def regex(pattern, hint='') -> Checker:
     return regex_impl
 
 
+def pep440_version(hint='') -> Checker:
+    """Validates if input is a PEP 440 compliant version string"""
+    from packaging.version import Version, InvalidVersion
+
+    def pep440_impl(value: str):
+        try:
+            Version(value)
+        except InvalidVersion:
+            return f"'{value}' is not a valid PEP 440 version! {hint}"
+
+    return pep440_impl
+
+
 def skip_validation(_) -> None:
     """Dummy Checker used to skip validation"""
     return None


### PR DESCRIPTION
## Summary

`habana-torch-plugin` can report PEP 440 versions like `1.23.0.post1`. The build version regex `^\d+\.\d+\.\d+\.\d+$` rejects anything that isn't four dot-separated integers, causing startup failure:

```
RuntimeError: build: '1.23.0.post1' doesn't match pattern '^\d+\.\d+\.\d+\.\d+$'!
```

## Fix

Replace the hardcoded regex with a `pep440_version()` validator that uses `packaging.version.Version` (already a dependency via `config.py`) to validate. This accepts any valid PEP 440 version — post-releases, dev releases, release candidates — without enumerating suffixes in a regex.

## Changes

- `validation.py`: Add `pep440_version()` checker
- `environment.py`: Use `pep440_version()` instead of `regex()` for build version validation

`VersionRange()` in `features.py` already uses `packaging.version.Version` to parse the build string, so this makes validation consistent with consumption.

Fixes #1350

Signed-off-by: Willy Hardy <whardy@redhat.com>