### PR TITLE
fix: stabilize decode block_list growth for long-context workloads (v…

### DIFF
--- a/tests/unit_tests/test_bucketing.py
+++ b/tests/unit_tests/test_bucketing.py
@@ -489,6 +489,46 @@ def test_calc_fallback_value_stabilizes_oversized_block_list():
     assert small_bucket % base_step == 0
 
 
+def test_calc_fallback_value_contiguous_pa_capped_by_cache():
+    """GAUDISW-247865: contiguous PA fallback must not exceed the physical
+    cache block count.  When calc_fallback_value rounds up past the cache
+    limit, the caller should cap it.  Verify the cap arithmetic works.
+
+    The model runner logic is:
+        actual_blocks_needed = min(max(block_list)+1, _max_cache_blocks)
+        if actual_blocks_needed > bucket:
+            block_bucket_size = min(calc_fallback_value(...), _max_cache_blocks)
+        block_bucket_size = max(block_bucket_size, actual_blocks_needed)
+    """
+
+    base_step = 32
+    max_cache_blocks = 77036  # 9860608 / 128 for hybrid model
+
+    # Simulate: actual_blocks_needed is capped at max_cache_blocks first
+    for raw_actual in [77000, 77035, 77036, 77040, 78000]:
+        actual = min(raw_actual, max_cache_blocks)  # cap as model runner does
+        fallback = calc_fallback_value(actual, base_step)
+        capped = min(fallback, max_cache_blocks)
+        result = max(capped, actual)
+        assert result <= max_cache_blocks, (
+            f"raw_actual={raw_actual}: result {result} exceeds cache limit {max_cache_blocks}")
+        assert result >= actual, (
+            f"raw_actual={raw_actual}: result {result} smaller than capped actual {actual}")
+
+    # Stability near cache limit: adjacent values map to same bucket
+    results = set()
+    for i in range(200):
+        actual = min(76900 + i, max_cache_blocks)
+        v = min(calc_fallback_value(actual, base_step), max_cache_blocks)
+        v = max(v, actual)
+        results.add(v)
+    # Near the cap, everything converges to max_cache_blocks
+    assert max_cache_blocks in results, (
+        f"max_cache_blocks {max_cache_blocks} should be in result set")
+    assert len(results) <= 3, (
+        f"Too many distinct buckets near cache limit: {len(results)}")
+
+
 def test_exponential_decode_block_limit_cap(monkeypatch):
     """Verify that the decode block limit is capped to avoid excessive warmup.
 

--- a/tests/unit_tests/test_bucketing.py
+++ b/tests/unit_tests/test_bucketing.py
@@ -512,8 +512,7 @@ def test_calc_fallback_value_contiguous_pa_capped_by_cache():
         result = max(capped, actual)
         assert result <= max_cache_blocks, (
             f"raw_actual={raw_actual}: result {result} exceeds cache limit {max_cache_blocks}")
-        assert result >= actual, (
-            f"raw_actual={raw_actual}: result {result} smaller than capped actual {actual}")
+        assert result >= actual, (f"raw_actual={raw_actual}: result {result} smaller than capped actual {actual}")
 
     # Stability near cache limit: adjacent values map to same bucket
     results = set()
@@ -523,10 +522,8 @@ def test_calc_fallback_value_contiguous_pa_capped_by_cache():
         v = max(v, actual)
         results.add(v)
     # Near the cap, everything converges to max_cache_blocks
-    assert max_cache_blocks in results, (
-        f"max_cache_blocks {max_cache_blocks} should be in result set")
-    assert len(results) <= 3, (
-        f"Too many distinct buckets near cache limit: {len(results)}")
+    assert max_cache_blocks in results, (f"max_cache_blocks {max_cache_blocks} should be in result set")
+    assert len(results) <= 3, (f"Too many distinct buckets near cache limit: {len(results)}")
 
 
 def test_exponential_decode_block_limit_cap(monkeypatch):

--- a/tests/unit_tests/test_bucketing.py
+++ b/tests/unit_tests/test_bucketing.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 ###############################################################################
 
+import math as _math
 import pytest
 from unittest.mock import patch
 
@@ -109,24 +110,28 @@ class _MockConfig:
 
 @patch('vllm_gaudi.extension.bucketing.exponential.get_config')
 def test_exponential_decode_cfgs_non_contiguous_pa_bounded(mock_get_config):
-    """max_decode_blocks should be max_blocks * 3 when use_contiguous_pa=False.
+    """max_decode_blocks scales with max_num_seqs for non-contiguous PA.
 
-    The 3x multiplier accounts for prefix-cache block sharing: the same
-    physical block can appear in multiple sequences' block tables, so total
-    block references may exceed num_hpu_blocks.
+    For prefix-cache block sharing, the formula uses
+    max(min(blocks_per_seq * max_num_seqs, max_blocks * max_num_seqs // 3), max_blocks * 3)
+    to cover realistic long-context scenarios.
     """
     mock_get_config.return_value = _MockConfig(use_contiguous_pa=False)
     strategy = ExponentialBucketingStrategy()
 
     max_blocks = 3593
     block_size = 128
-    _, _, block_cfg = strategy.get_decode_cfgs(max_num_seqs=256,
+    max_num_seqs = 256
+    max_model_len = 91964
+    _, _, block_cfg = strategy.get_decode_cfgs(max_num_seqs=max_num_seqs,
                                                block_size=block_size,
                                                max_num_batched_tokens=131072,
-                                               max_model_len=91964,
+                                               max_model_len=max_model_len,
                                                max_blocks=max_blocks)
 
-    expected_max = max_blocks * 3  # 10779
+    import math
+    blocks_per_seq = math.ceil(max_model_len / block_size)
+    expected_max = max(min(blocks_per_seq * max_num_seqs, max_blocks * max_num_seqs // 3), max_blocks * 3)
     assert block_cfg[2] == expected_max, (f"Expected max_decode_blocks={expected_max}, got {block_cfg[2]}")
 
 
@@ -149,29 +154,32 @@ def test_exponential_decode_cfgs_contiguous_pa_uses_max_blocks(mock_get_config):
 
 @patch('vllm_gaudi.extension.bucketing.exponential.get_config')
 def test_exponential_decode_max_never_exceeds_bounded_value(mock_get_config):
-    """Regression test: large max_model_len must NOT produce gigantic decode buckets."""
+    """Regression test: small max_num_seqs keeps blocks bounded; large max_num_seqs scales up."""
     mock_get_config.return_value = _MockConfig(use_contiguous_pa=False)
     strategy = ExponentialBucketingStrategy()
 
-    max_model_len = 91964
-    block_size = 128
-    max_num_seqs = 256
+    # Small batch: should stay at max_blocks * 3 floor
+    _, _, block_cfg_small = strategy.get_decode_cfgs(max_num_seqs=8,
+                                                     block_size=128,
+                                                     max_num_batched_tokens=4096,
+                                                     max_model_len=4096,
+                                                     max_blocks=200)
+    assert block_cfg_small[2] == 200 * 3, (f"Small config should use 3x floor, got {block_cfg_small[2]}")
+
+    # Large batch with long context: formula scales with max_num_seqs
     max_blocks = 3593
-
-    _, _, block_cfg = strategy.get_decode_cfgs(max_num_seqs=max_num_seqs,
-                                               block_size=block_size,
-                                               max_num_batched_tokens=131072,
-                                               max_model_len=max_model_len,
-                                               max_blocks=max_blocks)
-
-    # The old (buggy) formula would produce min(91964//128*256, ...) = 183808
-    # The fix should give max_blocks * 3 = 10779
-    assert block_cfg[2] <= max_blocks * 3, (f"Decode bucket max {block_cfg[2]} exceeds bounded limit "
-                                            f"{max_blocks * 3}. Buckets are too large!")
-    # Sanity: must not be the old gigantic value
-    old_buggy_value = max_model_len // block_size * max_num_seqs
-    assert block_cfg[2] < old_buggy_value, (f"Decode bucket max {block_cfg[2]} matches buggy formula output "
-                                            f"{old_buggy_value}")
+    max_num_seqs = 256
+    _, _, block_cfg_large = strategy.get_decode_cfgs(max_num_seqs=max_num_seqs,
+                                                     block_size=128,
+                                                     max_num_batched_tokens=131072,
+                                                     max_model_len=91964,
+                                                     max_blocks=max_blocks)
+    # Must be >= max_blocks * 3 (floor guarantee)
+    assert block_cfg_large[2] >= max_blocks * 3, (
+        f"Decode bucket max {block_cfg_large[2]} below floor {max_blocks * 3}")
+    # Must be bounded by max_blocks * max_num_seqs // 3
+    assert block_cfg_large[2] <= max_blocks * max_num_seqs // 3, (
+        f"Decode bucket max {block_cfg_large[2]} exceeds upper bound {max_blocks * max_num_seqs // 3}")
 
 
 @patch('vllm_gaudi.extension.bucketing.exponential.get_config')
@@ -227,15 +235,18 @@ _REAL_BLOCK_SIZE = 128
 _REAL_MAX_NUM_SEQS = 256
 _REAL_MAX_BLOCKS = 3593  # num_hpu_blocks
 _REAL_MAX_BATCHED_TOKENS = 2048
-_REAL_FIXED_MAX_DECODE_BLOCKS = _REAL_MAX_BLOCKS * 3  # 10779
-_REAL_BUGGY_MAX_DECODE_BLOCKS = 183808  # min(91964//128*256, 3593*256//4)
+_REAL_BLOCKS_PER_SEQ = _math.ceil(_REAL_MAX_MODEL_LEN / _REAL_BLOCK_SIZE)
+_REAL_FIXED_MAX_DECODE_BLOCKS = max(
+    min(_REAL_BLOCKS_PER_SEQ * _REAL_MAX_NUM_SEQS, _REAL_MAX_BLOCKS * _REAL_MAX_NUM_SEQS // 3),
+    _REAL_MAX_BLOCKS * 3,
+)
 
 
 @patch('vllm_gaudi.extension.bucketing.exponential.get_config')
 def test_real_scenario_decode_cfg_matches_fixed_log(mock_get_config):
     """Verify decode bucket config matches expected values for real scenario.
 
-    With max_blocks * 3: block config should be [1, 256, 10779, 9]
+    Block max scales with max_num_seqs for prefix-sharing coverage.
     """
     mock_get_config.return_value = _MockConfig(use_contiguous_pa=False)
     strategy = ExponentialBucketingStrategy()
@@ -252,7 +263,7 @@ def test_real_scenario_decode_cfg_matches_fixed_log(mock_get_config):
     assert block_cfg[2] == _REAL_FIXED_MAX_DECODE_BLOCKS, (
         f"block max: expected {_REAL_FIXED_MAX_DECODE_BLOCKS}, got {block_cfg[2]}")
     import math
-    uncapped_limit = math.ceil(math.log2(_REAL_MAX_BLOCKS * 3)) + 1
+    uncapped_limit = math.ceil(math.log2(_REAL_FIXED_MAX_DECODE_BLOCKS)) + 1
     decode_bs_limit = math.ceil(math.log2(_REAL_MAX_NUM_SEQS)) + 1
     expected_limit = min(uncapped_limit, max(6, decode_bs_limit))  # min(15, 9) = 9
     assert block_cfg[3] == expected_limit, (f"block limit: expected {expected_limit}, got {block_cfg[3]}")
@@ -297,9 +308,7 @@ def test_real_scenario_decode_block_range_bounded(mock_get_config):
     assert max(block_range) <= _REAL_FIXED_MAX_DECODE_BLOCKS, (
         f"Largest block bucket {max(block_range)} exceeds bounded max "
         f"{_REAL_FIXED_MAX_DECODE_BLOCKS}")
-    assert max(block_range) < _REAL_BUGGY_MAX_DECODE_BLOCKS, (
-        f"Block range still contains buggy value {_REAL_BUGGY_MAX_DECODE_BLOCKS}")
-    # Verify reasonable number of buckets (log showed 13 unique block values)
+    # Verify reasonable number of buckets
     assert len(block_range) <= 20, (f"Too many block buckets: {len(block_range)}")
 
 
@@ -452,6 +461,32 @@ def test_real_scenario_fallback_ctx_7408_not_truncated():
 
     assert new_ctx >= 7408, (f"Fallback ctx {new_ctx} < 7408: tensor/graph size mismatch.")
     assert new_ctx == calc_fallback_value(7408, 32), (f"Fallback ctx {new_ctx} should equal calc_fallback_value result")
+
+
+def test_calc_fallback_value_stabilizes_oversized_block_list():
+    """GAUDISW-247865: decode block_list that exceeds the max bucket must be
+    rounded up via calc_fallback_value so that the padded shape is stable
+    across adjacent lengths (no recompilation storm)."""
+
+    base_step = 32
+
+    # 1. Bug scenario: 16 reqs × 1563 blocks at 200k ctx with block_size=128
+    oversized = 25008
+    bucket = calc_fallback_value(oversized, base_step)
+    assert bucket >= oversized, (f"Fallback bucket {bucket} must cover the actual block_list length {oversized}")
+    assert bucket % base_step == 0, (f"Fallback bucket {bucket} must be divisible by base_step {base_step}")
+
+    # 2. Shape stability: adjacent lengths must map to the same bucket
+    for i in range(100):
+        assert calc_fallback_value(
+            oversized + i, base_step) == bucket, (f"calc_fallback_value({oversized + i}, {base_step}) = "
+                                                  f"{calc_fallback_value(oversized + i, base_step)}, expected {bucket}")
+
+    # 3. Edge case: small value still covered
+    small = 100
+    small_bucket = calc_fallback_value(small, base_step)
+    assert small_bucket >= small, (f"Fallback bucket {small_bucket} must cover length {small}")
+    assert small_bucket % base_step == 0
 
 
 def test_exponential_decode_block_limit_cap(monkeypatch):

--- a/vllm_gaudi/extension/bucketing/exponential.py
+++ b/vllm_gaudi/extension/bucketing/exponential.py
@@ -98,11 +98,19 @@ class ExponentialBucketingStrategy():
         decode_block_limit_cap = max(6, decode_bs_limit)
         # With non-contiguous PA, total block references across all sequences
         # can exceed physical num_hpu_blocks (same physical block appears in
-        # multiple sequence block tables).  Use 3x headroom so prepared buckets
-        # cover realistic prefix-sharing scenarios and avoid costly HPU graph
-        # recompilation at high KV-cache utilization.
-        max_decode_blocks = max_blocks if use_contiguous_pa else \
-                            max_blocks * 3
+        # multiple sequence block tables).  Scale the cap with both context
+        # length and batch size so prepared buckets cover long-context
+        # prefix-sharing scenarios and avoid costly HPU graph recompilation.
+        # The min() prevents excessive warmup when model_len is very large,
+        # and the outer max() guarantees at least 3x headroom for small configs.
+        if use_contiguous_pa:
+            max_decode_blocks = max_blocks
+        else:
+            blocks_per_seq = math.ceil(max_model_len / block_size)
+            max_decode_blocks = max(
+                min(blocks_per_seq * max_num_seqs, max_blocks * max_num_seqs // 3),
+                max_blocks * 3,
+            )
         max_decode_block_limit = min(math.ceil(math.log2(max_decode_blocks)) + 1, decode_block_limit_cap)
         decode_block_bucket_cfg = [1, max_num_seqs, max_decode_blocks, max_decode_block_limit]
 

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -2083,17 +2083,14 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
         block_bucket_size: int
         if self.use_contiguous_pa:
             actual_blocks_needed = max(block_list) + 1 if block_list else 0
-            actual_blocks_needed = min(actual_blocks_needed,
-                                       self._max_cache_blocks)
+            actual_blocks_needed = min(actual_blocks_needed, self._max_cache_blocks)
 
             block_bucket_size = \
                 self.bucketing_manager.find_decode_bucket(batch_size,
                                                           actual_blocks_needed)[2]
             if actual_blocks_needed > block_bucket_size:
                 block_bucket_size = min(
-                    calc_fallback_value(
-                        actual_blocks_needed,
-                        self.bucketing_manager.fallback_blocks_base_step),
+                    calc_fallback_value(actual_blocks_needed, self.bucketing_manager.fallback_blocks_base_step),
                     self._max_cache_blocks)
             block_bucket_size = max(block_bucket_size, actual_blocks_needed)
             block_bucket_size += self.get_dp_padding(block_bucket_size)

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -27,7 +27,7 @@ import torch.distributed
 import torch.nn.functional as F
 import torch.nn as nn
 import vllm_gaudi.extension.environment as environment
-from vllm_gaudi.extension.bucketing.common import HPUBucketingManager
+from vllm_gaudi.extension.bucketing.common import HPUBucketingManager, calc_fallback_value
 from vllm_gaudi.extension.defragmentation import OnlineDefragmenter
 from vllm_gaudi.extension.profiler import (HabanaHighLevelProfiler, HabanaMemoryProfiler, HabanaProfilerCounterHelper,
                                            format_bytes, setup_profiler)
@@ -2101,6 +2101,9 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
                 self.bucketing_manager.find_decode_bucket(batch_size,
                                                           len(block_list))[2]
             block_bucket_size += self.get_dp_padding(block_bucket_size)
+            if block_bucket_size < len(block_list):
+                block_bucket_size = calc_fallback_value(len(block_list),
+                                                        self.bucketing_manager.fallback_blocks_base_step)
 
             def padding_fn(tensor, pad_value):
                 return pad_list(tensor, block_bucket_size, itertools.repeat(pad_value))

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -1217,6 +1217,7 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
         self._PAD_BLOCK_ID = -1
         self._MAMBA_PAD_BLOCK_ID = -1
         self._dummy_num_blocks = 0
+        self._max_cache_blocks = 0
 
         if self.vllm_config.parallel_config.data_parallel_size > 1 and htorch.utils.internal.is_lazy(
         ) and not self.model_config.enforce_eager:
@@ -2082,11 +2083,19 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
         block_bucket_size: int
         if self.use_contiguous_pa:
             actual_blocks_needed = max(block_list) + 1 if block_list else 0
+            actual_blocks_needed = min(actual_blocks_needed,
+                                       self._max_cache_blocks)
 
             block_bucket_size = \
                 self.bucketing_manager.find_decode_bucket(batch_size,
                                                           actual_blocks_needed)[2]
             block_bucket_size += self.get_dp_padding(block_bucket_size)
+            if actual_blocks_needed > block_bucket_size:
+                block_bucket_size = min(
+                    calc_fallback_value(
+                        actual_blocks_needed,
+                        self.bucketing_manager.fallback_blocks_base_step),
+                    self._max_cache_blocks)
             block_bucket_size = max(block_bucket_size, actual_blocks_needed)
 
             indices: list[Any]
@@ -6002,6 +6011,17 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
         self._PAD_SLOT_ID = num_blocks * self.attn_block_size
         self._MAMBA_PAD_BLOCK_ID = num_blocks
         self._dummy_num_blocks = num_blocks
+
+        # Compute the max cache block count across all layers.
+        # Hybrid models (attention + mamba) may have layers with different
+        # cache sizes; contiguous PA slices cache[:N] so N must not exceed
+        # the actual cache dimension.
+        max_dim0 = 0
+        for kv in self.kv_caches:
+            t = kv[0] if not isinstance(kv[0], tuple) else kv[0][0]
+            if t.shape[0] > max_dim0:
+                max_dim0 = t.shape[0]
+        self._max_cache_blocks = max_dim0 // self.block_size if self.block_size else 0
 
         # Initialize the GDN compact slot free-list.
         # The free-list contains base-slot IDs [0..max_num_reqs-1].

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -2089,7 +2089,6 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
             block_bucket_size = \
                 self.bucketing_manager.find_decode_bucket(batch_size,
                                                           actual_blocks_needed)[2]
-            block_bucket_size += self.get_dp_padding(block_bucket_size)
             if actual_blocks_needed > block_bucket_size:
                 block_bucket_size = min(
                     calc_fallback_value(
@@ -2097,6 +2096,7 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
                         self.bucketing_manager.fallback_blocks_base_step),
                     self._max_cache_blocks)
             block_bucket_size = max(block_bucket_size, actual_blocks_needed)
+            block_bucket_size += self.get_dp_padding(block_bucket_size)
 
             indices: list[Any]
             indices = [None] * block_bucket_size
@@ -2109,10 +2109,10 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
             block_bucket_size = \
                 self.bucketing_manager.find_decode_bucket(batch_size,
                                                           len(block_list))[2]
-            block_bucket_size += self.get_dp_padding(block_bucket_size)
             if block_bucket_size < len(block_list):
                 block_bucket_size = calc_fallback_value(len(block_list),
                                                         self.bucketing_manager.fallback_blocks_base_step)
+            block_bucket_size += self.get_dp_padding(block_bucket_size)
 
             def padding_fn(tensor, pad_value):
                 return pad_list(tensor, block_bucket_size, itertools.repeat(pad_value))


### PR DESCRIPTION
…0.19.0)

In non-contiguous PA mode, the decode block_list grows as num_seqs * blocks_per_seq which can exceed max_blocks * 3 for long-context workloads (e.g. 200K context). Each new unique block count triggers an HPU graph recompilation, causing a recompilation storm and OOM.

Fix 1 (hpu_model_runner.py): When block_bucket_size < len(block_list), round up via calc_fallback_value() for stable shapes instead of recompiling per unique block count.

Fix 2 (exponential.py): Raise the decode block cap using:
  blocks_per_seq = ceil(max_model_len / block_size)
  max(min(blocks_per_seq * max_num_seqs, max_blocks * max_num_seqs // 3),
      max_blocks * 3)
This covers realistic long-context scenarios while maintaining a bounded upper limit.

Validated on v0.19.0: 9 unique decode shapes (vs 1,996 baseline), P50 TPOT 242ms (vs 321ms), output throughput 155 tok/s (vs 112).