### PR TITLE
Minor release notes improvements for 0.19.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,6 @@ vLLM Hardware Plugin for Intel® Gaudi®
 
   This release introduces validated support and critical stability fixes for Qwen3-VL models leveraging HPUMMEncoderAttention. Performance and stability were improved through backported Mamba architecture optimizations, Docker and UBI infrastructure enhancements, and a forced CPU loading mechanism for INC quantization to prevent OOM errors.
 
-- [2026/02] Version 0.15.1 is now available, built on [vLLM 0.15.1](https://github.com/vllm-project/vllm/releases/tag/v0.15.1) and fully compatible with [Intel® Gaudi® v1.23.0](https://docs.habana.ai/en/v1.23.0/Release_Notes/GAUDI_Release_Notes.html).
-
-  This release introduces validated support for Granite 4.0-h and Qwen3-VL (dense and MoE variants) on Intel Gaudi 3, alongside significant Llama 4 stability fixes. It also features major prefill performance improvements via full chunked prefill attention, FlashAttention online merge, b2b matmul operations, and KV cache sharing. Additionally, this version adds HPU ops for Mamba/SSM architectures to enable hybrid models, and introduces new support for ModelOpt FP8 quantization.
-
-- [2026/02] Version 0.14.1 is now available, built on [vLLM 0.14.1](https://github.com/vllm-project/vllm/releases/tag/v0.14.1) and fully compatible with [Intel® Gaudi® v1.23.0](https://docs.habana.ai/en/v1.23.0/Release_Notes/GAUDI_Release_Notes.html). It introduces support for Granite 4.0h and Qwen 3 VL models.
-
-- [2026/01] Version 0.13.0 is now available, built on [vLLM 0.13.0](https://github.com/vllm-project/vllm/releases/tag/v0.13.0) and fully compatible with [Intel® Gaudi® v1.23.0](https://docs.habana.ai/en/v1.23.0/Release_Notes/GAUDI_Release_Notes.html). It introduces experimental dynamic quantization for MatMul and KV‑cache operations to improve performance and also supports additional models.
-
 ---
 
 ## About

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -4,9 +4,9 @@ This document provides an overview of the features, changes, and fixes introduce
 
 ## 0.19.0
 
-This version is based on [vLLM 0.19.0](https://github.com/vllm-project/vllm/releases/tag/v0.19.0) and supports [Intel® Gaudi® Software v1.24.0](https://docs.habana.ai/en/v1.24.0/Release_Notes/GAUDI_Release_Notes.html) with PyTorch 2.10.
+This version is based on [vLLM 0.19.0](https://github.com/vllm-project/vllm/releases/tag/v0.19.0) and supports the latest [Intel® Gaudi® Software v1.24.0](https://docs.habana.ai/en/v1.24.0/Release_Notes/GAUDI_Release_Notes.html) with PyTorch 2.10.
 
-This release upgrades the platform to Intel® Gaudi® Software v1.24.0 with PyTorch 2.10. It introduces Qwen 3.5 model support with compact mode, Mamba prefix caching for hybrid models, MxFP4 weight loading and dequantization, LMCache integration, and a custom depthwise conv1d TPC kernel for MambaMixer2. Performance improvements include torch.compile-compatible online defragmentation, reduced warmup time via decode bucket capping, and optimized hybrid KV cache visibility. Multiple stability fixes address OOM crashes, multimodal prefill batching, grammar bitmask corruption, and FP8 quantization issues.
+This release introduces Qwen 3.5 model support with compact mode, Mamba prefix caching for hybrid models, MxFP4 weight loading and dequantization, LMCache integration, and a custom depthwise conv1d TPC kernel for MambaMixer2. Performance improvements include torch.compile-compatible online defragmentation, reduced warmup time via decode bucket capping, and optimized hybrid KV cache visibility. Multiple stability fixes address OOM crashes, multimodal prefill batching, grammar bitmask corruption, and FP8 quantization issues.
 
 For a full list of changes, see the [Detailed Release Notes](release_notes_v0.19.0.md).
 

--- a/docs/release_notes_v0.17.1.md
+++ b/docs/release_notes_v0.17.1.md
@@ -10,104 +10,104 @@ This release is based on [vLLM v0.17.1](https://github.com/vllm-project/vllm/rel
 
 - Added validated support for **Ernie4.5-VL**, **GPT-OSS** (20B/120B), and **reranking models** (Bert-based, Roberta-based, and Qwen3-based).
 - Introduced **MxFP4 weight loading and dequantization** support for Gaudi, enabling GPT-OSS model inference.
-- Major **Mamba/Granite 4.0-h** improvements including prefix caching support, custom depthwise conv1d TPC kernels, and precision enhancements.
+- Introduced major **Mamba/Granite 4.0-h** improvements, including prefix caching support, custom depthwise conv1d TPC kernels, and precision enhancements.
 - Enhanced **RowParallel NIC chunking** for better distributed inference performance.
 - Added **logprobs** output functionality and **Granite tool calling** accuracy improvements.
-- Improved stability through grammar bitmask corruption fixes.
+- Improved stability by fixing grammar bitmask corruption.
 
 ---
 
 ## New Model Support
 
-- Add Support for **Ernie4.5-VL** ([#813](https://github.com/vllm-project/vllm-gaudi/pull/813))
-- Ported reranking models: Bert-based, Roberta-based and Qwen3-based ([#1001](https://github.com/vllm-project/vllm-gaudi/pull/1001))
-- Added support for **GPT-OSS** models (lmsys/gpt-oss-20b-bf16, lmsys/gpt-oss-120b-bf16, openai/gpt-oss-20b, openai/gpt-oss-120b) via MxFP4 weight dequantization ([#1251](https://github.com/vllm-project/vllm-gaudi/pull/1251))
-- Enable caching for Qwen3 MoE op ([#1249](https://github.com/vllm-project/vllm-gaudi/pull/1249))
+- Added support for **Ernie4.5-VL**. ([#813](https://github.com/vllm-project/vllm-gaudi/pull/813))
+- Ported the following reranking models: Bert-based, Roberta-based, and Qwen3-based. ([#1001](https://github.com/vllm-project/vllm-gaudi/pull/1001))
+- Added support for **GPT-OSS** models (lmsys/gpt-oss-20b-bf16, lmsys/gpt-oss-120b-bf16, openai/gpt-oss-20b, and openai/gpt-oss-120b) via MxFP4 weight dequantization. ([#1251](https://github.com/vllm-project/vllm-gaudi/pull/1251))
+- Enabled caching for Qwen3 MoE op. ([#1249](https://github.com/vllm-project/vllm-gaudi/pull/1249))
 
 ---
 
 ## Performance
 
-- Optimization of `selective_state_update` ref in MambaMixer2 decode ([#1244](https://github.com/vllm-project/vllm-gaudi/pull/1244))
-- Replacing fancy indexing with select and copy for Granite4 state update ([#1210](https://github.com/vllm-project/vllm-gaudi/pull/1210))
-- Creating custom depthwise conv1d kernel for MambaMixer2 ([#1175](https://github.com/vllm-project/vllm-gaudi/pull/1175))
-- Improving precision of `_depthwise_conv1d_tpc` for bf16 ([#1203](https://github.com/vllm-project/vllm-gaudi/pull/1203))
-- hpu_mamba_chunk_scan_combined_varlen improvements ([#997](https://github.com/vllm-project/vllm-gaudi/pull/997))
-- RowParallel NIC chunking ([#896](https://github.com/vllm-project/vllm-gaudi/pull/896))
-- Adding `compute_logits` to `_compile_methods` ([#1081](https://github.com/vllm-project/vllm-gaudi/pull/1081))
-- Blocking B2BMatmul in dynamic quantization ([#1002](https://github.com/vllm-project/vllm-gaudi/pull/1002))
+- Optimized the `selective_state_update` reference in MambaMixer2 decode. ([#1244](https://github.com/vllm-project/vllm-gaudi/pull/1244))
+- Replaced fancy indexing with select and copy for Granite4 state updates. ([#1210](https://github.com/vllm-project/vllm-gaudi/pull/1210))
+- Created a custom depthwise conv1d kernel for `MambaMixer2`. ([#1175](https://github.com/vllm-project/vllm-gaudi/pull/1175))
+- Improved bf16 precision of `_depthwise_conv1d_tpc`. ([#1203](https://github.com/vllm-project/vllm-gaudi/pull/1203))
+- Improved `hpu_mamba_chunk_scan_combined_varlen`. ([#997](https://github.com/vllm-project/vllm-gaudi/pull/997))
+- Improved RowParallel NIC chunking. ([#896](https://github.com/vllm-project/vllm-gaudi/pull/896))
+- Added `compute_logits` to `_compile_methods`. ([#1081](https://github.com/vllm-project/vllm-gaudi/pull/1081))
+- Blocked `B2BMatmul` in dynamic quantization. ([#1002](https://github.com/vllm-project/vllm-gaudi/pull/1002))
 
 ---
 
 ## Attention & KV Cache
 
-- Instead of changing KV cache shape, transpose state in conv1d ([#1025](https://github.com/vllm-project/vllm-gaudi/pull/1025))
-- Fix KV cache memory regression from unconditional RowParallelLinear OOT registration ([#1215](https://github.com/vllm-project/vllm-gaudi/pull/1215))
-- Prefix caching support for HPUMambaMixer2 ([#1198](https://github.com/vllm-project/vllm-gaudi/pull/1198))
+- Transposed state in `conv1d` instead of changing the KV cache shape. ([#1025](https://github.com/vllm-project/vllm-gaudi/pull/1025))
+- Fixed a KV cache memory regression caused by unconditional `RowParallelLinear` OOT registration. ([#1215](https://github.com/vllm-project/vllm-gaudi/pull/1215))
+- Added prefix caching support for `HPUMambaMixer2`. ([#1198](https://github.com/vllm-project/vllm-gaudi/pull/1198))
 
 ---
 
 ## Quantization
 
-- Load and Dequant MxFP4 Weights ([#1251](https://github.com/vllm-project/vllm-gaudi/pull/1251))
-- Granite-4.0-h Calibration config ([#1221](https://github.com/vllm-project/vllm-gaudi/pull/1221))
-- Force CPU loading for INC quantization to prevent OOM during weight loading ([#1006](https://github.com/vllm-project/vllm-gaudi/pull/1006))
-- Fix type mismatch in DeepSeek with fp8_fused_sdpa for mla prefill ([#978](https://github.com/vllm-project/vllm-gaudi/pull/978))
+- Loaded and dequantized MxFP4 weights. ([#1251](https://github.com/vllm-project/vllm-gaudi/pull/1251))
+- Added a Granite-4.0-h calibration config. ([#1221](https://github.com/vllm-project/vllm-gaudi/pull/1221))
+- Forced CPU loading for INC quantization to prevent OOM during weight loading. ([#1006](https://github.com/vllm-project/vllm-gaudi/pull/1006))
+- Fixed a type mismatch in DeepSeek with fp8_fused_sdpa for MLA prefill. ([#978](https://github.com/vllm-project/vllm-gaudi/pull/978))
 
 ---
 
 ## Plugin Core
 
-- Add `num_spec` field to MambaMixer2 for upstream compatibility ([#1142](https://github.com/vllm-project/vllm-gaudi/pull/1142))
-- Fix SharedFusedMoE attribute error for Llama4 MoE layers ([#1172](https://github.com/vllm-project/vllm-gaudi/pull/1172))
-- Fixing redundant transpose in HPUMambaMixer2 ([#999](https://github.com/vllm-project/vllm-gaudi/pull/999))
-- Fix HPUMambaMixer2 inheritance dependency ([#1017](https://github.com/vllm-project/vllm-gaudi/pull/1017))
-- Fix mamba cumsum padded calculations ([#1009](https://github.com/vllm-project/vllm-gaudi/pull/1009))
-- `use_qk_norm` parameter sourced directly from config ([#972](https://github.com/vllm-project/vllm-gaudi/pull/972))
-- Replace mm dummy options ([#1085](https://github.com/vllm-project/vllm-gaudi/pull/1085))
-- Logprobs functionality ([#1101](https://github.com/vllm-project/vllm-gaudi/pull/1101))
-- Granite accuracy for tool calling ([#1018](https://github.com/vllm-project/vllm-gaudi/pull/1018))
-- Add torch inference decorator back to warmup ([#1104](https://github.com/vllm-project/vllm-gaudi/pull/1104))
-- Added mechanism for adding events to tlparse ([#1054](https://github.com/vllm-project/vllm-gaudi/pull/1054))
-- Fix to gemma3 UT — replaced tuple operation by TC friendly equivalent ([#1083](https://github.com/vllm-project/vllm-gaudi/pull/1083))
+- Added the `num_spec` field to MambaMixer2 for upstream compatibility. ([#1142](https://github.com/vllm-project/vllm-gaudi/pull/1142))
+- Fixed a `SharedFusedMoE` attribute error for Llama4 MoE layers. ([#1172](https://github.com/vllm-project/vllm-gaudi/pull/1172))
+- Removed a redundant transpose in `HPUMambaMixer2`. ([#999](https://github.com/vllm-project/vllm-gaudi/pull/999))
+- Fixed an `HPUMambaMixer2` inheritance dependency. ([#1017](https://github.com/vllm-project/vllm-gaudi/pull/1017))
+- Fixed Mamba cumsum padded calculations. ([#1009](https://github.com/vllm-project/vllm-gaudi/pull/1009))
+- Sourced the `use_qk_norm` parameter directly from the config. ([#972](https://github.com/vllm-project/vllm-gaudi/pull/972))
+- Replaced MM dummy options. ([#1085](https://github.com/vllm-project/vllm-gaudi/pull/1085))
+- Added the `logprobs` functionality. ([#1101](https://github.com/vllm-project/vllm-gaudi/pull/1101))
+- Improved Granite tool-calling accuracy. ([#1018](https://github.com/vllm-project/vllm-gaudi/pull/1018))
+- Added the torch inference decorator back to warmup. ([#1104](https://github.com/vllm-project/vllm-gaudi/pull/1104))
+- Added a mechanism for adding events to `tlparse`. ([#1054](https://github.com/vllm-project/vllm-gaudi/pull/1054))
+- Fixed the `gemma3` UT by replacing a tuple operation with a TC-friendly equivalent. ([#1083](https://github.com/vllm-project/vllm-gaudi/pull/1083))
 
 ---
 
 ## Serving & Infrastructure
 
-- Set docker auto calc rules for reserved memory in Torch compile mode ([#1170](https://github.com/vllm-project/vllm-gaudi/pull/1170))
-- Improve docker autocalc linear recipe for long contexts ([#959](https://github.com/vllm-project/vllm-gaudi/pull/959))
-- Fix Dockerfile for RHEL 9.6 build by updating package installation order ([#1008](https://github.com/vllm-project/vllm-gaudi/pull/1008))
-- Install torchaudio from CPU wheel to match PyTorch version in Dockerfile ([#1110](https://github.com/vllm-project/vllm-gaudi/pull/1110))
-- Moved inline Dockerfile to a separate file and added torchaudio ([#1050](https://github.com/vllm-project/vllm-gaudi/pull/1050))
-- Install torchaudio in CD Dockerfiles ([#1051](https://github.com/vllm-project/vllm-gaudi/pull/1051))
-- Add PT_VERSION argument and install torchaudio in Dockerfile ([#1043](https://github.com/vllm-project/vllm-gaudi/pull/1043))
-- UBI image: remove pt_fork and duplicated package ([#1066](https://github.com/vllm-project/vllm-gaudi/pull/1066))
-- Restore default `temperature=0` for the server after #32723 ([#1039](https://github.com/vllm-project/vllm-gaudi/pull/1039))
-- Fix setuptools package discovery to include sub-packages ([#1219](https://github.com/vllm-project/vllm-gaudi/pull/1219))
-- Fix `-u` flag requiring argument in `calibrate_model.sh` ([#1167](https://github.com/vllm-project/vllm-gaudi/pull/1167))
+- Set docker autocalc rules for reserved memory in Torch compile mode. ([#1170](https://github.com/vllm-project/vllm-gaudi/pull/1170))
+- Improved the docker autocalc linear recipe for long contexts. ([#959](https://github.com/vllm-project/vllm-gaudi/pull/959))
+- Fixed the Dockerfile for RHEL 9.6 builds by updating the package installation order. ([#1008](https://github.com/vllm-project/vllm-gaudi/pull/1008))
+- Installed `torchaudio` from the CPU wheel to match the PyTorch version in the Dockerfile. ([#1110](https://github.com/vllm-project/vllm-gaudi/pull/1110))
+- Moved the inline Dockerfile to a separate file and added `torchaudio`. ([#1050](https://github.com/vllm-project/vllm-gaudi/pull/1050))
+- Installed `torchaudio` in CD Dockerfiles. ([#1051](https://github.com/vllm-project/vllm-gaudi/pull/1051))
+- Added the `PT_VERSION` argument and installed `torchaudio` in the Dockerfile. ([#1043](https://github.com/vllm-project/vllm-gaudi/pull/1043))
+- Removed `pt_fork` and a duplicated package from the UBI image. ([#1066](https://github.com/vllm-project/vllm-gaudi/pull/1066))
+- Restored the server default `temperature=0` after #32723. ([#1039](https://github.com/vllm-project/vllm-gaudi/pull/1039))
+- Fixed `setuptools` package discovery to include sub-packages. ([#1219](https://github.com/vllm-project/vllm-gaudi/pull/1219))
+- Fixed the `-u` flag requiring an argument in `calibrate_model.sh`. ([#1167](https://github.com/vllm-project/vllm-gaudi/pull/1167))
 
 ---
 
 ## Fixes
 
-- Fix OOM crashes during high-concurrency inference ([#1252](https://github.com/vllm-project/vllm-gaudi/pull/1252))
-- Fix of Qwen Out of HOST memory (OOM) ([#1256](https://github.com/vllm-project/vllm-gaudi/pull/1256))
-- Fix grammar bitmask corruption in mixed structured-output batches ([#1199](https://github.com/vllm-project/vllm-gaudi/pull/1199))
-- Granite4.0h fallback bucket padding fix ([#1207](https://github.com/vllm-project/vllm-gaudi/pull/1207))
-- Fix prefill bucket mismatch when prefills with no context are padded ([#1064](https://github.com/vllm-project/vllm-gaudi/pull/1064))
-- Fix for default max decode blocks in exponential ([#1091](https://github.com/vllm-project/vllm-gaudi/pull/1091))
-- Fix import error for MultiModalBudget ([#1062](https://github.com/vllm-project/vllm-gaudi/pull/1062))
-- Qwen3-VL WarmUp Fix ([#994](https://github.com/vllm-project/vllm-gaudi/pull/994))
-- Server doesn't crash when request is canceled ([#990](https://github.com/vllm-project/vllm-gaudi/pull/990))
-- Fix param mismatch for `compute_nixl_compatibility_hash()` ([#1224](https://github.com/vllm-project/vllm-gaudi/pull/1224))
+- Fixed OOM crashes during high-concurrency inference. ([#1252](https://github.com/vllm-project/vllm-gaudi/pull/1252))
+- Fixed Qwen Out of Host Memory (OOM) errors. ([#1256](https://github.com/vllm-project/vllm-gaudi/pull/1256))
+- Fixed grammar bitmask corruption in mixed structured-output batches. ([#1199](https://github.com/vllm-project/vllm-gaudi/pull/1199))
+- Fixed Granite4.0h fallback bucket padding. ([#1207](https://github.com/vllm-project/vllm-gaudi/pull/1207))
+- Fixed a prefill bucket mismatch when prefills with no context were padded. ([#1064](https://github.com/vllm-project/vllm-gaudi/pull/1064))
+- Fixed default max decode blocks in exponential. ([#1091](https://github.com/vllm-project/vllm-gaudi/pull/1091))
+- Fixed an import error for MultiModalBudget. ([#1062](https://github.com/vllm-project/vllm-gaudi/pull/1062))
+- Fixed Qwen3-VL warmup. ([#994](https://github.com/vllm-project/vllm-gaudi/pull/994))
+- Prevented server crashes when requests were canceled. ([#990](https://github.com/vllm-project/vllm-gaudi/pull/990))
+- Fixed a parameter mismatch for `compute_nixl_compatibility_hash()`. ([#1224](https://github.com/vllm-project/vllm-gaudi/pull/1224))
 
 ---
 
 ## Security
 
-- SDL secure error handling fixes ([#1246](https://github.com/vllm-project/vllm-gaudi/pull/1246))
-- Coverity fix including security, null-like values, duplicates and typos ([#1163](https://github.com/vllm-project/vllm-gaudi/pull/1163))
+- Fixed SDL secure error handling issues. ([#1246](https://github.com/vllm-project/vllm-gaudi/pull/1246))
+- Fixed coverity issues, including security, null-like values, duplicates, and typos. ([#1163](https://github.com/vllm-project/vllm-gaudi/pull/1163))
 
 ---
 

--- a/docs/release_notes_v0.19.0.md
+++ b/docs/release_notes_v0.19.0.md
@@ -8,111 +8,111 @@ This release is based on [vLLM v0.19.0](https://github.com/vllm-project/vllm/rel
 
 ## Highlights
 
-- Upgraded platform compatibility to **Intel® Gaudi® Software v1.24.0** and **PyTorch 2.10**, advancing from the v1.23.0 / PT 2.9 baseline used in previous releases.
-- Added initial **Qwen 3.5** model support with compact mode for improved memory utilization (#1153, #1235, #1312).
-- Introduced **Mamba prefix caching** support for hybrid SSM-Transformer models on v0.19.0 (#1330).
-- Added **MxFP4 weight loading and dequantization** for next-generation quantization formats (#1156).
-- Integrated **LMCache** support via monkey-patching for external cache backends (#1176).
-- Introduced **custom depthwise conv1d TPC kernel** for MambaMixer2 to improve hybrid model performance (#1092).
-- Adapted the **online defragmenter for torch.compile** mode, enabling memory defragmentation in compiled execution (#986).
-- Improved warmup performance by **capping decode block bucket limits** (#1160).
+- Upgraded platform compatibility to **Intel® Gaudi® Software v1.24.0** and **PyTorch 2.10**.
+- Introduced **Qwen 3.5** model support with compact mode for improved memory utilization.
+- Introduced **Mamba prefix caching** support for hybrid SSM-Transformer models on v0.19.0.
+- Added **MxFP4 weight loading and dequantization** for next-generation quantization formats.
+- Integrated **LMCache** support via monkey-patching for external cache backends.
+- Introduced **custom depthwise conv1d TPC kernel** for MambaMixer2 to improve hybrid model performance.
+- Adapted the **online defragmenter for torch.compile** mode, enabling memory defragmentation in compiled execution.
+- Improved warmup performance by **capping decode block bucket limits**.
 
 ---
 
 ## New Model Support
 
-- Qwen 3.5 initial enablement ([#1153](https://github.com/vllm-project/vllm-gaudi/pull/1153))
-- Qwen 3.5 compact mode ([#1235](https://github.com/vllm-project/vllm-gaudi/pull/1235))
-- Qwen 3.5 additional changes and fixes ([#1312](https://github.com/vllm-project/vllm-gaudi/pull/1312))
+- Added initial Qwen 3.5 model support. ([#1153](https://github.com/vllm-project/vllm-gaudi/pull/1153))
+- Added Qwen 3.5 compact mode. ([#1235](https://github.com/vllm-project/vllm-gaudi/pull/1235))
+- Added Qwen 3.5 additional changes and fixes. ([#1312](https://github.com/vllm-project/vllm-gaudi/pull/1312))
 
 ---
 
 ## Performance
 
-- Creating custom depthwise conv1d kernel for MambaMixer2 ([#1092](https://github.com/vllm-project/vllm-gaudi/pull/1092))
-- Adapt Online defragmenter for torch compile ([#986](https://github.com/vllm-project/vllm-gaudi/pull/986))
-- Set reserved memory for Torch compile ([#1093](https://github.com/vllm-project/vllm-gaudi/pull/1093))
-- Cap decode block bucket limit to reduce warmup time ([#1160](https://github.com/vllm-project/vllm-gaudi/pull/1160))
-- Optimize selective_state_update ([#1295](https://github.com/vllm-project/vllm-gaudi/pull/1295))
-- Optimizing visible block number for Hybrid kv_cache ([#1319](https://github.com/vllm-project/vllm-gaudi/pull/1319))
+- Created a custom depthwise conv1d kernel for MambaMixer2. ([#1092](https://github.com/vllm-project/vllm-gaudi/pull/1092))
+- Adapted the online defragmenter for torch.compile. ([#986](https://github.com/vllm-project/vllm-gaudi/pull/986))
+- Set reserved memory for torch.compile. ([#1093](https://github.com/vllm-project/vllm-gaudi/pull/1093))
+- Capped the decode block bucket limit to reduce warmup time. ([#1160](https://github.com/vllm-project/vllm-gaudi/pull/1160))
+- Optimized `selective_state_update`. ([#1295](https://github.com/vllm-project/vllm-gaudi/pull/1295))
+- Optimized the visible block number for hybrid KV cache. ([#1319](https://github.com/vllm-project/vllm-gaudi/pull/1319))
 
 ---
 
 ## Attention & KV Cache
 
-- Mamba prefix caching support for v0.19.0 ([#1330](https://github.com/vllm-project/vllm-gaudi/pull/1330))
-- Fix for proper KV cache slot addressing for Hybrid models ([#1323](https://github.com/vllm-project/vllm-gaudi/pull/1323))
-- Resolving kv_cache access in HPUMambaMixer2 and reintroducing Granite4.0 in CI ([#1287](https://github.com/vllm-project/vllm-gaudi/pull/1287))
-- Remove dead Unified Attention (UA) code ([#1226](https://github.com/vllm-project/vllm-gaudi/pull/1226))
-- Fix KV cache memory regression from unconditional RowParallelLinear OOT registration ([#1146](https://github.com/vllm-project/vllm-gaudi/pull/1146))
-- Exclude dummy block from NIXL KV cache registration ([#1140](https://github.com/vllm-project/vllm-gaudi/pull/1140))
+- Added Mamba prefix caching support for v0.19.0. ([#1330](https://github.com/vllm-project/vllm-gaudi/pull/1330))
+- Fixed proper KV cache slot addressing for hybrid models. ([#1323](https://github.com/vllm-project/vllm-gaudi/pull/1323))
+- Resolved KV cache access in HPUMambaMixer2 and reintroduced Granite4.0 in CI. ([#1287](https://github.com/vllm-project/vllm-gaudi/pull/1287))
+- Removed dead Unified Attention (UA) code. ([#1226](https://github.com/vllm-project/vllm-gaudi/pull/1226))
+- Fixed a KV cache memory regression caused by unconditional RowParallelLinear OOT registration. ([#1146](https://github.com/vllm-project/vllm-gaudi/pull/1146))
+- Excluded dummy block from NIXL KV cache registration. ([#1140](https://github.com/vllm-project/vllm-gaudi/pull/1140))
 
 ---
 
 ## Quantization
 
-- Load and Dequant MxFP4 Weights ([#1156](https://github.com/vllm-project/vllm-gaudi/pull/1156))
-- Fix INC FP8 dynamic quantization for MoE models on HPU ([#1183](https://github.com/vllm-project/vllm-gaudi/pull/1183))
-- Fix FP8 block-to-channel conversion breaking MLA weight loading ([#1220](https://github.com/vllm-project/vllm-gaudi/pull/1220))
-- Fix INC/MLA alias-path quantization failures ([#1222](https://github.com/vllm-project/vllm-gaudi/pull/1222))
-- Granite-4.0-h Calibration config ([#1221](https://github.com/vllm-project/vllm-gaudi/pull/1221))
-- Fix Synapse GC compile failure for FP8-quantized models ([#1334](https://github.com/vllm-project/vllm-gaudi/pull/1334))
+- Loaded and dequantized MxFP4 weights. ([#1156](https://github.com/vllm-project/vllm-gaudi/pull/1156))
+- Fixed INC FP8 dynamic quantization for MoE models on HPU. ([#1183](https://github.com/vllm-project/vllm-gaudi/pull/1183))
+- Fixed FP8 block-to-channel conversion breaking MLA weight loading. ([#1220](https://github.com/vllm-project/vllm-gaudi/pull/1220))
+- Fixed INC/MLA alias-path quantization failures. ([#1222](https://github.com/vllm-project/vllm-gaudi/pull/1222))
+- Added Granite-4.0-h calibration config. ([#1221](https://github.com/vllm-project/vllm-gaudi/pull/1221))
+- Fixed Synapse GC compile failure for FP8-quantized models. ([#1334](https://github.com/vllm-project/vllm-gaudi/pull/1334))
 
 ---
 
 ## Plugin Core
 
-- Patch for LMCache ([#1176](https://github.com/vllm-project/vllm-gaudi/pull/1176))
-- Remove aggregate module HpuDeepseekOCRVisual ([#1102](https://github.com/vllm-project/vllm-gaudi/pull/1102))
-- Remove deprecated virtual_engine from ForwardContext ([#1187](https://github.com/vllm-project/vllm-gaudi/pull/1187))
-- Fix CPUOffloadingSpec import path and remove obsolete roberta patch ([#1229](https://github.com/vllm-project/vllm-gaudi/pull/1229))
-- Separate conv1d for Granite 4.0 (v0.17.1-style) ([#1320](https://github.com/vllm-project/vllm-gaudi/pull/1320))
-- Add num_spec field to MambaMixer2 for upstream compatibility ([#1141](https://github.com/vllm-project/vllm-gaudi/pull/1141))
-- Fix include all sub-packages in setuptools package discovery ([#1212](https://github.com/vllm-project/vllm-gaudi/pull/1212))
+- Added a patch for LMCache. ([#1176](https://github.com/vllm-project/vllm-gaudi/pull/1176))
+- Removed aggregate module HpuDeepseekOCRVisual. ([#1102](https://github.com/vllm-project/vllm-gaudi/pull/1102))
+- Removed deprecated `virtual_engine` from `ForwardContext`. ([#1187](https://github.com/vllm-project/vllm-gaudi/pull/1187))
+- Fixed CPUOffloadingSpec import path and removed obsolete roberta patch. ([#1229](https://github.com/vllm-project/vllm-gaudi/pull/1229))
+- Separated conv1d for Granite 4.0 (v0.17.1-style). ([#1320](https://github.com/vllm-project/vllm-gaudi/pull/1320))
+- Added the `num_spec` field to MambaMixer2 for upstream compatibility. ([#1141](https://github.com/vllm-project/vllm-gaudi/pull/1141))
+- Fixed setuptools package discovery to include all sub-packages. ([#1212](https://github.com/vllm-project/vllm-gaudi/pull/1212))
 
 ---
 
 ## Serving & Infrastructure
 
-- Parameterize EXTRA_INDEX_URL in Dockerfiles ([#1131](https://github.com/vllm-project/vllm-gaudi/pull/1131))
-- Add VLLM_REPO and VLLM_GAUDI_REPO args to RHEL UBI Dockerfile ([#1225](https://github.com/vllm-project/vllm-gaudi/pull/1225))
-- Add real context length to the high-level profile ([#1169](https://github.com/vllm-project/vllm-gaudi/pull/1169))
-- Add more than 2 models to sleep mode model swapping test ([#1100](https://github.com/vllm-project/vllm-gaudi/pull/1100))
-- Add AI agents config files ([#1123](https://github.com/vllm-project/vllm-gaudi/pull/1123))
-- Update quickstart guide and supported model list ([#1173](https://github.com/vllm-project/vllm-gaudi/pull/1173))
+- Parameterized EXTRA_INDEX_URL in Dockerfiles. ([#1131](https://github.com/vllm-project/vllm-gaudi/pull/1131))
+- Added VLLM_REPO and VLLM_GAUDI_REPO arguments to RHEL UBI Dockerfile. ([#1225](https://github.com/vllm-project/vllm-gaudi/pull/1225))
+- Added real context length to the high-level profile. ([#1169](https://github.com/vllm-project/vllm-gaudi/pull/1169))
+- Added more than 2 models to the sleep mode model swapping test. ([#1100](https://github.com/vllm-project/vllm-gaudi/pull/1100))
+- Added AI agents config files. ([#1123](https://github.com/vllm-project/vllm-gaudi/pull/1123))
+- Updated the quickstart guide and supported model list. ([#1173](https://github.com/vllm-project/vllm-gaudi/pull/1173))
 
 ---
 
 ## Fixes
 
-- Fix OOM crashes during high-concurrency inference ([#1124](https://github.com/vllm-project/vllm-gaudi/pull/1124))
-- Fix multimodal prefill batching for 2D padded inputs ([#1126](https://github.com/vllm-project/vllm-gaudi/pull/1126))
-- Fix M-RoPE position tensor shape for batched multimodal prefill (BS>1) ([#1216](https://github.com/vllm-project/vllm-gaudi/pull/1216))
-- Fix preempted prompts and prefill/decoding splitting ([#830](https://github.com/vllm-project/vllm-gaudi/pull/830))
-- Fix grammar bitmask corruption in mixed structured-output batches ([#1200](https://github.com/vllm-project/vllm-gaudi/pull/1200))
-- Fix Qwen Out of HOST memory (OOM) ([#1247](https://github.com/vllm-project/vllm-gaudi/pull/1247))
-- Fix SharedFusedMoE attribute error for Llama4 MoE layers ([#1172](https://github.com/vllm-project/vllm-gaudi/pull/1172))
-- Fix false-positive cross-layer block detection for MLA in NIXL ([#1205](https://github.com/vllm-project/vllm-gaudi/pull/1205))
-- Fix block size setting for granite 4.0h ([#1318](https://github.com/vllm-project/vllm-gaudi/pull/1318))
-- Granite4.0h fallback bucket padding fix ([#1207](https://github.com/vllm-project/vllm-gaudi/pull/1207))
-- Fix wrong AI Lab names in validated_models.md ([#1282](https://github.com/vllm-project/vllm-gaudi/pull/1282))
-- Fix -u flag requiring argument in calibrate_model.sh ([#1121](https://github.com/vllm-project/vllm-gaudi/pull/1121))
+- Fixed OOM crashes during high-concurrency inference. ([#1124](https://github.com/vllm-project/vllm-gaudi/pull/1124))
+- Fixed multimodal prefill batching for 2D padded inputs. ([#1126](https://github.com/vllm-project/vllm-gaudi/pull/1126))
+- Fixed M-RoPE position tensor shape for batched multimodal prefill (BS>1). ([#1216](https://github.com/vllm-project/vllm-gaudi/pull/1216))
+- Fixed preempted prompts and prefill/decoding splitting. ([#830](https://github.com/vllm-project/vllm-gaudi/pull/830))
+- Fixed grammar bitmask corruption in mixed structured-output batches. ([#1200](https://github.com/vllm-project/vllm-gaudi/pull/1200))
+- Fixed Qwen out of host memory (OOM) errors. ([#1247](https://github.com/vllm-project/vllm-gaudi/pull/1247))
+- Fixed a `SharedFusedMoE` attribute error for Llama4 MoE layers. ([#1172](https://github.com/vllm-project/vllm-gaudi/pull/1172))
+- Fixed false-positive cross-layer block detection for MLA in NIXL. ([#1205](https://github.com/vllm-project/vllm-gaudi/pull/1205))
+- Fixed block size setting for Granite 4.0h. ([#1318](https://github.com/vllm-project/vllm-gaudi/pull/1318))
+- Fixed Granite4.0h fallback bucket padding. ([#1207](https://github.com/vllm-project/vllm-gaudi/pull/1207))
+- Fixed wrong AI Lab names in validated_models.md. ([#1282](https://github.com/vllm-project/vllm-gaudi/pull/1282))
+- Fixed the `-u` flag requiring an argument in calibrate_model.sh. ([#1121](https://github.com/vllm-project/vllm-gaudi/pull/1121))
 
 ---
 
 ## Security
 
-- Coverity fix including security, null-like values, duplicates and typos ([#1164](https://github.com/vllm-project/vllm-gaudi/pull/1164))
-- SDL secure error handling fixes ([#1245](https://github.com/vllm-project/vllm-gaudi/pull/1245))
+- Fixed coverity issues, including security, null-like values, duplicates, and typos. ([#1164](https://github.com/vllm-project/vllm-gaudi/pull/1164))
+- Fixed SDL secure error handling issues. ([#1245](https://github.com/vllm-project/vllm-gaudi/pull/1245))
 
 ---
 
 ## Deprecation & Breaking Changes
 
-- Upgraded to **Intel® Gaudi® Software v1.24.0** and **PyTorch 2.10** — users must update their Gaudi software stack from v1.23.0 to v1.24.0.
-- Removed dead Unified Attention (UA) code ([#1226](https://github.com/vllm-project/vllm-gaudi/pull/1226)).
-- Removed aggregate module HpuDeepseekOCRVisual ([#1102](https://github.com/vllm-project/vllm-gaudi/pull/1102)).
-- Removed deprecated `virtual_engine` from `ForwardContext` ([#1187](https://github.com/vllm-project/vllm-gaudi/pull/1187)).
+- Upgraded to **Intel® Gaudi® Software v1.24.0** and **PyTorch 2.10**, which requires users to update their Intel Gaudi software stack from v1.23.0 to v1.24.0.
+- Removed unused Unified Attention (UA) code. ([#1226](https://github.com/vllm-project/vllm-gaudi/pull/1226)).
+- Removed the aggregate module `HpuDeepseekOCRVisual`. ([#1102](https://github.com/vllm-project/vllm-gaudi/pull/1102)).
+- Removed deprecated `virtual_engine` from `ForwardContext`. ([#1187](https://github.com/vllm-project/vllm-gaudi/pull/1187)).
 
 ---
 


### PR DESCRIPTION
- Removed a few older releases from the readme highlights to reduce clutter and improve the visibility of recent updates
- Added my earlier suggestions back to the 0.17.1 release notes, as they appeared to have been removed
- Added minor suggestions to the 0.19.0 release notes to ensure a more consistent tense, style, and overall professional tone.