### PR TITLE
Logging omitted buckets when bucketing from file is enabled

### DIFF
--- a/vllm_gaudi/extension/bucketing/common.py
+++ b/vllm_gaudi/extension/bucketing/common.py
@@ -481,6 +481,14 @@ def generate_buckets(bs_range,
                         ctx = edge_ctx
                 if all(bucket_filter(bs, query, ctx) for bucket_filter in filters):
                     buckets.add(corrector(bs, query, ctx))
+    if file_buckets and omitted_buckets:
+        phase = 'prompt' if is_prompt else 'decode'
+        logger().warning(
+            "The following %s buckets from custom bucketing file "
+            "(VLLM_BUCKETING_FROM_FILE) were omitted during warmup:", phase)
+        for bucket in sorted(omitted_buckets):
+            logger().warning("  %s", bucket)
+
     if not buckets:
         phase = 'prompt' if is_prompt else 'decode'
         for bucket in omitted_buckets:


### PR DESCRIPTION
## Warn users about omitted buckets from custom bucketing file

When a user specifies custom buckets via `VLLM_BUCKETING_FROM_FILE`, some buckets may be silently dropped by internal filters (e.g. exceeding `max_model_len` or `max_num_batched_tokens`). Previously there was no indication that requested buckets were not warmed up, which could lead to unexpected fallback compilations at runtime.

This change adds a warning log listing each omitted bucket and the filter condition that rejected it, so users are informed when their custom bucket configuration is not fully honored. The warning only applies to file-based buckets — auto-generated buckets remain unchanged.
