### PR TITLE
[v0.19.0] Revert "[GAUDISW-247226] Cap decode block bucket limit to reduce warmup time (#1160)"

### DIFF
--- a/tests/unit_tests/test_bucketing.py
+++ b/tests/unit_tests/test_bucketing.py
@@ -235,7 +235,7 @@ _REAL_BUGGY_MAX_DECODE_BLOCKS = 183808  # min(91964//128*256, 3593*256//4)
 def test_real_scenario_decode_cfg_matches_fixed_log(mock_get_config):
     """Verify decode bucket config matches expected values for real scenario.
 
-    With max_blocks * 3: block config should be [1, 256, 10779, 9]
+    With max_blocks * 3: block config should be [1, 256, 10779, 14]
     """
     mock_get_config.return_value = _MockConfig(use_contiguous_pa=False)
     strategy = ExponentialBucketingStrategy()
@@ -246,15 +246,13 @@ def test_real_scenario_decode_cfg_matches_fixed_log(mock_get_config):
                                                max_model_len=_REAL_MAX_MODEL_LEN,
                                                max_blocks=_REAL_MAX_BLOCKS)
 
-    # Expected: [1, 256, 10779, 9]
+    # Expected: [1, 256, 10779, 14]
     assert block_cfg[0] == 1, f"block min: expected 1, got {block_cfg[0]}"
     assert block_cfg[1] == _REAL_MAX_NUM_SEQS, (f"block step: expected {_REAL_MAX_NUM_SEQS}, got {block_cfg[1]}")
     assert block_cfg[2] == _REAL_FIXED_MAX_DECODE_BLOCKS, (
         f"block max: expected {_REAL_FIXED_MAX_DECODE_BLOCKS}, got {block_cfg[2]}")
     import math
-    uncapped_limit = math.ceil(math.log2(_REAL_MAX_BLOCKS * 3)) + 1
-    decode_bs_limit = math.ceil(math.log2(_REAL_MAX_NUM_SEQS)) + 1
-    expected_limit = min(uncapped_limit, max(6, decode_bs_limit))  # min(15, 9) = 9
+    expected_limit = math.ceil(math.log2(_REAL_MAX_BLOCKS * 3)) + 1  # 14
     assert block_cfg[3] == expected_limit, (f"block limit: expected {expected_limit}, got {block_cfg[3]}")
 
 
@@ -452,42 +450,3 @@ def test_real_scenario_fallback_ctx_7408_not_truncated():
 
     assert new_ctx >= 7408, (f"Fallback ctx {new_ctx} < 7408: tensor/graph size mismatch.")
     assert new_ctx == calc_fallback_value(7408, 32), (f"Fallback ctx {new_ctx} should equal calc_fallback_value result")
-
-
-def test_exponential_decode_block_limit_cap(monkeypatch):
-    """Verify that the decode block limit is capped to avoid excessive warmup.
-
-    Reproduces the GAUDISW-247226 scenario: max_num_seqs=21 with a large KV
-    cache (65536 blocks) previously produced ~126 decode buckets and ~30 min
-    warmup.  With the cap the block dimension should have at most 6 exponential
-    steps, giving significantly fewer total buckets.
-    """
-    monkeypatch.setenv("VLLM_EXPONENTIAL_BUCKETING", "true")
-    monkeypatch.setenv("VLLM_CONTIGUOUS_PA", "true")
-    clear_config()
-    get_config()
-
-    strategy = ExponentialBucketingStrategy()
-    max_num_seqs = 21
-    block_size = 128
-    max_num_batched_tokens = 8192
-    max_model_len = 131072
-    max_blocks = 65536
-
-    bs_cfg, query_cfg, block_cfg = strategy.get_decode_cfgs(max_num_seqs, block_size, max_num_batched_tokens,
-                                                            max_model_len, max_blocks)
-
-    bs_range = strategy.get_range(bs_cfg)
-    block_range = strategy.get_range(block_cfg)
-
-    # decode_bs_limit = ceil(log2(21)) + 1 = 6
-    # cap = max(6, 6) = 6  →  block_limit capped at 6
-    assert block_cfg[3] == 6
-
-    # Block range: 6 exponential values + 1 (bmin_origin=1) ≤ 7 unique values
-    assert len(block_range) <= 7
-
-    # Total decode buckets (Cartesian product) should be much less than
-    # the uncapped ~126.
-    total = len(bs_range) * len(block_range)
-    assert total <= 50

--- a/vllm_gaudi/extension/bucketing/exponential.py
+++ b/vllm_gaudi/extension/bucketing/exponential.py
@@ -89,13 +89,6 @@ class ExponentialBucketingStrategy():
         decode_bs_limit = math.ceil(math.log2(max_num_seqs)) + 1
         decode_bs_bucket_cfg = [1, 2, max_num_seqs, decode_bs_limit]
         decode_query_bucket_cfg = [1, 1, 1, 1]
-        # Cap block limit to avoid excessive decode warmup buckets.
-        # Without the cap, large KV caches (e.g. 131K context) produce
-        # 17-18 block buckets which, combined with batch-size buckets,
-        # yields 100+ decode graphs and 30+ min warmup time.
-        # The cap scales with batch-size buckets to keep the total
-        # Cartesian product manageable while preserving coverage.
-        decode_block_limit_cap = max(6, decode_bs_limit)
         # With non-contiguous PA, total block references across all sequences
         # can exceed physical num_hpu_blocks (same physical block appears in
         # multiple sequence block tables).  Use 3x headroom so prepared buckets
@@ -103,7 +96,7 @@ class ExponentialBucketingStrategy():
         # recompilation at high KV-cache utilization.
         max_decode_blocks = max_blocks if use_contiguous_pa else \
                             max_blocks * 3
-        max_decode_block_limit = min(math.ceil(math.log2(max_decode_blocks)) + 1, decode_block_limit_cap)
+        max_decode_block_limit = math.ceil(math.log2(max_decode_blocks)) + 1
         decode_block_bucket_cfg = [1, max_num_seqs, max_decode_blocks, max_decode_block_limit]
 
         msg = ("Decode bucket config (min, step, max_warmup, limit) "


### PR DESCRIPTION
Reverts the changes from PR #1160 on the `releases/v0.19.0` branch.

**Reverted changes:**
- `vllm_gaudi/extension/bucketing/exponential.py`: Remove `decode_block_limit_cap` and restore uncapped `max_decode_block_limit`
- `tests/unit_tests/test_bucketing.py`: Remove `test_exponential_decode_block_limit_cap` test and restore original expected values in `test_real_scenario_decode_cfg_matches_fixed_log`