### PR TITLE
Eliminate Llama4 torch.compile recompilations on HPU

### DIFF
--- a/vllm_gaudi/models/__init__.py
+++ b/vllm_gaudi/models/__init__.py
@@ -44,6 +44,10 @@ def register_model():
     from vllm_gaudi.models.qwen3_moe import HpuQwen3MoeForCausalLM  # noqa: F401
     ModelRegistry.register_model("Qwen3MoeForCausalLM", "vllm_gaudi.models.qwen3_moe:HpuQwen3MoeForCausalLM")
 
+    from vllm_gaudi.models.llama4 import HpuLlama4ForConditionalGeneration  # noqa: F401
+    ModelRegistry.register_model("Llama4ForConditionalGeneration",
+                                 "vllm_gaudi.models.llama4:HpuLlama4ForConditionalGeneration")
+
     import vllm_gaudi.models.deepseek_v2  # noqa: F401
 
     from vllm_gaudi.models.deepseek_ocr import HpuDeepseekOCRForCausalLM  # noqa: F401

--- a/vllm_gaudi/models/llama4.py
+++ b/vllm_gaudi/models/llama4.py
@@ -16,7 +16,6 @@ This module provides:
      to eliminate torch._dynamo type guards across layers.
 """
 
-import logging
 import types
 from itertools import islice
 
@@ -25,6 +24,7 @@ import torch
 import torch.nn as nn
 from vllm.config import VllmConfig
 from vllm.distributed import get_pp_group
+from vllm.logger import init_logger
 from vllm.model_executor.models.llama4 import (
     Llama4ForCausalLM as UpstreamLlama4ForCausalLM,
     Llama4Model as UpstreamLlama4Model,
@@ -33,7 +33,7 @@ from vllm.model_executor.models.mllama4 import (
     Llama4ForConditionalGeneration as UpstreamLlama4ForConditionalGeneration, )
 from vllm.sequence import IntermediateTensors
 
-logger = logging.getLogger(__name__)
+logger = init_logger(__name__)
 
 
 class HpuLlama4Model(UpstreamLlama4Model):
@@ -91,17 +91,17 @@ class HpuLlama4ForCausalLM(UpstreamLlama4ForCausalLM):
         self.model.__class__ = HpuLlama4Model
 
         # Apply branch-free attention patches (only in compile mode)
+        # Note: _unify_feed_forward_types is deferred to post-load via
+        # apply_hpu_llama4_post_load_patches() to avoid breaking weight loading
+        # (wrapping changes named_parameters() keys and hides .experts attribute).
         if not htorch.utils.internal.is_lazy():
             layers = getattr(self.model, "layers", [])
             _apply_branch_free_attention(layers)
             unified = _unify_attention_types(layers)
-            ff_unified = _unify_feed_forward_types(layers)
             logger.info(
                 "HpuLlama4ForCausalLM: applied branch-free attention patches, "
-                "unified %d ChunkedLocalAttention -> Attention, "
-                "unified %d feed_forward modules",
+                "unified %d ChunkedLocalAttention -> Attention",
                 unified,
-                ff_unified,
             )
 
 
@@ -122,6 +122,11 @@ def _apply_branch_free_attention(layers):
         logger.warning("No RoPE layer found to reference rotary_emb from")
         return
 
+    # If no layer has qk_norm (use_qk_norm=False), install nn.Identity()
+    # so the branchfree forward can call self.qk_norm() unconditionally.
+    if ref_qk_norm is None:
+        ref_qk_norm = nn.Identity()
+
     patched = 0
     for layer in layers:
         attn = layer.self_attn
@@ -137,12 +142,15 @@ def _apply_branch_free_attention(layers):
 def _patch_attention_module(attn, ref_rotary_emb, ref_qk_norm):
     """Patch a single Llama4Attention module to be branch-free."""
     if attn.rotary_emb is None:
-        attn.rotary_emb = ref_rotary_emb
+        # Use object.__setattr__ to avoid nn.Module registering a shared
+        # reference as a submodule under multiple parent paths, which would
+        # confuse tools that walk named_modules() (quantization, FX tracing).
+        object.__setattr__(attn, "rotary_emb", ref_rotary_emb)
 
     # QK norm: install reference on NoPE layers that have None
     has_qk_norm = attn.qk_norm is not None
     if not has_qk_norm and ref_qk_norm is not None:
-        attn.qk_norm = ref_qk_norm
+        object.__setattr__(attn, "qk_norm", ref_qk_norm)
 
     device = next(attn.parameters()).device
     attn.register_buffer(
@@ -153,7 +161,7 @@ def _patch_attention_module(attn, ref_rotary_emb, ref_qk_norm):
     attn.register_buffer(
         "_apply_temp_tuning",
         torch.tensor(
-            getattr(attn, "attn_temperature_tuning", False) and attn.nope,
+            getattr(attn, "attn_temperature_tuning", False),
             dtype=torch.bool,
             device=device,
         ),
@@ -208,6 +216,11 @@ def _unify_attention_types(layers):
 
     Since ChunkedLocalAttention does NOT override forward(), the __class__
     swap is behaviorally identical. get_kv_cache_spec is preserved as instance method.
+
+    WARNING: After this swap, isinstance(x, ChunkedLocalAttention) returns False.
+    Currently safe because maybe_set_chunked_attention_layers uses string matching
+    on backend names. If upstream ever switches to isinstance checks, this will
+    need updating. A _was_chunked_local marker is set for future detection.
     """
     from vllm.model_executor.layers.attention.attention import Attention
     from vllm.model_executor.layers.attention.chunked_local_attention import (
@@ -219,6 +232,7 @@ def _unify_attention_types(layers):
     for layer in layers:
         attn_inner = layer.self_attn.attn
         if type(attn_inner) is ChunkedLocalAttention:
+            attn_inner._was_chunked_local = True
             attn_inner.__class__ = Attention
             attn_inner.get_kv_cache_spec = types.MethodType(chunked_get_kv_cache_spec, attn_inner)
             unified_count += 1
@@ -270,25 +284,48 @@ class HpuLlama4ForConditionalGeneration(UpstreamLlama4ForConditionalGeneration):
         self.language_model.model.__class__ = HpuLlama4Model
 
         # Apply branch-free attention patches (only in compile mode)
+        # Note: _unify_feed_forward_types is deferred to post-load via
+        # apply_hpu_llama4_post_load_patches() to avoid breaking weight loading.
         if not htorch.utils.internal.is_lazy():
             layers = getattr(self.language_model.model, "layers", [])
             _apply_branch_free_attention(layers)
             unified = _unify_attention_types(layers)
-            ff_unified = _unify_feed_forward_types(layers)
             logger.info(
                 "HpuLlama4ForConditionalGeneration: applied branch-free attention, "
-                "unified %d ChunkedLocalAttention -> Attention, "
-                "unified %d feed_forward modules",
+                "unified %d ChunkedLocalAttention -> Attention",
                 unified,
-                ff_unified,
             )
 
 
+def apply_hpu_llama4_post_load_patches(model) -> None:
+    """Apply patches that must run after load_weights().
+
+    _unify_feed_forward_types wraps feed_forward modules in a unified type.
+    This must happen after weight loading because the wrapper changes
+    named_parameters() keys (adds .inner.) and hides .experts attribute,
+    which would break load_moe_expert_weights() in upstream Llama4Model.
+
+    Called from apply_model_specific_patches() in hpu_model_runner.py.
+    """
+    if not is_hpu_llama4_model(model):
+        return
+    if htorch.utils.internal.is_lazy():
+        return
+
+    # Get layers from ConditionalGeneration or CausalLM
+    if isinstance(model, HpuLlama4ForConditionalGeneration):
+        layers = getattr(model.language_model.model, "layers", [])
+    else:
+        layers = getattr(model.model, "layers", [])
+
+    ff_unified = _unify_feed_forward_types(layers)
+    if ff_unified > 0:
+        logger.info("Post-load: unified %d feed_forward modules", ff_unified)
+
+
 def is_hpu_llama4_model(model) -> bool:
-    """Check if the model is an HpuLlama4ForCausalLM (has heterogeneous layers).
+    """Check if the model is an HPU Llama4 model (has heterogeneous layers).
 
     Called from hpu_model_runner.py to set _has_heterogeneous_layers flag.
     """
-    # Check the outer ConditionalGeneration model or inner CausalLM
-    return (isinstance(model, HpuLlama4ForConditionalGeneration)
-            or isinstance(getattr(model, "language_model", model), HpuLlama4ForCausalLM))
+    return isinstance(model, HpuLlama4ForConditionalGeneration)

--- a/vllm_gaudi/models/llama4.py
+++ b/vllm_gaudi/models/llama4.py
@@ -1,0 +1,294 @@
+# SPDX-License-Identifier: Apache-2.0
+"""HPU-optimized Llama4 modules using model registry override pattern.
+
+Llama4 has 48 decoder layers with heterogeneous configurations:
+  - NoPE layers: no rotary_emb, temperature tuning, Attention backend
+  - RoPE layers: has rotary_emb, no temperature tuning, ChunkedLocalAttention
+
+This module provides:
+  1. HpuLlama4Model — overrides forward() to initialize residual as zeros
+     instead of None, eliminating torch._dynamo type guard.
+  2. HpuLlama4ForCausalLM — registered via ModelRegistry, applies branch-free
+     attention patches and attention type unification in __init__.
+  3. Branch-free attention patching — boolean buffer masks + torch.where
+     eliminate Python if/else guards on nope/rotary_emb/temperature_tuning.
+  4. Attention type unification — swaps ChunkedLocalAttention → Attention
+     to eliminate torch._dynamo type guards across layers.
+"""
+
+import logging
+import types
+from itertools import islice
+
+import habana_frameworks.torch as htorch
+import torch
+import torch.nn as nn
+from vllm.config import VllmConfig
+from vllm.distributed import get_pp_group
+from vllm.model_executor.models.llama4 import (
+    Llama4ForCausalLM as UpstreamLlama4ForCausalLM,
+    Llama4Model as UpstreamLlama4Model,
+)
+from vllm.model_executor.models.mllama4 import (
+    Llama4ForConditionalGeneration as UpstreamLlama4ForConditionalGeneration, )
+from vllm.sequence import IntermediateTensors
+
+logger = logging.getLogger(__name__)
+
+
+class HpuLlama4Model(UpstreamLlama4Model):
+    """Llama4Model with residual initialized as zeros instead of None.
+
+    The upstream LlamaModel.forward() sets ``residual = None`` for the first
+    rank, which creates a torch._dynamo type guard (None vs Tensor) that
+    causes recompilation between layer 0 and layers 1-47. Initializing
+    residual as ``torch.zeros_like(hidden_states)`` eliminates this guard.
+    """
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None,
+        inputs_embeds: torch.Tensor | None = None,
+        **extra_layer_kwargs,
+    ) -> torch.Tensor | IntermediateTensors | tuple[torch.Tensor, list[torch.Tensor]]:
+        if get_pp_group().is_first_rank:
+            hidden_states = inputs_embeds if inputs_embeds is not None else self.embed_input_ids(input_ids)
+            residual = torch.zeros_like(hidden_states)
+        else:
+            assert intermediate_tensors is not None
+            hidden_states = intermediate_tensors["hidden_states"]
+            residual = intermediate_tensors["residual"]
+
+        aux_hidden_states = []
+        for idx, layer in enumerate(islice(self.layers, self.start_layer, self.end_layer)):
+            if idx in self.aux_hidden_state_layers:
+                aux_hidden_states.append(hidden_states + residual)
+            hidden_states, residual = layer(positions, hidden_states, residual, **extra_layer_kwargs)
+
+        if not get_pp_group().is_last_rank:
+            return IntermediateTensors({"hidden_states": hidden_states, "residual": residual})
+
+        hidden_states, _ = self.norm(hidden_states, residual)
+
+        if len(aux_hidden_states) > 0:
+            return hidden_states, aux_hidden_states
+        return hidden_states
+
+
+class HpuLlama4ForCausalLM(UpstreamLlama4ForCausalLM):
+    """HPU-optimized Llama4ForCausalLM registered via ModelRegistry.
+
+    Applies branch-free attention patches, attention type unification,
+    and swaps the inner model class to HpuLlama4Model for residual fix.
+    """
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__(vllm_config=vllm_config, prefix=prefix)
+
+        # Swap inner model class for residual=zeros fix
+        self.model.__class__ = HpuLlama4Model
+
+        # Apply branch-free attention patches (only in compile mode)
+        if not htorch.utils.internal.is_lazy():
+            layers = getattr(self.model, "layers", [])
+            _apply_branch_free_attention(layers)
+            unified = _unify_attention_types(layers)
+            ff_unified = _unify_feed_forward_types(layers)
+            logger.info(
+                "HpuLlama4ForCausalLM: applied branch-free attention patches, "
+                "unified %d ChunkedLocalAttention -> Attention, "
+                "unified %d feed_forward modules",
+                unified,
+                ff_unified,
+            )
+
+
+def _apply_branch_free_attention(layers):
+    """Apply branch-free attention patches to all Llama4Attention layers."""
+    ref_rotary_emb = None
+    ref_qk_norm = None
+    for layer in layers:
+        attn = layer.self_attn
+        if ref_rotary_emb is None and hasattr(attn, "rotary_emb") and attn.rotary_emb is not None:
+            ref_rotary_emb = attn.rotary_emb
+        if ref_qk_norm is None and hasattr(attn, "qk_norm") and attn.qk_norm is not None:
+            ref_qk_norm = attn.qk_norm
+        if ref_rotary_emb is not None and ref_qk_norm is not None:
+            break
+
+    if ref_rotary_emb is None:
+        logger.warning("No RoPE layer found to reference rotary_emb from")
+        return
+
+    patched = 0
+    for layer in layers:
+        attn = layer.self_attn
+        if "Llama4Attention" not in type(attn).__name__:
+            continue
+        _patch_attention_module(attn, ref_rotary_emb, ref_qk_norm)
+        patched += 1
+
+    if patched > 0:
+        logger.info("Patched %d Llama4Attention layers for branch-free torch.compile", patched)
+
+
+def _patch_attention_module(attn, ref_rotary_emb, ref_qk_norm):
+    """Patch a single Llama4Attention module to be branch-free."""
+    if attn.rotary_emb is None:
+        attn.rotary_emb = ref_rotary_emb
+
+    # QK norm: install reference on NoPE layers that have None
+    has_qk_norm = attn.qk_norm is not None
+    if not has_qk_norm and ref_qk_norm is not None:
+        attn.qk_norm = ref_qk_norm
+
+    device = next(attn.parameters()).device
+    attn.register_buffer(
+        "_apply_rope",
+        torch.tensor(not attn.nope, dtype=torch.bool, device=device),
+        persistent=False,
+    )
+    attn.register_buffer(
+        "_apply_temp_tuning",
+        torch.tensor(
+            getattr(attn, "attn_temperature_tuning", False) and attn.nope,
+            dtype=torch.bool,
+            device=device,
+        ),
+        persistent=False,
+    )
+    attn.register_buffer(
+        "_has_qk_norm",
+        torch.tensor(has_qk_norm, dtype=torch.bool, device=device),
+        persistent=False,
+    )
+
+    attn.forward = types.MethodType(_branchfree_attention_forward, attn)
+
+
+def _branchfree_attention_forward(self, positions, hidden_states):
+    """Branch-free Llama4Attention forward.
+
+    All layers execute identical code. Boolean buffer masks + torch.where
+    select RoPE'd/un-RoPE'd, norm'd/un-norm'd, and scaled/un-scaled
+    at the data level — no Python if/else guards for torch.compile.
+    """
+    qkv, _ = self.qkv_proj(hidden_states)
+    q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+
+    # Always compute rotary embedding; NoPE layers discard via mask
+    q_rot, k_rot = self.rotary_emb(positions, q, k)
+    q = torch.where(self._apply_rope, q_rot, q)
+    k = torch.where(self._apply_rope, k_rot, k)
+
+    # QK norm: always compute, mask selects whether to apply.
+    # NoPE layers have a reference qk_norm installed but _has_qk_norm=False,
+    # so the normed values are discarded via torch.where.
+    q_for_norm = q.reshape(-1, self.head_dim)
+    q_normed = self.qk_norm(q_for_norm.float()).reshape(-1, self.q_size).to(q.dtype)
+    k_for_norm = k.reshape(-1, self.head_dim)
+    k_normed = self.qk_norm(k_for_norm.float()).reshape(-1, self.kv_size).to(k.dtype)
+    q = torch.where(self._has_qk_norm, q_normed, q)
+    k = torch.where(self._has_qk_norm, k_normed, k)
+
+    # Temperature tuning: always compute, NoPE mask selects
+    attn_scale = self._get_attn_scale(positions)
+    q_scaled = (q * attn_scale).to(q.dtype)
+    q = torch.where(self._apply_temp_tuning, q_scaled, q)
+
+    attn_output = self.attn(q, k, v)
+    output, _ = self.o_proj(attn_output)
+    return output
+
+
+def _unify_attention_types(layers):
+    """Change ChunkedLocalAttention instances to Attention type.
+
+    Since ChunkedLocalAttention does NOT override forward(), the __class__
+    swap is behaviorally identical. get_kv_cache_spec is preserved as instance method.
+    """
+    from vllm.model_executor.layers.attention.attention import Attention
+    from vllm.model_executor.layers.attention.chunked_local_attention import (
+        ChunkedLocalAttention, )
+
+    chunked_get_kv_cache_spec = ChunkedLocalAttention.get_kv_cache_spec
+    unified_count = 0
+
+    for layer in layers:
+        attn_inner = layer.self_attn.attn
+        if type(attn_inner) is ChunkedLocalAttention:
+            attn_inner.__class__ = Attention
+            attn_inner.get_kv_cache_spec = types.MethodType(chunked_get_kv_cache_spec, attn_inner)
+            unified_count += 1
+
+    return unified_count
+
+
+class _HpuLlama4FeedForward(nn.Module):
+    """Unified wrapper for Llama4MoE and LlamaMLP feed_forward modules.
+
+    Makes all feed_forward modules the same Python type to eliminate
+    torch._dynamo type guards when iterating across decoder layers.
+    """
+
+    def __init__(self, inner: nn.Module):
+        super().__init__()
+        self.inner = inner
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.inner(hidden_states)
+
+
+def _unify_feed_forward_types(layers) -> int:
+    """Wrap all feed_forward modules in a unified type.
+
+    Replaces heterogeneous Llama4MoE / LlamaMLP feed_forward attributes
+    with _HpuLlama4FeedForward wrappers so torch._dynamo sees one type.
+    """
+    unified = 0
+    for layer in layers:
+        ff = layer.feed_forward
+        if not isinstance(ff, _HpuLlama4FeedForward):
+            layer.feed_forward = _HpuLlama4FeedForward(ff)
+            unified += 1
+    return unified
+
+
+class HpuLlama4ForConditionalGeneration(UpstreamLlama4ForConditionalGeneration):
+    """HPU override of Llama4ForConditionalGeneration.
+
+    After upstream init creates language_model (Llama4ForCausalLM),
+    swaps the inner model class and applies branch-free attention patches.
+    """
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__(vllm_config=vllm_config, prefix=prefix)
+
+        # Swap inner model class for residual=zeros fix
+        self.language_model.model.__class__ = HpuLlama4Model
+
+        # Apply branch-free attention patches (only in compile mode)
+        if not htorch.utils.internal.is_lazy():
+            layers = getattr(self.language_model.model, "layers", [])
+            _apply_branch_free_attention(layers)
+            unified = _unify_attention_types(layers)
+            ff_unified = _unify_feed_forward_types(layers)
+            logger.info(
+                "HpuLlama4ForConditionalGeneration: applied branch-free attention, "
+                "unified %d ChunkedLocalAttention -> Attention, "
+                "unified %d feed_forward modules",
+                unified,
+                ff_unified,
+            )
+
+
+def is_hpu_llama4_model(model) -> bool:
+    """Check if the model is an HpuLlama4ForCausalLM (has heterogeneous layers).
+
+    Called from hpu_model_runner.py to set _has_heterogeneous_layers flag.
+    """
+    # Check the outer ConditionalGeneration model or inner CausalLM
+    return (isinstance(model, HpuLlama4ForConditionalGeneration)
+            or isinstance(getattr(model, "language_model", model), HpuLlama4ForCausalLM))

--- a/vllm_gaudi/models/llama4.py
+++ b/vllm_gaudi/models/llama4.py
@@ -86,23 +86,28 @@ class HpuLlama4ForCausalLM(UpstreamLlama4ForCausalLM):
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__(vllm_config=vllm_config, prefix=prefix)
+        _apply_hpu_llama4_init_patches(self.model)
 
-        # Swap inner model class for residual=zeros fix
-        self.model.__class__ = HpuLlama4Model
 
-        # Apply branch-free attention patches (only in compile mode)
-        # Note: _unify_feed_forward_types is deferred to post-load via
-        # apply_hpu_llama4_post_load_patches() to avoid breaking weight loading
-        # (wrapping changes named_parameters() keys and hides .experts attribute).
-        if not htorch.utils.internal.is_lazy():
-            layers = getattr(self.model, "layers", [])
-            _apply_branch_free_attention(layers)
-            unified = _unify_attention_types(layers)
-            logger.info(
-                "HpuLlama4ForCausalLM: applied branch-free attention patches, "
-                "unified %d ChunkedLocalAttention -> Attention",
-                unified,
-            )
+def _apply_hpu_llama4_init_patches(model_root: nn.Module) -> None:
+    """Shared init-time patches for both CausalLM and ConditionalGeneration.
+
+    Swaps the inner model class for the residual=zeros fix and applies
+    branch-free attention + attention type unification in compile mode.
+    _unify_feed_forward_types is deferred to post-load via
+    apply_hpu_llama4_post_load_patches() to avoid breaking weight loading.
+    """
+    model_root.__class__ = HpuLlama4Model
+
+    if not htorch.utils.internal.is_lazy():
+        layers = getattr(model_root, "layers", [])
+        _apply_branch_free_attention(layers)
+        unified = _unify_attention_types(layers)
+        logger.info(
+            "HpuLlama4: applied branch-free attention patches, "
+            "unified %d ChunkedLocalAttention -> Attention",
+            unified,
+        )
 
 
 def _apply_branch_free_attention(layers):
@@ -279,22 +284,7 @@ class HpuLlama4ForConditionalGeneration(UpstreamLlama4ForConditionalGeneration):
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__(vllm_config=vllm_config, prefix=prefix)
-
-        # Swap inner model class for residual=zeros fix
-        self.language_model.model.__class__ = HpuLlama4Model
-
-        # Apply branch-free attention patches (only in compile mode)
-        # Note: _unify_feed_forward_types is deferred to post-load via
-        # apply_hpu_llama4_post_load_patches() to avoid breaking weight loading.
-        if not htorch.utils.internal.is_lazy():
-            layers = getattr(self.language_model.model, "layers", [])
-            _apply_branch_free_attention(layers)
-            unified = _unify_attention_types(layers)
-            logger.info(
-                "HpuLlama4ForConditionalGeneration: applied branch-free attention, "
-                "unified %d ChunkedLocalAttention -> Attention",
-                unified,
-            )
+        _apply_hpu_llama4_init_patches(self.language_model.model)
 
 
 def apply_hpu_llama4_post_load_patches(model) -> None:

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -579,8 +579,10 @@ def apply_model_specific_patches(model_runner):
     maybe_set_chunked_attention_layers(model_runner)
     patch_llama4_get_attn_scale(model_runner.model)
     _init_mamba_split_weights(model_runner.model)
-    from vllm_gaudi.models.llama4 import is_hpu_llama4_model
+    from vllm_gaudi.models.llama4 import (apply_hpu_llama4_post_load_patches,
+                                          is_hpu_llama4_model)
     model_runner._has_heterogeneous_layers = is_hpu_llama4_model(model_runner.model)
+    apply_hpu_llama4_post_load_patches(model_runner.model)
 
 
 class HpuKVConnectorModelRunnerMixin(KVConnectorModelRunnerMixin):

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -579,6 +579,8 @@ def apply_model_specific_patches(model_runner):
     maybe_set_chunked_attention_layers(model_runner)
     patch_llama4_get_attn_scale(model_runner.model)
     _init_mamba_split_weights(model_runner.model)
+    from vllm_gaudi.models.llama4 import is_hpu_llama4_model
+    model_runner._has_heterogeneous_layers = is_hpu_llama4_model(model_runner.model)
 
 
 class HpuKVConnectorModelRunnerMixin(KVConnectorModelRunnerMixin):
@@ -947,6 +949,7 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
             self.kv_cache_dtype = STR_DTYPE_TO_TORCH_DTYPE[cache_config.cache_dtype]
         self.kv_cache_dtype_str = HPU_TORCH_DTYPE_TO_STR_DTYPE[self.kv_cache_dtype]
         self.is_pooling_model = model_config.pooler_config is not None
+        self._has_heterogeneous_layers: bool = False
 
         self.sliding_window = model_config.get_sliding_window()
         self.interleaved_sliding_window = (is_interleaved(vllm_config.model_config.hf_text_config)
@@ -5289,6 +5292,25 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
                       self.warmup_graphs(
                           self.bucketing_manager.decode_buckets, False, kv_caches)
                     self.log_graph_warmup_summary(self.bucketing_manager.decode_buckets, False, mem_post_decode)
+
+        # Validation warmup: run smallest buckets outside compile-only mode
+        # to trigger torch.compile guard specializations for heterogeneous layers
+        # (e.g. Llama4 mix of MoE/MLP feed_forward types).
+        if (can_use_compile_only_mode and not self.model_config.enforce_eager and not self.is_pooling_model
+                and self._has_heterogeneous_layers):
+            logger.info("Running validation warmup to trigger guard specializations...")
+            saved_graphed = self.graphed_buckets.copy()
+            self.graphed_buckets.clear()
+            prompt_buckets = self.bucketing_manager.prompt_buckets
+            if prompt_buckets:
+                validation_prompt_buckets = [prompt_buckets[0]]
+                if len(prompt_buckets) > 1:
+                    validation_prompt_buckets.append(prompt_buckets[-1])
+                self.warmup_graphs(validation_prompt_buckets, True, kv_caches)
+            if self.bucketing_manager.decode_buckets:
+                self.warmup_graphs([self.bucketing_manager.decode_buckets[0]], False, kv_caches)
+            self.graphed_buckets = saved_graphed
+            logger.info("Validation warmup complete.")
 
         end_time = time.perf_counter()
         end_mem = HabanaMemoryProfiler.current_device_memory_usage()

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -579,8 +579,7 @@ def apply_model_specific_patches(model_runner):
     maybe_set_chunked_attention_layers(model_runner)
     patch_llama4_get_attn_scale(model_runner.model)
     _init_mamba_split_weights(model_runner.model)
-    from vllm_gaudi.models.llama4 import (apply_hpu_llama4_post_load_patches,
-                                          is_hpu_llama4_model)
+    from vllm_gaudi.models.llama4 import (apply_hpu_llama4_post_load_patches, is_hpu_llama4_model)
     model_runner._has_heterogeneous_layers = is_hpu_llama4_model(model_runner.model)
     apply_hpu_llama4_post_load_patches(model_runner.model)
 


### PR DESCRIPTION
Llama4 Maverick has 48 heterogeneous decoder layers (NoPE/RoPE, MoE/MLP, ChunkedLocal/regular attention) causing torch._dynamo guard recompilations on the first benchmark run, resulting in P99 TTFT ~9081ms vs ~939ms on subsequent runs.

Changes:
- Add HpuLlama4ForConditionalGeneration model registry override
- Initialize residual as zeros instead of None to eliminate type guard
- Apply branch-free attention (boolean masks + torch.where) to remove Python if/else guards on nope/rotary_emb/temperature_tuning
- Unify ChunkedLocalAttention -> Attention to eliminate type guards
- Add validation warmup for heterogeneous layer guard specializations

Note: _mark_unbacked_dim0 for block_list already added by PR #1329.

Reduces first-run P99 TTFT from ~9081ms to ~1037ms (88.6% improvement).