### PR TITLE
Fix Llama4 Maverick FP8 torch.compile routing failures

### DIFF
--- a/vllm_gaudi/attention/backends/hpu_attn.py
+++ b/vllm_gaudi/attention/backends/hpu_attn.py
@@ -565,10 +565,17 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
                                            block_size=attn_metadata.block_size,
                                            is_prompt=attn_metadata.is_prompt)
 
-        if attn_metadata.is_prompt:
+        if attn_metadata.is_prompt or seq_len > 1:
             # Prompt run.
+            # NOTE: The `seq_len > 1` guard is a compile-safe fallback.
+            # flat_pa (decode attention) only supports single-token queries.
+            # Under torch.compile on HPU, attn_metadata.is_prompt may not
+            # trigger graph recompilation when switching between prompt and
+            # decode phases during warmup.  Tensor shapes are always guarded
+            # correctly, so routing multi-token inputs through the prompt
+            # path prevents a shape mismatch inside flat_pa's batch2block.
             query_shape = (batch_size, seq_len, self.num_heads, self.head_size)
-            kv_shape = (batch_size, seq_len_kv, self.num_kv_heads, self.head_size)
+            kv_shape = (batch_size, -1, self.num_kv_heads, self.head_size)
 
             attn_bias = attn_metadata.attn_bias
             position_bias = None

--- a/vllm_gaudi/attention/backends/hpu_attn.py
+++ b/vllm_gaudi/attention/backends/hpu_attn.py
@@ -530,8 +530,6 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
         else:
             batch_size, seq_len, hidden_size = query.shape
 
-        seq_len_kv = key.shape[0] // batch_size if key.dim() == 2 else key.shape[1]
-
         key = key.view(-1, self.num_kv_heads, self.head_size)
         value = value.view(-1, self.num_kv_heads, self.head_size)
         slot_mapping = attn_metadata.slot_mapping.flatten() if attn_metadata.slot_mapping is not None else None

--- a/vllm_gaudi/models/llama4.py
+++ b/vllm_gaudi/models/llama4.py
@@ -101,11 +101,15 @@ def _apply_hpu_llama4_init_patches(model_root: nn.Module) -> None:
 
     if not htorch.utils.internal.is_lazy():
         layers = getattr(model_root, "layers", [])
-        _apply_branch_free_attention(layers)
+        # NOTE: _apply_branch_free_attention is SKIPPED.
+        # The branchfree attention forward is incompatible with torch.compile
+        # on HPU: 3D hidden_states (batch, seq, hidden) cause FakeTensor
+        # validation errors when batch==seq==1 during decode warmup (symbols
+        # unify).  Regional compilation handles the NoPE/RoPE if/else graph
+        # breaks in upstream Llama4Attention.forward.
         unified = _unify_attention_types(layers)
         logger.info(
-            "HpuLlama4: applied branch-free attention patches, "
-            "unified %d ChunkedLocalAttention -> Attention",
+            "HpuLlama4: unified %d ChunkedLocalAttention -> Attention",
             unified,
         )
 
@@ -187,6 +191,13 @@ def _branchfree_attention_forward(self, positions, hidden_states):
     All layers execute identical code. Boolean buffer masks + torch.where
     select RoPE'd/un-RoPE'd, norm'd/un-norm'd, and scaled/un-scaled
     at the data level — no Python if/else guards for torch.compile.
+
+    NOTE: This function is currently NOT applied to the model (see
+    _apply_hpu_llama4_init_patches).  The 3D hidden_states (batch, seq,
+    hidden) cause torch.compile FakeTensor validation errors when
+    batch==seq==1 during decode warmup (symbolic variables unify).
+    Regional compilation handles the NoPE/RoPE if/else graph breaks
+    in upstream Llama4Attention.forward instead.
     """
     qkv, _ = self.qkv_proj(hidden_states)
     q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)

--- a/vllm_gaudi/ops/hpu_layernorm.py
+++ b/vllm_gaudi/ops/hpu_layernorm.py
@@ -16,7 +16,7 @@ class HPURMSNorm(RMSNorm):
         HPUFusedRMSNorm = rms_norm()
         if residual is not None:
             orig_shape = x.shape
-            residual = residual + x.view(residual.shape)
+            residual = residual + x
             # Note: HPUFusedRMSNorm requires 3D tensors as inputs
             x = HPUFusedRMSNorm.apply(residual, self.weight, self.variance_epsilon)
             return x.view(orig_shape), residual


### PR DESCRIPTION
## Problem

Llama4-Maverick-17B-128E-Instruct fails during warmup with FP8 INC quantization on HPU (torch.compile mode):

```
ValueError: Batch dimension 0 of matmul inputs should be the same or at least
one of them should be equal to 1. Got 328128 and 41016
```

## Root Cause

Three interrelated torch.compile issues on HPU:

1. **Prompt/decode misrouting**: `attn_metadata.is_prompt` is not properly guarded by torch.compile on HPU. During warmup, prompt scenarios (seq_len > 1) get routed through the decode path (`flat_pa`), which only supports seq_len=1, causing shape mismatches in `batch2block`.

2. **Branchfree attention incompatibility**: The `_branchfree_attention_forward` (PR #1360) uses 3D hidden_states `(batch, seq, hidden)`. When batch==seq==1 during decode warmup, torch.compile unifies both dimensions into the same symbolic variable, breaking all view/reshape operations.

3. **Layernorm view failure**: `x.view(residual.shape)` in `HPURMSNorm` fails under FakeTensor tracing when x and residual have symbolically-unified dimensions.

## Fix

**`hpu_attn.py`**: Add `seq_len > 1` as a compile-safe routing fallback alongside `attn_metadata.is_prompt`. Tensor shapes are always correctly guarded by torch.compile, so multi-token inputs are reliably routed to the prompt path. Also use `-1` in `kv_shape` to let PyTorch infer the kv sequence dimension.

**`llama4.py`**: Skip `_apply_branch_free_attention()` patching. Regional compilation handles the NoPE/RoPE if/else graph breaks in upstream `Llama4Attention.forward` without issues.

**`hpu_layernorm.py`**: Remove redundant `x.view(residual.shape)` — `x` and `residual` always have the same shape, so the view is unnecessary.

## Testing

Verified on 8x HL-325L (G3) with:
- Model: Llama4-Maverick-17B-128E-Instruct
- FP8 INC quantization (`maxabs_quant_g3.json`)
- TP=8, max-model-len=131072, block-size=128
- Full warmup: 144 prompt buckets + 35 decode buckets — **0 errors**
- Server starts successfully (`Application startup complete`)
