### PR TITLE
Prefix caching support for HPUMambaMixer2

### DIFF
--- a/vllm_gaudi/attention/backends/hpu_attn.py
+++ b/vllm_gaudi/attention/backends/hpu_attn.py
@@ -139,7 +139,8 @@ class HPUAttentionMetadata(HPUPagedAttentionMetadata, AttentionMetadata):
     chunked_block_usage: Optional[torch.Tensor] = None
     has_initial_states_p: Optional[torch.Tensor] = None
     last_chunk_indices_p: Optional[torch.Tensor] = None
-    state_indices_tensor: Optional[torch.Tensor] = None  # shape: [batch,]
+    load_indices_tensor: Optional[torch.Tensor] = None  # shape: [batch,]
+    store_indices_tensor: Optional[torch.Tensor] = None  # shape: [batch,]
 
 
 @dataclass

--- a/vllm_gaudi/models/qwen3_5.py
+++ b/vllm_gaudi/models/qwen3_5.py
@@ -63,8 +63,12 @@ class HPUGatedDeltaNetAttention(GatedDeltaNetAttention):
         return query, key, value
 
     def _resolve_state_indices(self, attn_metadata):
-        """Resolve state_indices_tensor, handling 2-D cache-group case."""
-        indices = attn_metadata.state_indices_tensor
+        """Resolve load_indices_tensor, handling 2-D cache-group case.
+
+        For Qwen 3.5 (GDN), load and store indices are identical
+        so using load_indices_tensor is sufficient.
+        """
+        indices = attn_metadata.load_indices_tensor
         if indices is not None and indices.dim() > 1:
             cg = self.cache_group_idx
             assert cg is not None

--- a/vllm_gaudi/ops/granite_causal_conv1d.py
+++ b/vllm_gaudi/ops/granite_causal_conv1d.py
@@ -6,9 +6,9 @@
 """Granite 4.0 specific causal conv1d implementation.
 
 This is a simplified conv1d implementation based on the v0.17.1 code,
-adapted for the v0.19.0 metadata interface (single cache_indices instead
-of separate load/store indices).  It processes one sequence at a time
-(padded_batch == 1) and does not support prefix caching.
+adapted for the v0.19.0 metadata interface (separate load/store
+cache indices).  It processes one sequence at a time
+(padded_batch == 1) and supports prefix caching.
 
 Used exclusively by hpu_mamba_mixer2.py (Granite 4.0).  Other models
 continue to use causal_conv1d_pytorch.py.
@@ -33,7 +33,11 @@ def granite_causal_conv1d_fn(
     bias: torch.Tensor | None,
     conv_states: torch.Tensor | None,
     query_start_loc: torch.Tensor,
-    cache_indices: torch.Tensor | None = None,
+    enable_prefix_caching: bool = False,
+    load_cache_indices: torch.Tensor | None = None,
+    store_cache_indices: torch.Tensor | None = None,
+    blocks_caching_range: torch.Tensor | None = None,
+    seqlens_offsets_for_blocks: torch.Tensor | None = None,
     has_initial_state: torch.Tensor | None = None,
     activation: str | None = "silu",
     metadata=None,
@@ -79,7 +83,7 @@ def granite_causal_conv1d_fn(
 
     # Get init_state for all batch
     if has_initial_state is not None:
-        init_state = torch.where(has_initial_state, conv_states[cache_indices, -state_len:, :],
+        init_state = torch.where(has_initial_state, conv_states[load_cache_indices, -state_len:, :],
                                  torch.zeros(padded_batch, state_len, dim, device=x_work.device, dtype=work_dtype))
     else:
         init_state = torch.zeros(padded_batch, state_len, dim, device=x_work.device, dtype=work_dtype)
@@ -87,12 +91,23 @@ def granite_causal_conv1d_fn(
     init_state = init_state.squeeze()
 
     seq_input = torch.cat([init_state, seq_x], dim=1)
+    if enable_prefix_caching:
+        assert seqlens_offsets_for_blocks is not None
+        assert blocks_caching_range is not None
+        offset = torch.arange(state_len, device=x.device)  # [state_len]
+        indices = seqlens_offsets_for_blocks.unsqueeze(1) + offset  # [N, state_len]
 
-    # Store new state at the end of the sequence
-    end = qsl[-1]
-    idx = torch.arange(state_len, device=x_work.device) + end
-    new_state = seq_input.index_select(dim=1, index=idx)
-    conv_states[cache_indices, -state_len:, :] = new_state.transpose(-1, -2)
+        # Gather all slices at once: seq_input is [dim, seq_len+state_len],
+        # indices is [N, state_len] -> new_states is [N, dim, state_len]
+        new_states = seq_input[:, indices].permute(1, 0, 2)
+
+        # Scatter all updates at once
+        conv_states[blocks_caching_range, -state_len:, :] = new_states.transpose(-1, -2)
+    else:
+        end = qsl[-1]
+        idx = torch.arange(state_len, device=x_work.device) + end
+        new_state = seq_input.index_select(dim=1, index=idx)
+        conv_states[store_cache_indices, -state_len:, :] = new_state.transpose(-1, -2)
 
     # Apply depthwise convolution using element-wise TPC ops.
     seq_input = seq_input.unsqueeze(0)
@@ -108,7 +123,8 @@ def granite_causal_conv1d_update(
     weight: torch.Tensor,
     bias: torch.Tensor | None = None,
     activation: bool | str | None = None,
-    conv_state_indices: torch.Tensor | None = None,
+    load_cache_indices: torch.Tensor | None = None,
+    store_cache_indices: torch.Tensor | None = None,
     query_start_loc: torch.Tensor | None = None,
     validate_data: bool = False,
 ):
@@ -123,7 +139,8 @@ def granite_causal_conv1d_update(
         bias,
         conv_state,
         qsl,
-        cache_indices=conv_state_indices,
+        load_cache_indices=load_cache_indices,
+        store_cache_indices=store_cache_indices,
         has_initial_state=None,
         activation=activation,
         metadata=None,
@@ -140,7 +157,8 @@ def granite_causal_conv1d_fn_update(
     bias: torch.Tensor | None,
     conv_states: torch.Tensor | None,
     query_start_loc: torch.Tensor,
-    cache_indices: torch.Tensor | None = None,
+    load_cache_indices: torch.Tensor | None = None,
+    store_cache_indices: torch.Tensor | None = None,
     has_initial_state: torch.Tensor | None = None,
     activation: str | None = "silu",
     metadata=None,
@@ -180,7 +198,7 @@ def granite_causal_conv1d_fn_update(
                 and has_initial_state.numel() != padded_batch:
             raise ValueError("'has_initial_state' must align with 'query_start_loc'.")
 
-    init_state = conv_states[cache_indices, -state_len:, :]
+    init_state = conv_states[load_cache_indices, -state_len:, :]
     init_state = init_state.transpose(-1, -2)
 
     seq_input = torch.cat([init_state, x_work], dim=2)
@@ -190,6 +208,6 @@ def granite_causal_conv1d_fn_update(
     seq_out = _depthwise_conv1d_tpc(seq_input, weight_work, bias_work)
     seq_out = _apply_activation(seq_out, activation)
 
-    conv_states[cache_indices, -state_len:, :] = new_state.transpose(-1, -2)
+    conv_states[store_cache_indices, -state_len:, :] = new_state.transpose(-1, -2)
 
     return seq_out.to(original_dtype)

--- a/vllm_gaudi/ops/hpu_mamba_mixer2.py
+++ b/vllm_gaudi/ops/hpu_mamba_mixer2.py
@@ -363,23 +363,28 @@ class HPUMambaMixer2(MambaMixer2):
         )
 
         forward_context = get_forward_context()
-        # attn_metadata contains metadata necessary for the mamba2 triton
-        # kernels to operate in continuous batching and in chunked prefill
-        # modes; they are computed at top-level model forward since they
-        # stay the same and reused for all mamba layers in the same iteration
         attn_metadata: AttentionMetadata = forward_context.attn_metadata
 
         assert self.cache_config is not None
-        assert not self.cache_config.enable_prefix_caching
+        enable_prefix_caching = self.cache_config.enable_prefix_caching
         if attn_metadata is not None:
             self_kv_cache = self.kv_cache
             # conv_state = (..., dim, width-1) yet contiguous along 'dim'
             conv_state = self_kv_cache[0]
             ssm_state = self_kv_cache[1]
 
-            state_indices_tensor = attn_metadata.state_indices_tensor[self.cache_group_idx]
+            load_indices_tensor = attn_metadata.load_indices_tensor[self.cache_group_idx]
+            store_indices_tensor = attn_metadata.store_indices_tensor[self.cache_group_idx]
+            if enable_prefix_caching and attn_metadata.is_prompt:
+                blocks_caching_range = attn_metadata.blocks_caching_range[self.cache_group_idx]
+                mamba_chunks_to_block_mapping = attn_metadata.mamba_chunks_to_block_mapping[self.cache_group_idx]
+                seqlens_offsets_for_blocks = attn_metadata.seqlens_offsets_for_blocks
+            else:
+                blocks_caching_range = None
+                mamba_chunks_to_block_mapping = None
+                seqlens_offsets_for_blocks = None
+
             has_initial_states_p = attn_metadata.has_initial_states_p
-            prep_initial_states = attn_metadata.prep_initial_states
             # is below sufficient to get chunk_size or does it need to passed via metadata
             assert self.model_config is not None
             chunk_size = self.model_config.get_mamba_chunk_size()
@@ -398,9 +403,8 @@ class HPUMambaMixer2(MambaMixer2):
 
         # Process prefill requests
         if has_prefill:
-            # 2. Convolution sequence transformation
             assert padding_mask_flat is not None
-            x = hidden_states_B_C.transpose(0, 1)  # this is the form that causal-conv see
+            x = hidden_states_B_C.transpose(0, 1)
             hidden_states_B_C = hidden_states_B_C * padding_mask_flat
             dt = dt * padding_mask_flat
 
@@ -411,7 +415,11 @@ class HPUMambaMixer2(MambaMixer2):
                 activation=self.activation,
                 conv_states=conv_state,
                 has_initial_state=has_initial_states_p,
-                cache_indices=state_indices_tensor,
+                enable_prefix_caching=enable_prefix_caching,
+                load_cache_indices=load_indices_tensor,
+                store_cache_indices=store_indices_tensor,
+                blocks_caching_range=blocks_caching_range,
+                seqlens_offsets_for_blocks=seqlens_offsets_for_blocks,
                 metadata=attn_metadata,
                 query_start_loc=query_start_loc_p,
                 is_prompt=True,
@@ -422,13 +430,8 @@ class HPUMambaMixer2(MambaMixer2):
 
             # 3. State Space Model sequence transformation
             initial_states = None
-            if has_initial_states_p is not None and prep_initial_states:
-                kernel_ssm_indices = state_indices_tensor
-                initial_states = torch.where(
-                    has_initial_states_p[:, None, None, None],
-                    ssm_state[kernel_ssm_indices],
-                    0,
-                )
+            if attn_metadata.prep_initial_states:
+                initial_states = ssm_state[load_indices_tensor]
 
             # NOTE: final output is an in-place update of out tensor
             varlen_states = hpu_mamba_chunk_scan_combined_varlen(
@@ -449,10 +452,13 @@ class HPUMambaMixer2(MambaMixer2):
                 out=output.view(output.shape[0], -1, self.head_dim),
                 state_dtype=ssm_state.dtype,
                 padding_mask=padding_mask_flat,
-            )[last_chunk_indices_p]
+            )
             output = output * padding_mask_flat.view(output.shape[0], 1)
 
-            ssm_state[state_indices_tensor] = varlen_states
+            if enable_prefix_caching:
+                ssm_state[mamba_chunks_to_block_mapping] = varlen_states
+            else:
+                ssm_state[store_indices_tensor] = varlen_states[last_chunk_indices_p]
 
         # Process decode requests
         if has_decode:
@@ -463,7 +469,8 @@ class HPUMambaMixer2(MambaMixer2):
                 self.conv_weights,
                 self.conv1d.bias,
                 self.activation,
-                conv_state_indices=state_indices_tensor,
+                load_cache_indices=load_indices_tensor,
+                store_cache_indices=store_indices_tensor,
                 query_start_loc=query_start_loc_p,
             )
 
@@ -495,7 +502,7 @@ class HPUMambaMixer2(MambaMixer2):
                 z=None,
                 dt_bias=dt_bias,
                 dt_softplus=True,
-                state_batch_indices=state_indices_tensor,
-                dst_state_batch_indices=state_indices_tensor,
+                state_batch_indices=load_indices_tensor,
+                dst_state_batch_indices=store_indices_tensor,
                 out=output.view(output.shape[0], -1, self.head_dim),
             )

--- a/vllm_gaudi/platform.py
+++ b/vllm_gaudi/platform.py
@@ -146,48 +146,32 @@ class HpuPlatform(Platform):
         # unify_kv_cache_spec_page_size() fails because the two page sizes
         # are not divisible.
         if (cache_config and cache_config.block_size is not None and vllm_config.model_config is not None
-                and vllm_config.model_config.is_hybrid):
-            # Ensure block_size is 128-aligned (should already be, but
-            # guard against future callers that set odd sizes).
-            original_block_size = cache_config.block_size
-            aligned_block_size = ((original_block_size + 127) // 128) * 128
-            if aligned_block_size != original_block_size:
-                logger.warning(
-                    "Padding hybrid cache block_size from %d to %d to satisfy "
-                    "Gaudi 128-token kernel alignment.",
-                    original_block_size,
-                    aligned_block_size,
-                )
-                cache_config.block_size = aligned_block_size
-                if cache_config.mamba_cache_mode == "align":
-                    cache_config.mamba_block_size = aligned_block_size
-
+                and vllm_config.model_config.is_hybrid and cache_config.mamba_page_size_padded is not None):
             # Recompute mamba_page_size_padded so it is a multiple of
             # the HPU attention page size.
-            if cache_config.mamba_page_size_padded is not None:
-                from vllm.utils.torch_utils import get_dtype_size
-                from math import ceil
-                model_config = vllm_config.model_config
-                if cache_config.cache_dtype == "auto":
-                    kv_dtype = model_config.dtype
-                else:
-                    from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
-                    kv_dtype = STR_DTYPE_TO_TORCH_DTYPE[cache_config.cache_dtype]
-                num_kv_heads = model_config.get_num_kv_heads(parallel_config)
-                head_size = model_config.get_head_size()
-                attn_page = (2 * cache_config.block_size * num_kv_heads * head_size * get_dtype_size(kv_dtype))
-                if attn_page > 0 and cache_config.mamba_page_size_padded % attn_page != 0:
-                    old_padded = cache_config.mamba_page_size_padded
-                    cache_config.mamba_page_size_padded = (ceil(old_padded / attn_page) * attn_page)
-                    logger.info(
-                        "Rescaled mamba_page_size_padded from %d to %d "
-                        "to align with HPU attention page size %d "
-                        "(block_size=%d).",
-                        old_padded,
-                        cache_config.mamba_page_size_padded,
-                        attn_page,
-                        cache_config.block_size,
-                    )
+            from vllm.utils.torch_utils import get_dtype_size
+            from math import ceil
+            model_config = vllm_config.model_config
+            if cache_config.cache_dtype == "auto":
+                kv_dtype = model_config.dtype
+            else:
+                from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
+                kv_dtype = STR_DTYPE_TO_TORCH_DTYPE[cache_config.cache_dtype]
+            num_kv_heads = model_config.get_num_kv_heads(parallel_config)
+            head_size = model_config.get_head_size()
+            attn_page = (2 * cache_config.block_size * num_kv_heads * head_size * get_dtype_size(kv_dtype))
+            if attn_page > 0 and cache_config.mamba_page_size_padded % attn_page != 0:
+                old_padded = cache_config.mamba_page_size_padded
+                cache_config.mamba_page_size_padded = (ceil(old_padded / attn_page) * attn_page)
+                logger.info(
+                    "Rescaled mamba_page_size_padded from %d to %d "
+                    "to align with HPU attention page size %d "
+                    "(block_size=%d).",
+                    old_padded,
+                    cache_config.mamba_page_size_padded,
+                    attn_page,
+                    cache_config.block_size,
+                )
         if (parallel_config.distributed_executor_backend in ['mp', 'uni']
                 and envs.VLLM_WORKER_MULTIPROC_METHOD == 'fork'):
             if os.environ.get("VLLM_WORKER_MULTIPROC_METHOD", None) is not None:
@@ -219,6 +203,18 @@ class HpuPlatform(Platform):
             logger.warning("Using Contiguous PA, disabling prefix caching")
             vllm_config.cache_config.enable_prefix_caching = False
 
+        if (vllm_config.cache_config.enable_prefix_caching and vllm_config.cache_config.mamba_cache_mode == "all"):
+            vllm_config.cache_config.mamba_cache_mode = "align"
+            logger.info("[HPU] Overriding mamba_cache_mode from 'all' to 'align' "
+                        "to ensure block-aligned chunked prefill splits.")
+
+        if (vllm_config.model_config is not None and vllm_config.model_config.is_hybrid):
+            logger.debug(
+                "[HPU] Hybrid model cache config: block_size=%s, "
+                "mamba_block_size=%s, mamba_cache_mode=%s, "
+                "enable_prefix_caching=%s", cache_config.block_size, getattr(cache_config, "mamba_block_size", None),
+                getattr(cache_config, "mamba_cache_mode", None), cache_config.enable_prefix_caching)
+
         if compilation_config.mode != CompilationMode.NONE:
             logger.info("[HPU] Forcing CompilationMode.NONE "
                         "compilation mode")
@@ -248,20 +244,59 @@ class HpuPlatform(Platform):
         cache_config = vllm_config.cache_config
         model_config = vllm_config.model_config
 
-        # Granite 4.0-H (granitemoehybrid) needs FA-style 16-token block
-        # alignment so that the minimum KV-cache block fitting the mamba page
-        # is 528 tokens, matching GPU behaviour.  The upstream
-        # _align_hybrid_block_size derives the alignment from
-        #   max(min(supported_kernel_block_sizes), cache_config.block_size)
-        # which is pinned at 128 because HPU sets block_size=128 in
-        # check_and_update_config.  We temporarily lower block_size to the
-        # vLLM default (16) and flag it as "user-specified" to prevent phase 1
-        # of super().update_block_size_for_backend from overriding it, then
-        # let _align_hybrid_block_size compute the correct 528-token size.
+        # For Granite 4.0-H (granitemoehybrid), we compute the correct
+        # block_size in this method using the PC-aware alignment formula
+        # (528 without prefix caching, 768 with prefix caching).
+        # We set block_size before calling super and mark it as
+        # user-specified so Phase 1 preserves it; Phase 2
+        # (_align_hybrid_block_size) then validates and sets
+        # mamba_page_size_padded.
         is_granite_hybrid = (model_config is not None
                              and getattr(model_config.hf_config, "model_type", None) == "granitemoehybrid")
         if is_granite_hybrid:
-            cache_config.block_size = 16
+            # Compute the correct block_size using the PC-aware formula.
+            from vllm.utils.math_utils import cdiv
+            from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec
+            from vllm.model_executor.models import ModelRegistry
+            if cache_config.cache_dtype == "auto":
+                kv_dtype = model_config.dtype
+            else:
+                from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
+                kv_dtype = STR_DTYPE_TO_TORCH_DTYPE[cache_config.cache_dtype]
+            attn_1tok = FullAttentionSpec(
+                block_size=1,
+                num_kv_heads=model_config.get_num_kv_heads(vllm_config.parallel_config),
+                head_size=model_config.get_head_size(),
+                dtype=kv_dtype,
+            ).page_size_bytes
+            model_cls, _ = ModelRegistry.resolve_model_cls(
+                model_config.architecture,
+                model_config=model_config,
+            )
+            mamba_page_size = MambaSpec(
+                shapes=model_cls.get_mamba_state_shape_from_config(vllm_config),
+                dtypes=model_cls.get_mamba_state_dtype_from_config(vllm_config),
+                block_size=-1,
+            ).page_size_bytes
+            if mamba_page_size > 0:
+                if cache_config.enable_prefix_caching:
+                    mamba_chunk_size = getattr(model_config.hf_config, 'mamba_d_chunk', 256)
+                    alignment = mamba_chunk_size
+                else:
+                    alignment = 16
+                attn_block_size = alignment * cdiv(mamba_page_size, alignment * attn_1tok)
+                cache_config.block_size = attn_block_size
+                if cache_config.mamba_cache_mode == "align":
+                    cache_config.mamba_block_size = attn_block_size
+                logger.info(
+                    "Setting granitemoehybrid block_size to %d tokens "
+                    "(alignment=%d, mamba_page_size=%d bytes, "
+                    "prefix_caching=%s).",
+                    attn_block_size,
+                    alignment,
+                    mamba_page_size,
+                    cache_config.enable_prefix_caching,
+                )
             if not cache_config.user_specified_block_size:
                 cache_config.user_specified_block_size = True
                 super().update_block_size_for_backend(vllm_config)

--- a/vllm_gaudi/v1/attention/backends/hpu_attn.py
+++ b/vllm_gaudi/v1/attention/backends/hpu_attn.py
@@ -36,15 +36,15 @@ class HPUAttentionBackendV1(HPUAttentionBackend):
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[Union[int, MultipleOf]]:
         # 128 is the standard HPU kernel block size; 528 is required for
-        # Granite 4.0-H (granitemoehybrid) which uses 16-token FA alignment
-        # (16 * ceil(mamba_page_size / (16 * attn_1token_bytes)) = 528).
+        # Granite 4.0-H (granitemoehybrid) without prefix caching (16-token
+        # FA alignment), 768 with prefix caching (chunk-aligned).
         return [MultipleOf(16)]
 
     @classmethod
     def get_preferred_block_size(cls, default_block_size: int) -> int:
         # Always prefer 128-token HPU kernel blocks. For Granite 4.0-H,
-        # check_and_update_config computes the correct 528-token size before
-        # update_block_size_for_backend runs.
+        # check_and_update_config computes the correct block size (528 or
+        # 768) before update_block_size_for_backend runs.
         return 128
 
 
@@ -60,6 +60,9 @@ class HPUAttentionMetadataV1(HPUAttentionMetadata):
     query_start_loc: Optional[torch.Tensor] = None
     query_start_loc_p: Optional[torch.Tensor] = None
     padding_mask_flat: Optional[torch.Tensor] = None
+    blocks_caching_range: Optional[torch.Tensor] = None
+    mamba_chunks_to_block_mapping: Optional[torch.Tensor] = None
+    seqlens_offsets_for_blocks: Optional[torch.Tensor] = None
 
     def seq_len(self):
         return self.slot_mapping.size(-1)
@@ -80,9 +83,13 @@ class HPUAttentionMetadataV1(HPUAttentionMetadata):
                               prep_initial_states=None,
                               has_initial_states_p=None,
                               last_chunk_indices_p=None,
-                              state_indices_tensor=None,
+                              load_indices_tensor=None,
+                              store_indices_tensor=None,
                               query_start_loc=None,
-                              padding_mask_flat=None):
+                              padding_mask_flat=None,
+                              blocks_caching_range=None,
+                              mamba_chunks_to_block_mapping=None,
+                              seqlens_offsets_for_blocks=None):
         return cls(is_prompt=True,
                    block_list=block_list,
                    block_mapping=None,
@@ -98,10 +105,14 @@ class HPUAttentionMetadataV1(HPUAttentionMetadata):
                    prep_initial_states=prep_initial_states,
                    has_initial_states_p=has_initial_states_p,
                    last_chunk_indices_p=last_chunk_indices_p,
-                   state_indices_tensor=state_indices_tensor,
+                   load_indices_tensor=load_indices_tensor,
+                   store_indices_tensor=store_indices_tensor,
                    query_start_loc=query_start_loc,
                    query_start_loc_p=query_start_loc,
-                   padding_mask_flat=padding_mask_flat)
+                   padding_mask_flat=padding_mask_flat,
+                   blocks_caching_range=blocks_caching_range,
+                   mamba_chunks_to_block_mapping=mamba_chunks_to_block_mapping,
+                   seqlens_offsets_for_blocks=seqlens_offsets_for_blocks)
 
     @classmethod
     def make_decode_metadata(cls,
@@ -117,7 +128,8 @@ class HPUAttentionMetadataV1(HPUAttentionMetadata):
                              chunked_block_list,
                              chunked_block_usage,
                              chunked_block_groups,
-                             state_indices_tensor=None,
+                             load_indices_tensor=None,
+                             store_indices_tensor=None,
                              query_start_loc=None,
                              seq_lens_tensor=None):
         return cls(is_prompt=False,
@@ -139,6 +151,7 @@ class HPUAttentionMetadataV1(HPUAttentionMetadata):
                    slot_mapping=slot_mapping,
                    block_size=block_size,
                    prep_initial_states=None,
-                   state_indices_tensor=state_indices_tensor,
+                   load_indices_tensor=load_indices_tensor,
+                   store_indices_tensor=store_indices_tensor,
                    query_start_loc=query_start_loc,
                    query_start_loc_p=query_start_loc)

--- a/vllm_gaudi/v1/core/sched/hpu_async_scheduler.py
+++ b/vllm_gaudi/v1/core/sched/hpu_async_scheduler.py
@@ -5,6 +5,38 @@ from vllm.v1.request import Request
 
 class HPUAsyncScheduler(AsyncScheduler):
 
+    def _mamba_block_aligned_split(
+        self,
+        request: Request,
+        num_new_tokens: int,
+        num_new_local_computed_tokens: int = 0,
+        num_external_computed_tokens: int = 0,
+    ) -> int:
+        """HPU override: align chunked-prefill splits to mamba_chunk_size.
+
+        The upstream implementation aligns to block_size (e.g. 768).  On HPU
+        the model runner requires context_lens to be a multiple of
+        mamba_chunk_size (e.g. 256).  Since block_size must stay large for
+        memory-layout reasons, we substitute mamba_chunk_size here.
+        """
+        chunk_size = self.vllm_config.model_config.get_mamba_chunk_size()
+        num_mamba_layers = self.vllm_config.model_config.get_num_layers_by_block_type(
+            self.vllm_config.parallel_config, "mamba")
+        if num_mamba_layers == 0 or not self.vllm_config.cache_config.enable_prefix_caching:
+            return super()._mamba_block_aligned_split(request, num_new_tokens, num_new_local_computed_tokens,
+                                                      num_external_computed_tokens)
+
+        num_computed_tokens = (request.num_computed_tokens + num_new_local_computed_tokens +
+                               num_external_computed_tokens)
+        prompt_end = max(request.num_prompt_tokens, request.num_tokens - 1)
+        if num_computed_tokens < prompt_end:
+            remaining = prompt_end - num_computed_tokens
+            if num_new_tokens < remaining:
+                # Partial prefill: round down so context_lens stays
+                # chunk_size-aligned after this step.
+                num_new_tokens = (num_new_tokens // chunk_size * chunk_size)
+        return num_new_tokens
+
     def _update_request_with_output(self, request: Request, new_token_ids: list[int]) -> tuple[list[int], bool]:
         # HPU may complete prompt processing and generate logits for a request
         # even if the scheduler only scheduled a partial chunk (where

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -581,6 +581,35 @@ def apply_model_specific_patches(model_runner):
     _init_mamba_split_weights(model_runner.model)
 
 
+def compute_prefix_caching_block_indices(num_reqs: int, num_computed_tokens, num_scheduled_tokens,
+                                         mamba_block_size: int) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+
+    num_computed_tokens = torch.tensor(num_computed_tokens, dtype=torch.int32)
+    num_scheduled_tokens = torch.tensor(num_scheduled_tokens, dtype=torch.int32)
+
+    if num_computed_tokens.numel() > num_reqs:
+        num_computed_tokens = num_computed_tokens[:num_reqs]
+    if num_scheduled_tokens.numel() > num_reqs:
+        num_scheduled_tokens = num_scheduled_tokens[:num_reqs]
+
+    # Block index of the last computed token
+    block_idx_last_computed_token = cdiv(num_computed_tokens, mamba_block_size) - 1
+    # which is <= block index for the first scheduled token
+    block_idx_first_scheduled_token = (cdiv(num_computed_tokens + 1, mamba_block_size) - 1)
+    # which is <= block index of the last scheduled token
+    block_idx_last_scheduled_token = (cdiv(num_computed_tokens + num_scheduled_tokens, mamba_block_size) - 1)
+    # -1 in case it's non-computed and causes later issues with indexing
+    block_idx_last_computed_token = torch.clamp(block_idx_last_computed_token, min=0)
+    # -1 in the case we have a padded request (0 seq-len)
+    block_idx_last_scheduled_token = torch.clamp(block_idx_last_scheduled_token, min=0)
+
+    return (
+        block_idx_last_computed_token,
+        block_idx_first_scheduled_token,
+        block_idx_last_scheduled_token,
+    )
+
+
 class HpuKVConnectorModelRunnerMixin(KVConnectorModelRunnerMixin):
 
     def __init__(self):
@@ -825,8 +854,9 @@ def trim_attn_metadata(metadata: HPUAttentionMetadataV1) -> object:
         'slot_mapping', 'is_prompt', 'block_size', 'block_groups', 'window_block_list', 'window_block_mapping',
         'window_block_usage', 'window_block_groups', 'window_attn_bias', 'chunked_block_mapping', 'chunked_attn_bias',
         'chunked_block_list', 'chunked_block_usage', 'chunked_block_groups', 'prep_initial_states',
-        'has_initial_states_p', 'last_chunk_indices_p', 'state_indices_tensor', 'query_start_loc', 'query_start_loc_p',
-        'padding_mask_flat'
+        'has_initial_states_p', 'last_chunk_indices_p', 'load_indices_tensor', 'store_indices_tensor',
+        'query_start_loc', 'query_start_loc_p', 'padding_mask_flat', 'blocks_caching_range',
+        'mamba_chunks_to_block_mapping', 'seqlens_offsets_for_blocks'
     ])
     return attention_metadata
 
@@ -1249,6 +1279,32 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
 
     def _make_buffer(self, *size: Union[int, torch.SymInt], dtype: torch.dtype, numpy: bool = True) -> CpuGpuBuffer:
         return CpuGpuBuffer(*size, dtype=dtype, device=self.device, pin_memory=self.pin_memory, with_numpy=numpy)
+
+    def prepare_mamba_state_idxs(self, req_indices, block_table_offsets, target_bs):
+        num_indices = len(req_indices)
+        all_state_indices_cpu = []
+        for group_idx in range(len(self.input_batch.block_table.block_tables)):
+            if group_idx in self._compact_gdn_group_ids:
+                g_offset = self._compact_gdn_group_offset[group_idx]
+                state_indices_cpu = torch.zeros(num_indices, dtype=torch.int32)
+                for i, req_idx in enumerate(req_indices):
+                    req_id = self.input_batch.req_ids[req_idx]
+                    base_slot = self._gdn_req_to_base_slot[req_id]
+                    state_indices_cpu[i] = base_slot * self._num_gdn_groups + g_offset + 1
+            else:
+                block_table_cpu_tensor = self.input_batch.block_table[group_idx].get_cpu_tensor()
+                state_indices_cpu = block_table_cpu_tensor[req_indices, block_table_offsets].clone()
+
+            if num_indices < target_bs:
+                padding = torch.full((target_bs - num_indices, ),
+                                     self._MAMBA_PAD_BLOCK_ID,
+                                     dtype=torch.int32,
+                                     device='cpu')
+                state_indices_cpu = torch.cat([state_indices_cpu, padding])
+
+            all_state_indices_cpu.append(state_indices_cpu)
+
+        return torch.stack(all_state_indices_cpu, dim=0)  # Shape: [num_groups, target_bs]
 
     def create_lora_mask(self, input_tokens: torch.Tensor, lora_ids: list[int], is_prompt: bool):
         '''
@@ -2422,33 +2478,95 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
             assert nphysical_chunks > 0, (f"target_seq={target_seq} must be >= chunk_size={chunk_size}")
             last_chunk_indices = [nphysical_chunks - 1 for _ in range(len(contents.req_ids))]
 
-            num_prefill_reqs = len(contents.req_ids)
-            all_state_indices_cpu = []
-            for group_idx in range(len(self.input_batch.block_table.block_tables)):
-                state_indices_cpu = torch.zeros(num_prefill_reqs, dtype=torch.int32)
+            mamba_block_size = self.cache_config.mamba_block_size
+            (block_idx_last_computed_token_cpu,
+             block_idx_first_scheduled_token_cpu,
+             block_idx_last_scheduled_token_cpu) = \
+                compute_prefix_caching_block_indices(
+                    len(contents.req_ids),
+                    context_lens,
+                    query_lens,
+                    mamba_block_size
+                )
 
-                if group_idx in self._compact_gdn_group_ids:
-                    g_offset = self._compact_gdn_group_offset[group_idx]
-                    for i, req_id in enumerate(contents.req_ids):
-                        base_slot = self._gdn_req_to_base_slot[req_id]
-                        state_indices_cpu[i] = base_slot * self._num_gdn_groups + g_offset + 1
-                else:
+            req_indices = [self.input_batch.req_id_to_index[req_id] for req_id in contents.req_ids]
+            if self.use_prefix_caching:
+                load_state_indices_cpu = self.prepare_mamba_state_idxs(req_indices, block_idx_last_computed_token_cpu,
+                                                                       target_bs)
+                store_state_indices_cpu = self.prepare_mamba_state_idxs(req_indices, block_idx_last_scheduled_token_cpu,
+                                                                        target_bs)
+            else:
+                zeros = [0] * len(req_indices)
+                load_state_indices_cpu = store_state_indices_cpu = \
+                    self.prepare_mamba_state_idxs(req_indices, zeros, target_bs)
+
+            if self.use_prefix_caching:
+                assert len(contents.req_ids) == 1
+                assert mamba_block_size % self.mamba_chunk_size == 0
+                assert context_lens[0] % self.mamba_chunk_size == 0
+
+                chunk_stride = mamba_block_size // self.mamba_chunk_size
+                # Max mamba blocks to cache for this bucket (upper bound)
+                max_cached_blocks = cdiv(target_seq, mamba_block_size) + 1
+
+                # chunk_offset: scheduled-chunk index of the last chunk
+                # of the first block to cache. Block boundaries fall at
+                # absolute chunk (block+1)*chunk_stride-1; subtract the
+                # first scheduled absolute chunk to get the local index.
+                first_sched_chunk_abs = context_lens[0] // self.mamba_chunk_size
+                first_block = block_idx_first_scheduled_token_cpu[0].item()
+                chunk_offset = (first_block + 1) * chunk_stride - 1 - first_sched_chunk_abs
+
+                all_blocks_caching_ranges_cpu = []
+                all_mamba_chunks_to_block_mappings_cpu = []
+                for group_idx in range(len(self.input_batch.block_table.block_tables)):
                     block_table_cpu_tensor = self.input_batch.block_table[group_idx].get_cpu_tensor()
-                    for i, req_id in enumerate(contents.req_ids):
-                        req_idx = self.input_batch.req_id_to_index[req_id]
-                        first_block = block_table_cpu_tensor[req_idx, 0]
-                        state_indices_cpu[i] = first_block
+                    first = block_idx_first_scheduled_token_cpu[0]
+                    last = block_idx_last_scheduled_token_cpu[0]
+                    blocks_caching_range = block_table_cpu_tensor[req_indices[0], first:last + 1].clone()
+                    n_blocks = blocks_caching_range.shape[0]
 
-                if num_prefill_reqs < target_bs:
-                    padding = torch.full((target_bs - num_prefill_reqs, ),
-                                         self._MAMBA_PAD_BLOCK_ID,
-                                         dtype=torch.int32,
-                                         device='cpu')
-                    state_indices_cpu = torch.cat([state_indices_cpu, padding])
+                    # Compute scheduled-chunk index for each block's last chunk;
+                    # clamp so partial last block maps to the last physical chunk.
+                    chunk_indices = torch.arange(n_blocks, dtype=torch.int64) * chunk_stride + chunk_offset
+                    chunk_indices = torch.clamp(chunk_indices, max=nphysical_chunks - 1)
 
-                all_state_indices_cpu.append(state_indices_cpu)
+                    mamba_chunks_to_block_mapping_cpu = torch.full((nphysical_chunks, ),
+                                                                   self._MAMBA_PAD_BLOCK_ID,
+                                                                   dtype=torch.int32,
+                                                                   device='cpu')
+                    mamba_chunks_to_block_mapping_cpu[chunk_indices] = blocks_caching_range
 
-            all_state_indices_cpu = torch.stack(all_state_indices_cpu, dim=0)  # Shape: [num_groups, target_bs]
+                    # Pad blocks_caching_range to fixed size for stable graph shapes
+                    bcr_padded = torch.full((max_cached_blocks, ),
+                                            self._MAMBA_PAD_BLOCK_ID,
+                                            dtype=torch.int32,
+                                            device='cpu')
+                    bcr_padded[:n_blocks] = blocks_caching_range
+
+                    all_blocks_caching_ranges_cpu.append(bcr_padded)
+                    all_mamba_chunks_to_block_mappings_cpu.append(mamba_chunks_to_block_mapping_cpu)
+
+                all_blocks_caching_ranges_cpu = torch.stack(all_blocks_caching_ranges_cpu, dim=0)
+                all_mamba_chunks_to_block_mappings_cpu = torch.stack(all_mamba_chunks_to_block_mappings_cpu, dim=0)
+
+                computed_tokens = context_lens[0]
+                scheduled_tokens = query_lens[0]
+                # Offsets index into seq_input = [init_state | scheduled_tokens],
+                # so they must be relative to the scheduled portion, not absolute.
+                offset = mamba_block_size - computed_tokens % mamba_block_size
+                seqlens_offsets_for_blocks_cpu = []
+                while offset < scheduled_tokens:
+                    seqlens_offsets_for_blocks_cpu.append(offset)
+                    offset += mamba_block_size
+                seqlens_offsets_for_blocks_cpu.append(scheduled_tokens)
+                # Pad to fixed size for stable graph shapes
+                pad_val = seqlens_offsets_for_blocks_cpu[-1]
+                while len(seqlens_offsets_for_blocks_cpu) < max_cached_blocks:
+                    seqlens_offsets_for_blocks_cpu.append(pad_val)
+                seqlens_offsets_for_blocks_cpu = torch.tensor(seqlens_offsets_for_blocks_cpu,
+                                                              dtype=torch.int32,
+                                                              device='cpu')
 
             # CREATE PADDING MASK HERE using target_bs and target_seq
             # Create mask on CPU: [target_bs, target_seq]
@@ -2468,7 +2586,8 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
             # Flatten to [target_bs * target_seq, 1] for easy multiplication
             padding_mask_flat_cpu = padding_mask_cpu.view(-1, 1)
 
-            state_indices_tensor = async_h2d_copy(all_state_indices_cpu, device=self.device)
+            load_indices_tensor = async_h2d_copy(load_state_indices_cpu, device=self.device)
+            store_indices_tensor = async_h2d_copy(store_state_indices_cpu, device=self.device)
 
             has_initial_states_p = async_h2d_copy(has_initial_states_cpu, dtype=torch.int32)
             last_chunk_indices_p = async_h2d_copy(last_chunk_indices, dtype=torch.int32)
@@ -2476,13 +2595,27 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
             padding_mask_flat = async_h2d_copy(padding_mask_flat_cpu, device=self.device)
             query_start_loc_p = async_h2d_copy(query_start_loc_p_cpu, dtype=torch.int32)
 
+            if self.use_prefix_caching:
+                blocks_caching_range = async_h2d_copy(all_blocks_caching_ranges_cpu, device=self.device)
+                mamba_chunks_to_block_mapping = async_h2d_copy(all_mamba_chunks_to_block_mappings_cpu,
+                                                               device=self.device)
+                seqlens_offsets_for_blocks = async_h2d_copy(seqlens_offsets_for_blocks_cpu, device=self.device)
+            else:
+                blocks_caching_range = None
+                mamba_chunks_to_block_mapping = None
+                seqlens_offsets_for_blocks = None
+
         else:
             prep_initial_states = None
-            state_indices_tensor = None
+            load_indices_tensor = None
+            store_indices_tensor = None
             has_initial_states_p = None
             last_chunk_indices_p = None
             padding_mask_flat = None
             query_start_loc_p = None
+            blocks_caching_range = None
+            seqlens_offsets_for_blocks = None
+            mamba_chunks_to_block_mapping = None
 
         query_lens = async_h2d_copy(query_lens, dtype=torch.int32)
         token_ids = async_h2d_copy(token_ids, dtype=torch.int32)
@@ -2493,18 +2626,23 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
         context_blocks_t: Optional[torch.tensor]
         context_blocks_t = async_h2d_copy(context_blocks, dtype=torch.int32).flatten() if target_blocks > 0 else None
 
-        attn_metadata = HPUAttentionMetadataV1.make_prefill_metadata(seq_lens_tensor=query_lens,
-                                                                     context_lens_tensor=context_lens,
-                                                                     slot_mapping=token_slots,
-                                                                     block_list=context_blocks_t,
-                                                                     attn_bias=attn_bias,
-                                                                     block_size=self.attn_block_size,
-                                                                     prep_initial_states=prep_initial_states,
-                                                                     has_initial_states_p=has_initial_states_p,
-                                                                     last_chunk_indices_p=last_chunk_indices_p,
-                                                                     state_indices_tensor=state_indices_tensor,
-                                                                     query_start_loc=query_start_loc_p,
-                                                                     padding_mask_flat=padding_mask_flat)
+        attn_metadata = HPUAttentionMetadataV1.make_prefill_metadata(
+            seq_lens_tensor=query_lens,
+            context_lens_tensor=context_lens,
+            slot_mapping=token_slots,
+            block_list=context_blocks_t,
+            attn_bias=attn_bias,
+            block_size=self.attn_block_size,
+            prep_initial_states=prep_initial_states,
+            has_initial_states_p=has_initial_states_p,
+            last_chunk_indices_p=last_chunk_indices_p,
+            load_indices_tensor=load_indices_tensor,
+            store_indices_tensor=store_indices_tensor,
+            query_start_loc=query_start_loc_p,
+            padding_mask_flat=padding_mask_flat,
+            blocks_caching_range=blocks_caching_range,
+            mamba_chunks_to_block_mapping=mamba_chunks_to_block_mapping,
+            seqlens_offsets_for_blocks=seqlens_offsets_for_blocks)
         return PrefillInputData(request_ids=[req_ids],
                                 prompt_lens=[query_lens],
                                 token_ids=[token_ids],
@@ -2739,27 +2877,27 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
                     block_size=decode_block_size)
 
         if self.num_mamba_like_layers > 0:
-            all_state_indices_cpu = []
-            for group_idx in range(len(self.input_batch.block_table.block_tables)):
-                if group_idx in self._compact_gdn_group_ids:
-                    g_offset = self._compact_gdn_group_offset[group_idx]
-                    base_slots = torch.tensor(
-                        [self._gdn_req_to_base_slot[self.input_batch.req_ids[i]] for i in range(num_decodes)],
-                        dtype=torch.int32)
-                    state_indices_cpu = base_slots * self._num_gdn_groups + g_offset + 1
-                else:
-                    block_table_cpu_tensor = self.input_batch.block_table[group_idx].get_cpu_tensor()
-                    state_indices_cpu = block_table_cpu_tensor[:num_decodes, 0].clone()
-                if num_decodes < padded_batch_size:
-                    padding = torch.full((padded_batch_size - num_decodes, ),
-                                         self._MAMBA_PAD_BLOCK_ID,
-                                         dtype=torch.int32,
-                                         device='cpu')
-                    state_indices_cpu = torch.cat([state_indices_cpu, padding])
+            mamba_block_size = self.cache_config.mamba_block_size
+            (block_idx_last_computed_token_cpu,
+             block_idx_first_scheduled_token_cpu,
+             block_idx_last_scheduled_token_cpu) = \
+                compute_prefix_caching_block_indices(
+                    num_decodes,
+                    context_lens,
+                    num_scheduled_tokens,
+                    mamba_block_size
+                )
 
-                all_state_indices_cpu.append(state_indices_cpu)
-
-            all_state_indices_cpu = torch.stack(all_state_indices_cpu, dim=0)  # Shape: [num_groups, target_bs]
+            req_indices = list(range(num_decodes))
+            if self.use_prefix_caching:
+                load_state_indices_cpu = self.prepare_mamba_state_idxs(req_indices, block_idx_last_computed_token_cpu,
+                                                                       padded_batch_size)
+                store_state_indices_cpu = self.prepare_mamba_state_idxs(req_indices, block_idx_last_scheduled_token_cpu,
+                                                                        padded_batch_size)
+            else:
+                zeros = [0] * len(req_indices)
+                load_state_indices_cpu = store_state_indices_cpu = \
+                    self.prepare_mamba_state_idxs(req_indices, zeros, padded_batch_size)
 
             seq_lens_cpu = torch.tensor(num_tokens_per_req, dtype=torch.int32, device='cpu', pin_memory=self.pin_memory)
 
@@ -2770,12 +2908,14 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
             query_start_loc_p_cpu[1:] = torch.cumsum(seq_lens_cpu.clone().to(dtype=torch.int32), dim=0)
 
             seq_lens_tensor = async_h2d_copy(seq_lens_cpu, device=self.device)
-            state_indices_tensor = async_h2d_copy(all_state_indices_cpu, device=self.device)
+            load_indices_tensor = async_h2d_copy(load_state_indices_cpu, device=self.device)
+            store_indices_tensor = async_h2d_copy(store_state_indices_cpu, device=self.device)
             query_start_loc_p = async_h2d_copy(query_start_loc_p_cpu, dtype=torch.int32)
 
         else:
             seq_lens_tensor = None
-            state_indices_tensor = None
+            load_indices_tensor = None
+            store_indices_tensor = None
             query_start_loc_p = None
 
         # CPU<>HPU sync *should not* happen here.
@@ -2838,7 +2978,8 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
             chunked_block_list=chunked_block_list_device,
             chunked_block_usage=chunked_block_usage_device,
             chunked_block_groups=chunked_block_groups_device,
-            state_indices_tensor=state_indices_tensor,
+            load_indices_tensor=load_indices_tensor,
+            store_indices_tensor=store_indices_tensor,
             seq_lens_tensor=seq_lens_tensor,
             query_start_loc=query_start_loc_p,
         )
@@ -5514,6 +5655,8 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
         if self.num_mamba_like_layers > 0:
             # Reassign block size for hybrid models after platform.py alignments
             self.block_size = self.vllm_config.cache_config.block_size
+            if self.enable_bucketing:
+                self.bucketing_manager.block_size = self.block_size
             maybe_set_mamba_kv_cache_groups_ids(self.model, self.kv_cache_config)
         self.initialize_attn_backend(kv_cache_config)
         kernel_block_sizes = prepare_kernel_block_sizes(kv_cache_config, self.attn_groups)


### PR DESCRIPTION
Prefix caching support for HPUMambaMixer2 with block_size fix

Cherry-pick of 025e052c (PR #1198) adapted for v0.19.0 with granite conv1d,
plus fix for mamba_cache_mode reset during granitemoehybrid block_size
re-computation (PR #1318 interaction).

Changes:
- Add prefix caching metadata computation in HPUModelRunner (prefill/decode)
- Modify HPUMambaMixer2 to use cached Mamba SSM/conv states
- Extend HPU attention backends with Mamba prefix caching tensors
- Add granite_causal_conv1d prefix caching support (load/store indices)
- Add hpu_async_scheduler for mamba_chunk_size-aligned splits
- Override mamba_cache_mode all->align for block-aligned chunked prefill
- Fix: reset mamba_cache_mode before upstream re-run to get correct
block_size=768 (3*256) instead of 528 in EngineCore subprocess
- Fix: restore compact GDN group handling in prepare_mamba_state_idxs
so Qwen 3.5 uses correct addressing (base_slot * num_groups + offset)
- Fix: update qwen3_5.py to use load_indices_tensor instead of removed
state_indices_tensor (GDN load/store indices are identical)