### PR TITLE
Bucketing edge cases finetune for longer ctx

### DIFF
--- a/vllm_gaudi/extension/bucketing/common.py
+++ b/vllm_gaudi/extension/bucketing/common.py
@@ -235,7 +235,7 @@ class HPUBucketingManager():
 
     ### RETRIEVE BUCKETS FUNCTIONS ###
 
-    def generate_fallback_bucket(self, batch_size, seq_len, ctx):
+    def generate_fallback_bucket(self, batch_size, seq_len, ctx, is_prompt=False):
         assert self.max_num_batched_tokens is not None
         new_batch_size = calc_fallback_value(batch_size, self.fallback_bs_base_step)
         if new_batch_size > self.max_num_seqs:
@@ -249,19 +249,30 @@ class HPUBucketingManager():
             new_ctx = 0
         else:
             new_ctx = calc_fallback_value(ctx, self.fallback_blocks_base_step)
-            # Safety cap: limit to max prepared decode bucket ctx to prevent
-            # catastrophic graph compilation from corrupted batch data.
-            if self._fallback_max_ctx > 0 and new_ctx > self._fallback_max_ctx:
-                logger().warning(f"Fallback ctx {new_ctx} exceeds max prepared "
-                                 f"decode bucket ctx {self._fallback_max_ctx}, capping.")
-                new_ctx = self._fallback_max_ctx
+            if is_prompt:
+                # For prompt buckets, cap to the theoretical max number of
+                # context blocks derived from max_model_len.
+                max_prompt_ctx = math.ceil(self.max_model_len / self.block_size)
+                if new_ctx > max_prompt_ctx:
+                    logger().warning(f"Fallback prompt ctx {new_ctx} exceeds theoretical "
+                                     f"max {max_prompt_ctx} (max_model_len="
+                                     f"{self.max_model_len}, block_size={self.block_size}),"
+                                     f" capping.")
+                    new_ctx = max_prompt_ctx
+            else:
+                # Safety cap: limit to max prepared decode bucket ctx to prevent
+                # catastrophic graph compilation from corrupted batch data.
+                if self._fallback_max_ctx > 0 and new_ctx > self._fallback_max_ctx:
+                    logger().warning(f"Fallback ctx {new_ctx} exceeds max prepared "
+                                     f"decode bucket ctx {self._fallback_max_ctx}, capping.")
+                    new_ctx = self._fallback_max_ctx
         return (new_batch_size, new_seq_len, new_ctx)
 
     def find_prompt_bucket(self, batch_size, seq_len, ctx=0):
         if self.initialized:
             found_bucket = find_equal_or_closest_greater_config(self.prompt_buckets, (batch_size, seq_len, ctx))
             if found_bucket is None:
-                new_bucket = self.generate_fallback_bucket(batch_size, seq_len, ctx)
+                new_bucket = self.generate_fallback_bucket(batch_size, seq_len, ctx, is_prompt=True)
                 logger().warning(f"Prompt bucket for {batch_size, seq_len, ctx}"
                                  f" was not prepared. Adding new bucket: {new_bucket}")
                 self.prompt_buckets.append(new_bucket)
@@ -385,10 +396,18 @@ def generate_buckets(bs_range,
     # filter rules for buckets
     # prompt
     def not_over_max_model_len(bs, query, ctx):
-        smaller_than_limit = (query + ctx * block_size) <= max_model_len
+        # For chunked prefill, the final query chunk can be shorter than the
+        # bucket query size due to padding. Keep buckets as long as context
+        # blocks can represent at least one valid context length with one
+        # query token available.
+        # The -1 reserves at least 1 token for query so that when
+        # max_model_len is exactly divisible by block_size, the ceiling
+        # ctx is not over-counted.
+        max_ctx_blocks = math.ceil((max_model_len - 1) / block_size)
+        smaller_than_limit = ctx <= max_ctx_blocks
         if not smaller_than_limit:
             omitted_buckets.add(
-                ("condition: (query + ctx * block_size) <= max_model_len", "-> bs, query, ctx: ", bs, query, ctx))
+                ("condition: ctx <= ceil((max_model_len - 1) / block_size)", "-> bs, query, ctx: ", bs, query, ctx))
         return smaller_than_limit
 
     def not_over_max_num_batched_tokens(bs, query, ctx):
@@ -409,9 +428,6 @@ def generate_buckets(bs_range,
 
     def no_corrections(bs, query, ctx):
         return (bs, query, ctx)
-
-    def mamba_decode_corrector(bs, query, ctx):
-        return (bs, query, min(ctx, bs * math.floor(max_model_len / block_size)))
 
     def correct_for_max_model_len(bs, query, ctx):
         return (bs, query, min(ctx, bs * math.ceil(max_model_len / block_size)))
@@ -441,9 +457,7 @@ def generate_buckets(bs_range,
         return filters_map[phase][use_contiguous_pa]
 
     def get_corrector(is_prompt, use_contiguous_pa):
-        if mamba_chunk_size > 0 and not is_prompt:
-            return mamba_decode_corrector
-        elif is_prompt or use_contiguous_pa:
+        if is_prompt or use_contiguous_pa:
             return no_corrections
         else:
             return correct_for_max_model_len

--- a/vllm_gaudi/extension/bucketing/common.py
+++ b/vllm_gaudi/extension/bucketing/common.py
@@ -252,7 +252,7 @@ class HPUBucketingManager():
             if is_prompt:
                 # For prompt buckets, cap to the theoretical max number of
                 # context blocks derived from max_model_len.
-                max_prompt_ctx = math.ceil(self.max_model_len / self.block_size)
+                max_prompt_ctx = math.ceil((self.max_model_len - 1) / self.block_size)
                 if new_ctx > max_prompt_ctx:
                     logger().warning(f"Fallback prompt ctx {new_ctx} exceeds theoretical "
                                      f"max {max_prompt_ctx} (max_model_len="

--- a/vllm_gaudi/extension/bucketing/common.py
+++ b/vllm_gaudi/extension/bucketing/common.py
@@ -403,11 +403,13 @@ def generate_buckets(bs_range,
         # The -1 reserves at least 1 token for query so that when
         # max_model_len is exactly divisible by block_size, the ceiling
         # ctx is not over-counted.
+        # Also reject buckets whose query alone exceeds max_model_len,
+        # since such a prompt chunk is never reachable at runtime.
         max_ctx_blocks = math.ceil((max_model_len - 1) / block_size)
-        smaller_than_limit = ctx <= max_ctx_blocks
+        smaller_than_limit = ctx <= max_ctx_blocks and query <= max_model_len
         if not smaller_than_limit:
-            omitted_buckets.add(
-                ("condition: ctx <= ceil((max_model_len - 1) / block_size)", "-> bs, query, ctx: ", bs, query, ctx))
+            omitted_buckets.add(("condition: ctx <= ceil((max_model_len - 1) / block_size) and query <= max_model_len",
+                                 "-> bs, query, ctx: ", bs, query, ctx))
         return smaller_than_limit
 
     def not_over_max_num_batched_tokens(bs, query, ctx):

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -4973,7 +4973,7 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
                         # the actual last chunk size. Recompute context blocks
                         # so that ctx * block_size + query_len <= max_model_len
                         # and scheduled tokens == prompt_query_len exactly.
-                        capped_ctx = ((self.max_model_len - prompt_query_len) // self.block_size)
+                        capped_ctx = max(0, (self.max_model_len - prompt_query_len) // self.block_size)
                         prompt_num_context_blocks = [capped_ctx]
                         prompt_total_tokens = [capped_ctx * self.block_size + prompt_query_len]
             for _ in range(prompt_bs):

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -4977,12 +4977,21 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
                 prompt_ctx_len = prompt_num_blocks * self.block_size
                 prompt_total_tokens = [prompt_query_len + prompt_ctx_len]
                 prompt_num_context_blocks = [prompt_num_blocks]
-                if self.max_model_len < sum(prompt_total_tokens) \
-                    and self.use_merged_prefill:
-                    # split query and ctx in merged prefill case
-                    prompt_total_tokens, prompt_num_context_blocks = \
-                         self.get_merged_prefill_seq_lens(prompt_query_len,
-                                                     prompt_num_blocks)
+                if self.max_model_len < sum(prompt_total_tokens):
+                    if self.use_merged_prefill:
+                        # split query and ctx in merged prefill case
+                        prompt_total_tokens, prompt_num_context_blocks = \
+                             self.get_merged_prefill_seq_lens(prompt_query_len,
+                                                         prompt_num_blocks)
+                    else:
+                        # With chunked prefill, query bucket + ctx * block_size
+                        # can exceed max_model_len when the bucket pads beyond
+                        # the actual last chunk size. Recompute context blocks
+                        # so that ctx * block_size + query_len <= max_model_len
+                        # and scheduled tokens == prompt_query_len exactly.
+                        capped_ctx = ((self.max_model_len - prompt_query_len) // self.block_size)
+                        prompt_num_context_blocks = [capped_ctx]
+                        prompt_total_tokens = [capped_ctx * self.block_size + prompt_query_len]
             for _ in range(prompt_bs):
                 for tokens, context_len in zip(prompt_total_tokens, prompt_num_context_blocks):
                     if self.speculative_config and self.speculative_config.use_eagle():


### PR DESCRIPTION
## Fix prompt bucket filtering and fallback for long-context chunked prefill

### Problem

When using `VLLM_BUCKETING_FROM_FILE` with `max_model_len=131072` and a non-power-of-two `block_size` (e.g. 528 for Granite hybrid models), the `not_over_max_model_len` filter silently rejected the max context bucket (ctx=249). The old check `(query + ctx * block_size) <= max_model_len` failed because the padded bucket query (e.g. 8192) plus full context (249×528=131,472) exceeded 131,072 — even though at runtime the actual last-chunk query is shorter than the bucket size.

This caused two cascading failures:
1. Missing max-ctx bucket forced fallback bucket generation at runtime.
2. The fallback (`calc_fallback_value`) overshoots dramatically (e.g. ctx=235 → 448 blocks), triggering OOM during graph compilation.

Additionally, `mamba_decode_corrector` used `math.floor` to cap decode ctx, producing 1984 instead of the correct 1992 (`8 × ceil(131072/528)`). This caused repeated fallback warnings during decode.

### Changes

**`vllm_gaudi/extension/bucketing/common.py`**:
- Relaxed `not_over_max_model_len` to check `ctx <= ceil((max_model_len - 1) / block_size)` — only context blocks matter, not the padded query size.
- Added prompt-specific fallback cap in `generate_fallback_bucket` to limit ctx to `ceil(max_model_len / block_size)`, preventing oversized fallback buckets.
- Fixed `mamba_decode_corrector` (`math.floor` → `math.ceil`) and removed it as it became identical to `correct_for_max_model_len`. Simplified `get_corrector` accordingly.

**`vllm_gaudi/v1/worker/hpu_model_runner.py`**:
- Fixed `_prepare_dummy_scenario` to cap warmup dummy total tokens when `query + ctx * block_size > max_model_len` in the non-merged-prefill path, recomputing context blocks so that `scheduled_tokens == prompt_query_len` exactly.
