### PR TITLE
Enabling higher prefill batch size in Granite4.0

### DIFF
--- a/vllm_gaudi/ops/granite_causal_conv1d.py
+++ b/vllm_gaudi/ops/granite_causal_conv1d.py
@@ -55,26 +55,48 @@ def granite_causal_conv1d_fn(
     assert qsl is not None
 
     padded_batch = qsl.numel() - 1
-    if padded_batch != 1:
-        raise ValueError(f"'padded_batch' must be 1 but we get {padded_batch}")
     dim, cu_seqlen = x_work.shape
     _, width = weight_work.shape
     state_len = max(width - 1, 0)
 
-    if validate_data:
-        if x_work.dim() != 2:
-            raise ValueError("'x' must be 2-D (dim, cu_seq_len).")
-        if weight_work.shape != (dim, width):
-            raise ValueError("'weight' must have shape (dim, width).")
-        if bias_work is not None and bias_work.shape != (dim, ):
-            raise ValueError("'bias' must match the feature dimension.")
-        if not ((x_work.stride(0) == 1) or (x_work.stride(1) == 1)):
-            raise ValueError("Input tensor must be in channel-last or "
-                             "channel-first memory layout.")
-        if has_initial_state is not None \
-                and has_initial_state.numel() != padded_batch:
-            raise ValueError("'has_initial_state' must align with 'query_start_loc'.")
+    # --- Batched path for prefill BS > 1 ---
+    if padded_batch > 1:
+        target_seq = cu_seqlen // padded_batch
 
+        # Reshape from [dim, BS*target_seq] -> [BS, dim, target_seq]
+        x_batch = x_work.view(dim, padded_batch, target_seq).permute(1, 0, 2)
+
+        # Load per-sequence init states: [BS, state_len, dim]
+        if has_initial_state is not None:
+            raw_states = conv_states[cache_indices, -state_len:, :]  # [BS, state_len, dim]
+            mask = has_initial_state.view(-1, 1, 1).to(dtype=raw_states.dtype)
+            init_states = raw_states * mask  # zero out where no initial state
+        else:
+            init_states = torch.zeros(padded_batch, state_len, dim, device=x_work.device, dtype=work_dtype)
+        init_states = init_states.transpose(-1, -2)  # [BS, dim, state_len]
+
+        # Concatenate: [BS, dim, state_len + target_seq]
+        seq_input = torch.cat([init_states, x_batch], dim=2)
+
+        # Gather new states per-sequence at actual_len positions
+        actual_lens = (qsl[1:padded_batch + 1] - qsl[:padded_batch]).clamp(min=0)
+        col_offsets = torch.arange(state_len, device=x_work.device, dtype=torch.int64)
+        col_indices = (actual_lens.unsqueeze(-1).to(torch.int64) + col_offsets.unsqueeze(0))  # [BS, state_len]
+        col_indices = col_indices.unsqueeze(1).expand(-1, dim, -1)
+        new_states = torch.gather(seq_input, 2, col_indices)  # [BS, dim, state_len]
+
+        # Store new conv states (skip padding entries with actual_len==0)
+        conv_states[cache_indices, -state_len:, :] = new_states.transpose(-1, -2)
+
+        # Apply batched depthwise conv1d
+        seq_out = _depthwise_conv1d_tpc(seq_input, weight_work, bias_work)
+        seq_out = _apply_activation(seq_out, activation)
+
+        # Reshape back: [BS, dim, target_seq] -> [dim, BS*target_seq]
+        result = seq_out.permute(1, 0, 2).reshape(dim, cu_seqlen)
+        return result.to(original_dtype)
+
+    # --- Original single-sequence path (BS == 1) ---
     seq_x = x_work[:, :]
 
     # Get init_state for all batch

--- a/vllm_gaudi/ops/granite_causal_conv1d.py
+++ b/vllm_gaudi/ops/granite_causal_conv1d.py
@@ -59,6 +59,22 @@ def granite_causal_conv1d_fn(
     _, width = weight_work.shape
     state_len = max(width - 1, 0)
 
+    if validate_data:
+        if x_work.dim() != 2:
+            raise ValueError("'x' must be 2-D (dim, cu_seq_len).")
+        if weight_work.shape != (dim, width):
+            raise ValueError("'weight' must have shape (dim, width).")
+        if bias_work is not None and bias_work.shape != (dim, ):
+            raise ValueError("'bias' must match the feature dimension.")
+        if not ((x_work.stride(0) == 1) or (x_work.stride(1) == 1)):
+            raise ValueError("Input tensor must be in channel-last or "
+                             "channel-first memory layout.")
+        if has_initial_state is not None \
+                and has_initial_state.numel() != padded_batch:
+            raise ValueError("'has_initial_state' must align with 'query_start_loc'.")
+        if padded_batch > 1 and cu_seqlen % padded_batch != 0:
+            raise ValueError("For batched prefill, 'cu_seqlen' must be divisible by padded_batch.")
+
     # --- Batched path for prefill BS > 1 ---
     if padded_batch > 1:
         target_seq = cu_seqlen // padded_batch
@@ -85,8 +101,16 @@ def granite_causal_conv1d_fn(
         col_indices = col_indices.unsqueeze(1).expand(-1, dim, -1)
         new_states = torch.gather(seq_input, 2, col_indices)  # [BS, dim, state_len]
 
-        # Store new conv states (skip padding entries with actual_len==0)
-        conv_states[cache_indices, -state_len:, :] = new_states.transpose(-1, -2)
+        # Store new conv states. For padding entries (actual_len == 0),
+        # cache_indices may contain repeated PAD block ids; advanced-index
+        # assignment with duplicate indices is undefined in general. To
+        # keep the write deterministic, zero the content of padding rows
+        # so that every duplicate write stores the same value. Real
+        # (non-padding) cache_indices are unique per request.
+        new_states_T = new_states.transpose(-1, -2)  # [BS, state_len, dim]
+        active_mask = (actual_lens > 0).view(-1, 1, 1)
+        new_states_T = torch.where(active_mask, new_states_T, torch.zeros_like(new_states_T))
+        conv_states[cache_indices, -state_len:, :] = new_states_T
 
         # Apply batched depthwise conv1d
         seq_out = _depthwise_conv1d_tpc(seq_input, weight_work, bias_work)

--- a/vllm_gaudi/ops/hpu_mamba_mixer2.py
+++ b/vllm_gaudi/ops/hpu_mamba_mixer2.py
@@ -279,6 +279,10 @@ class HPUMambaMixer2(MambaMixer2):
         hidden_states: torch.Tensor,
         mup_vector: torch.Tensor | None = None,
     ):
+        # Save original batch shape for output reshape.
+        # Input is [batch_size, seq_len, hidden] for prefill or
+        # [num_tokens, 1, hidden] / [num_tokens, hidden] for decode.
+        prefill_shape = hidden_states.shape[:-1]  # (batch_size, seq_len) or (num_tokens,) etc.
         hidden_states = hidden_states.view(-1, hidden_states.shape[-1])
 
         # 1. Split in_proj into two GEMMs for TPC/MME pipelining.
@@ -315,9 +319,9 @@ class HPUMambaMixer2(MambaMixer2):
         output, _ = self.out_proj(hidden_states_varlen)
 
         if get_forward_context().attn_metadata.is_prompt:
-            output = output.view(1, output.shape[0], output.shape[1])
+            output = output.view(*prefill_shape, output.shape[-1])
         else:
-            output = output.view(output.shape[0], 1, output.shape[1])
+            output = output.view(output.shape[0], 1, output.shape[-1])
 
         return output
 
@@ -404,6 +408,9 @@ class HPUMambaMixer2(MambaMixer2):
             hidden_states_B_C = hidden_states_B_C * padding_mask_flat
             dt = dt * padding_mask_flat
 
+            # Determine batch size for multi-sequence prefill
+            prefill_batch_size = query_start_loc_p.numel() - 1
+
             hidden_states_B_C = granite_causal_conv1d_fn(
                 x,
                 self.conv_weights,
@@ -430,6 +437,20 @@ class HPUMambaMixer2(MambaMixer2):
                     0,
                 )
 
+            # For multi-batch prefill (BS > 1), the flattened tensor is in
+            # padded layout: [BS * target_seq, dim].  The SSM must treat
+            # each target_seq block as an independent sequence.
+            ssm_cu_seqlens = query_start_loc_p
+            chunks_per_sequence = None
+            if prefill_batch_size > 1:
+                total_tokens = hidden_states_B_C.shape[0]
+                target_seq = total_tokens // prefill_batch_size
+                # Padded cu_seqlens: [0, target_seq, 2*target_seq, ...]
+                ssm_cu_seqlens = (
+                    torch.arange(prefill_batch_size + 1, device=hidden_states_B_C.device, dtype=torch.int32) *
+                    target_seq)
+                chunks_per_sequence = target_seq // chunk_size
+
             # NOTE: final output is an in-place update of out tensor
             varlen_states = hpu_mamba_chunk_scan_combined_varlen(
                 hidden_states_p.view(hidden_states_p.shape[0], self.num_heads // self.tp_size, self.head_dim),
@@ -441,7 +462,7 @@ class HPUMambaMixer2(MambaMixer2):
                 D=self.D,
                 z=None,
                 dt_bias=self.dt_bias,
-                cu_seqlens=query_start_loc_p,
+                cu_seqlens=ssm_cu_seqlens,
                 last_chunk_indices=last_chunk_indices_p,
                 initial_states=initial_states,
                 dt_softplus=True,
@@ -449,6 +470,7 @@ class HPUMambaMixer2(MambaMixer2):
                 out=output.view(output.shape[0], -1, self.head_dim),
                 state_dtype=ssm_state.dtype,
                 padding_mask=padding_mask_flat,
+                chunks_per_sequence=chunks_per_sequence,
             )[last_chunk_indices_p]
             output = output * padding_mask_flat.view(output.shape[0], 1)
 

--- a/vllm_gaudi/ops/pytorch_implementation.py
+++ b/vllm_gaudi/ops/pytorch_implementation.py
@@ -79,7 +79,17 @@ def new_chunk_state(B_expanded, x_chunked, dt_t, dA_cumsum_t, states_in_fp32=Tru
     return state
 
 
-def new_chunk_scan(cb, x_chunked, dt_t, dA_cumsum_t, C, states, output, D=None, z=None, initial_states=None):
+def new_chunk_scan(cb,
+                   x_chunked,
+                   dt_t,
+                   dA_cumsum_t,
+                   C,
+                   states,
+                   output,
+                   D=None,
+                   z=None,
+                   initial_states=None,
+                   chunks_per_sequence=None):
     """
     Arguments:
         cb: Tensor - (nchunks, ngroups, chunk_size, chunk_size) - already causally masked
@@ -91,7 +101,8 @@ def new_chunk_scan(cb, x_chunked, dt_t, dA_cumsum_t, C, states, output, D=None, 
         output: Tensor - (seqlen, nheads, hdim)
         D: Optional Tensor - (nheads, hdim) or (nheads)
         z: Optional Tensor - (seqlen, nheads, hdim)
-        initial_states: Optional Tensor - (1, nheads, hdim, dstate)
+        initial_states: Optional Tensor - (batch, nheads, hdim, dstate)
+        chunks_per_sequence: Optional int - for multi-sequence batched prefill
 
     Return:
         output: Tensor - (seqlen, nheads, hdim)
@@ -113,8 +124,22 @@ def new_chunk_scan(cb, x_chunked, dt_t, dA_cumsum_t, C, states, output, D=None, 
                   chunk_size).expand(nchunks, ngroups, nheads_ngroups_ratio, chunk_size,
                                      chunk_size).reshape(nchunks, nheads, chunk_size, chunk_size))
     states = states.float()
-    init = torch.zeros_like(states[:1]) if initial_states is None else initial_states.float()
-    prev_states = torch.cat([init, states[:-1]], dim=0)
+    # Construct prev_states: the state entering each chunk.
+    # For multi-sequence batched prefill, insert per-sequence initial
+    # states at sequence boundaries instead of one global init.
+    if chunks_per_sequence is not None and chunks_per_sequence < nchunks:
+        batch_size = nchunks // chunks_per_sequence
+        cps = chunks_per_sequence
+        if initial_states is None:
+            init = torch.zeros(batch_size, 1, nheads, *states.shape[2:], device=states.device, dtype=states.dtype)
+        else:
+            init = initial_states.float().unsqueeze(1)  # [B, 1, H, D, S]
+        states_seq = states.view(batch_size, cps, nheads, *states.shape[2:])
+        prev_states = torch.cat([init, states_seq[:, :-1]], dim=1)  # [B, cps, H, D, S]
+        prev_states = prev_states.reshape(nchunks, nheads, *states.shape[2:])
+    else:
+        init = torch.zeros_like(states[:1]) if initial_states is None else initial_states.float()
+        prev_states = torch.cat([init, states[:-1]], dim=0)
     if D is not None:
         D = D.float()
     if z is not None:
@@ -137,13 +162,14 @@ def new_chunk_scan(cb, x_chunked, dt_t, dA_cumsum_t, C, states, output, D=None, 
     output.copy_(out)
 
 
-def new_ssd_state_passing(states, dA_cumsum, initial_states=None, out_dtype=None):
+def new_ssd_state_passing(states, dA_cumsum, initial_states=None, out_dtype=None, chunks_per_sequence=None):
     """
     Arguments:
         states: Tensor - (nchunks, nheads, hdim)
         dA_cumsum: Tensor - (nheads, nchunks, chunk_size)
-        initial_states: Optional Tensor - (1, nheads, hdim)
+        initial_states: Optional Tensor - (batch, nheads, hdim)
         out_dtype: Optional dtype
+        chunks_per_sequence: Optional int - for multi-sequence batched prefill
     Return:
         output: Tensor - (nchunks, nheads, hdim)
 
@@ -164,6 +190,51 @@ def new_ssd_state_passing(states, dA_cumsum, initial_states=None, out_dtype=None
     # log-decay across all positions within chunk c.
     dA_last = dA_cumsum[:, :, -1]  # (nheads, nchunks)
 
+    # Multi-sequence batched prefill: process each sequence independently
+    # using block-diagonal decay matrices.  This is more memory-efficient
+    # than a single (nchunks+1)^2 matrix when BS > 1.
+    if chunks_per_sequence is not None and chunks_per_sequence < nchunks:
+        batch_size = nchunks // chunks_per_sequence
+        cps = chunks_per_sequence
+
+        # Reshape to per-sequence layout
+        states_seq = states.view(batch_size, cps, nheads, hdim)
+        dA_last_seq = dA_last.view(nheads, batch_size, cps)
+        dA_last_seq = dA_last_seq.permute(1, 0, 2)  # [B, H, cps]
+
+        # Build per-sequence initial states
+        if initial_states is not None:
+            init = initial_states.unsqueeze(1)  # [B, 1, H, hdim]
+        else:
+            init = torch.zeros(batch_size, 1, nheads, hdim, device=device, dtype=states.dtype)
+        all_states = torch.cat([init, states_seq[:, :-1]], dim=1)  # [B, cps, H, hdim]
+
+        # Build block-diagonal decay: [B, H, cps, cps]
+        dA_padded = F.pad(dA_last_seq, (1, 0))  # [B, H, cps+1]
+        cumsum = torch.cumsum(dA_padded, dim=-1)
+
+        # We only need the [1:, 1:] sub-block for cps x cps
+        cumsum_chunks = cumsum[:, :, 1:]  # [B, H, cps]
+        segsum = cumsum_chunks.unsqueeze(-1) - cumsum_chunks.unsqueeze(-2)
+        decay = torch.tril(torch.exp(segsum))  # [B, H, cps, cps]
+
+        # Also need decay from init (position 0) to each chunk
+        init_to_chunk = cumsum_chunks - cumsum[:, :, :1]  # [B, H, cps]
+        init_decay = torch.exp(init_to_chunk)  # [B, H, cps]
+
+        # Flatten B*H for bmm
+        BH = batch_size * nheads
+        all_st = all_states.permute(0, 2, 1, 3).reshape(BH, cps, hdim)
+        init_st = init.permute(0, 2, 1, 3).reshape(BH, 1, hdim)
+        decay_flat = decay.reshape(BH, cps, cps)
+        init_decay_flat = init_decay.reshape(BH, cps, 1)
+
+        new_states = torch.bmm(decay_flat, all_st) + init_decay_flat * init_st
+        out = new_states.view(batch_size, nheads, cps, hdim).permute(0, 2, 1, 3)
+        out = out.reshape(nchunks, nheads, hdim)
+        return out.to(out_dtype)
+
+    # Single-sequence path (original)
     # Prepend initial state as position 0
     if initial_states is not None:
         init = initial_states[0].unsqueeze(0)

--- a/vllm_gaudi/ops/ssd_combined.py
+++ b/vllm_gaudi/ops/ssd_combined.py
@@ -36,6 +36,7 @@ def _mamba_chunk_scan_combined_fwd(
         dt_limit=(0.0, float("inf")),
         state_dtype=None,
         padding_mask=None,
+        chunks_per_sequence=None,
 ):
     assert is_int_pow_2(chunk_size), "chunk_size must be integer power of 2"
     seqlen, nheads, headdim = x.shape
@@ -106,6 +107,7 @@ def _mamba_chunk_scan_combined_fwd(
         initial_states=initial_states.flatten(-2)
         if initial_states is not None else None,  # (batch, nheads, headdim*dstate)
         out_dtype=state_dtype if state_dtype is not None else C.dtype,
+        chunks_per_sequence=chunks_per_sequence,
     )
     states = states.view(states.shape[0], states.shape[1], -1, dstate)
 
@@ -130,6 +132,7 @@ def _mamba_chunk_scan_combined_fwd(
         D=D,
         z=z,
         initial_states=initial_states,
+        chunks_per_sequence=chunks_per_sequence,
     )
 
     return states
@@ -153,6 +156,7 @@ def hpu_mamba_chunk_scan_combined_varlen(
         dt_limit=(0.0, float("inf")),
         state_dtype=None,
         padding_mask=None,
+        chunks_per_sequence=None,
 ):
     """
     Argument:
@@ -172,6 +176,7 @@ def hpu_mamba_chunk_scan_combined_varlen(
         dt_softplus: Whether to apply softplus to dt
         out: (seqlen, nheads, headdim) preallocated output tensor
         state_dtype: The data type of the ssm state
+        chunks_per_sequence: Optional int - for multi-sequence batched prefill
     Return:
         varlen_states: (batch, nheads, headdim, dstate)
     """
@@ -196,6 +201,7 @@ def hpu_mamba_chunk_scan_combined_varlen(
         dt_limit=dt_limit,
         state_dtype=state_dtype,
         padding_mask=padding_mask,
+        chunks_per_sequence=chunks_per_sequence,
     )
 
     return varlen_states

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -2420,7 +2420,11 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
             assert chunk_size > 0
             nphysical_chunks = target_seq // chunk_size
             assert nphysical_chunks > 0, (f"target_seq={target_seq} must be >= chunk_size={chunk_size}")
-            last_chunk_indices = [nphysical_chunks - 1 for _ in range(len(contents.req_ids))]
+            # For multi-batch prefill (BS>1), the SSM processes
+            # BS * target_seq tokens.  Each sequence occupies
+            # nphysical_chunks chunks in the flattened layout, so
+            # sequence i's last chunk is at (i+1)*nphysical_chunks - 1.
+            last_chunk_indices = [(i + 1) * nphysical_chunks - 1 for i in range(len(contents.req_ids))]
 
             num_prefill_reqs = len(contents.req_ids)
             all_state_indices_cpu = []

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -2385,12 +2385,24 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
 
         if self.num_mamba_like_layers > 0:
             # COMPUTE query_start_loc (similar to GPU)
-            # This is a cumulative sum of query lengths
-            query_start_loc_p_cpu = torch.zeros(len(query_lens) + 1,
+            # This is a cumulative sum of query lengths.
+            # We size to target_bs + 1 so that padding entries repeat the
+            # final cumulative value; this makes qsl diffs equal to 0 for
+            # padding positions and keeps the batched prefill paths
+            # (conv1d / SSM) internally consistent with other tensors
+            # (state_indices_tensor, has_initial_states_p, ...) that are
+            # padded to target_bs.
+            query_start_loc_p_cpu = torch.zeros(target_bs + 1,
                                                 dtype=torch.int32,
                                                 device='cpu',
                                                 pin_memory=self.pin_memory)
-            query_start_loc_p_cpu[1:] = torch.cumsum(torch.tensor(query_lens, dtype=torch.int32), dim=0)
+            cumsum_lens = torch.cumsum(torch.tensor(query_lens, dtype=torch.int32), dim=0)
+            query_start_loc_p_cpu[1:len(query_lens) + 1] = cumsum_lens
+            if len(query_lens) < target_bs:
+                # Repeat the final cumulative value for padding entries
+                # so that (qsl[i+1] - qsl[i]) == 0 for padding positions.
+                last_cumsum = cumsum_lens[-1] if len(query_lens) > 0 else 0
+                query_start_loc_p_cpu[len(query_lens) + 1:] = last_cumsum
 
             num_computed_tokens_p_cpu = torch.zeros(len(contents.req_ids), dtype=torch.int32)
 
@@ -2421,10 +2433,13 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
             nphysical_chunks = target_seq // chunk_size
             assert nphysical_chunks > 0, (f"target_seq={target_seq} must be >= chunk_size={chunk_size}")
             # For multi-batch prefill (BS>1), the SSM processes
-            # BS * target_seq tokens.  Each sequence occupies
-            # nphysical_chunks chunks in the flattened layout, so
-            # sequence i's last chunk is at (i+1)*nphysical_chunks - 1.
-            last_chunk_indices = [(i + 1) * nphysical_chunks - 1 for i in range(len(contents.req_ids))]
+            # target_bs * target_seq tokens.  Each sequence slot (including
+            # padding) occupies nphysical_chunks chunks in the flattened
+            # layout, so slot i's last chunk is at (i+1)*nphysical_chunks - 1.
+            # We size this over the full padded batch (target_bs) so that
+            # downstream indexing aligns with state_indices_tensor (which
+            # is also padded to target_bs).
+            last_chunk_indices = [(i + 1) * nphysical_chunks - 1 for i in range(target_bs)]
 
             num_prefill_reqs = len(contents.req_ids)
             all_state_indices_cpu = []


### PR DESCRIPTION
# Enable Higher Prefill Batch Size for Granite 4.0 MambaMixer2

## Summary

Removes hard-coded BS=1 prefill limitations across the Granite MambaMixer2 conv1d, SSM, and model runner code paths, enabling multi-sequence prefill batches on Gaudi HPUs.

## Changes (5 files)

- **`granite_causal_conv1d.py`** — Remove BS=1 assertion; add batched conv1d path with per-sequence state gather/scatter.
- **`hpu_mamba_mixer2.py`** — Fix output reshape for dynamic batch shape; add padded `cu_seqlens` and `chunks_per_sequence` computation for multi-batch SSM.
- **`hpu_model_runner.py`** — Fix `last_chunk_indices` to use per-sequence offsets: `(i+1)*nphysical_chunks - 1`.
- **`ssd_combined.py`** — Thread `chunks_per_sequence` through SSM forward and varlen wrapper.
- **`pytorch_implementation.py`** — Add `chunks_per_sequence` to `new_ssd_state_passing()` and `new_chunk_scan()` for independent per-sequence processing in batched layout.

## Backward Compatibility

- BS=1 path is unchanged and preserved.
- No new configuration flags required — the model runner naturally batches when scheduler provides multiple prefill requests.
