### PR TITLE
Fix warmup failure and run mm graph warmup pt compile only mode

### DIFF
--- a/vllm_gaudi/extension/ops.py
+++ b/vllm_gaudi/extension/ops.py
@@ -1248,6 +1248,30 @@ class VllmMixtureOfExpertsOpFP8PerChannel(VllmMixtureOfExpertsOpBase):
         self.w13_input_scale = None
         self.w2_input_scale = None
 
+        # cached views to avoid rebuilding lists every forward
+        self._cached_w13_views = None
+        self._cached_w2_views = None
+        self._cached_w13_scale_views = None
+        self._cached_w2_scale_views = None
+
+    def _cache_weight_lists(self):
+        experts_range = range(self.num_experts)
+        self._cached_w13_views = tuple(self.w13_list[i].weight.squeeze() for i in experts_range)
+        self._cached_w2_views = tuple(self.w2_list[i].weight.squeeze() for i in experts_range)
+        self._cached_w13_scale_views = tuple(self.w13_list[i].scale_inv_fp8.squeeze() for i in experts_range)
+        self._cached_w2_scale_views = tuple(self.w2_list[i].scale_inv_fp8.squeeze() for i in experts_range)
+
+    def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys,
+                              error_msgs):
+        super()._load_from_state_dict(state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys,
+                                      error_msgs)
+        self._cache_weight_lists()
+
+    def _apply(self, fn):
+        ret = super()._apply(fn)
+        self._cache_weight_lists()
+        return ret
+
     def forward(
         self,
         x,
@@ -1259,11 +1283,14 @@ class VllmMixtureOfExpertsOpFP8PerChannel(VllmMixtureOfExpertsOpBase):
         tokens_num, _ = x.shape
         activation = _as_activation_str(activation)
         kwargs = self._get_extra_kwargs(tokens_num)
-        experts_range = range(self.num_experts)
-        w13_list = [self.w13_list[i].weight.squeeze() for i in experts_range]
-        w2_list = [self.w2_list[i].weight.squeeze() for i in experts_range]
-        w13_weight_scale = [self.w13_list[i].scale_inv_fp8.squeeze() for i in experts_range]
-        w2_weight_scale = [self.w2_list[i].scale_inv_fp8.squeeze() for i in experts_range]
+
+        if self._cached_w13_views is None or self._cached_w2_views is None:
+            self._cache_weight_lists()
+
+        w13_list = self._cached_w13_views
+        w2_list = self._cached_w2_views
+        w13_weight_scale = self._cached_w13_scale_views
+        w2_weight_scale = self._cached_w2_scale_views
 
         if self.w13_input_scale is None:
             x_fp8, x_scale = dynamic_quant(x)
@@ -1283,7 +1310,7 @@ class VllmMixtureOfExpertsOpFP8PerChannel(VllmMixtureOfExpertsOpBase):
         else:
             x_scale = self.w13_input_scale.data
             # w2_input_scale should be List[Tensor] when static and fused
-            w2_input_scale = [self.w2_input_scale[i] for i in experts_range]
+            w2_input_scale = [self.w2_input_scale[i] for i in range(self.num_experts)]
             x_fp8 = torch.ops.hpu.cast_to_fp8_v2(x, 1.0 / x_scale, False, False, torch.float8_e4m3fn)[0]
             final_hidden_states = torch.ops.hpu.mixture_of_experts(hidden_states=x_fp8,
                                                                    expert_routing_table=topk_ids.to(torch.int64),

--- a/vllm_gaudi/models/qwen2_5_vl.py
+++ b/vllm_gaudi/models/qwen2_5_vl.py
@@ -35,6 +35,7 @@ from vllm.model_executor.models.utils import (maybe_prefix, cast_overflow_tensor
 from vllm.multimodal.inputs import MultiModalFieldConfig
 
 import habana_frameworks.torch.core as htcore
+import habana_frameworks.torch.internal.bridge_config as bridge_config
 from habana_frameworks.torch.hpex.kernels import FusedSDPA
 
 logger = init_logger(__name__)
@@ -411,8 +412,22 @@ class Qwen2_5_VisionTransformerStaticShape(Qwen2_5_VisionTransformer):
                     0.0)
             rot_pos_emb_sin = F.pad(rot_pos_emb_sin, (0, 0, 0, num_pad_tokens), "constant", 0.0)
 
-            padding_attn_mask_full = create_block_diagonal_attention_mask(cu_seqlens)
-            padding_attn_mask_window = create_block_diagonal_attention_mask(cu_window_seqlens)
+            # In PT_COMPILE_ONLY_MODE, Synapse compiles graph recipes without
+            # executing tensors, so cu_seqlens values are uninitialized garbage.
+            # create_block_diagonal_attention_mask() reads cu_seqlens values to
+            # determine mask shapes and control flow (e.g. .to("cpu") fallback
+            # when seq_len > 40000), which is unsafe during compile-only warmup.
+            # Since create_block_diagonal_attention_mask() has no guard for the
+            # warmup path despite pt_compile_only_mode being active, we bypass
+            # it here with a dummy mask of the correct [bucket_size, bucket_size]
+            # shape, which is sufficient for FusedSDPA recipe compilation.
+            if bridge_config.get_pt_compile_only_mode():
+                mask_size = int(bucket_size)
+                padding_attn_mask_full = torch.zeros(mask_size, mask_size, dtype=torch.bool, device=self.device)
+                padding_attn_mask_window = torch.zeros(mask_size, mask_size, dtype=torch.bool, device=self.device)
+            else:
+                padding_attn_mask_full = create_block_diagonal_attention_mask(cu_seqlens)
+                padding_attn_mask_window = create_block_diagonal_attention_mask(cu_window_seqlens)
 
             # static part
             htcore.mark_step()

--- a/vllm_gaudi/models/qwen3_5.py
+++ b/vllm_gaudi/models/qwen3_5.py
@@ -113,7 +113,9 @@ class HPUGatedDeltaNetAttention(GatedDeltaNetAttention):
             prefill_seq_len = (num_tokens // prefill_num_seqs if prefill_num_seqs > 0 else 0)
             initial_state = ssm_state[state_indices].contiguous()
             if has_initial_state is not None:
-                initial_state[~has_initial_state.bool(), ...] = 0
+                # Avoid scatter_nd from boolean indexing
+                mask = has_initial_state.bool().view(-1, 1, 1, 1).to(initial_state.dtype)
+                initial_state = initial_state * mask
 
         return (is_prompt, conv_state, ssm_state, state_indices, query_start_loc, has_initial_state, padding_mask_flat,
                 num_decodes, mamba_block_size, prefill_num_seqs, prefill_seq_len, initial_state)

--- a/vllm_gaudi/ops/hpu_fused_moe.py
+++ b/vllm_gaudi/ops/hpu_fused_moe.py
@@ -22,8 +22,7 @@ from vllm.model_executor.layers.fused_moe.router.fused_topk_router import (
     FusedTopKRouter, )
 from vllm.model_executor.layers.fused_moe.router.grouped_topk_router import (
     GroupedTopKRouter, )
-from vllm.model_executor.layers.fused_moe.runner.moe_runner_base import (
-    get_layer_from_name, )
+
 from vllm.model_executor.layers.fused_moe.router.router_factory import (
     EMPTY_EPLB_STATE, )
 from vllm.model_executor.layers.fused_moe.router.routing_simulator_router import (
@@ -266,12 +265,16 @@ def patched_fused_moe_forward(
     hidden_states: torch.Tensor,
     router_logits: torch.Tensor,
 ) -> Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
-    """Patched forward that avoids graph breaks from ForwardContext lookups.
+    """Patched forward that avoids graph breaks from ForwardContext lookups
+    and dynamo per-layer string guards.
 
     Instead of calling forward_dispatch (which uses get_layer_from_name,
     ensure_moe_quant_config_init, and _sequence_parallel_context — all of
     which access ForwardContext and cause torch.compile graph breaks), we
-    cache the layer reference and call _forward_impl directly.
+    use a layer reference stashed on the runner at FusedMoE.__init__ time
+    (self._hpu_layer_ref) and call _forward_impl directly. This also
+    bypasses self.layer_name (a per-layer string) so dynamo no longer
+    emits per-layer string guards that trigger recompilation.
 
     The post-forward reduction sequence mirrors upstream
     MoERunnerBase.forward (vllm/model_executor/layers/fused_moe/runner/
@@ -282,11 +285,9 @@ def patched_fused_moe_forward(
     hidden_states, og_hidden_dims = self._maybe_pad_hidden_states(shared_experts_input, hidden_states)
 
     if self.moe_config.dp_size == 1:
-        # Cache layer ref to avoid per-forward get_layer_from_name graph break
-        if self._hpu_cached_layer is None:
-            self._hpu_cached_layer = get_layer_from_name(self.layer_name)
-            self._hpu_cached_layer.ensure_moe_quant_config_init()
-
+        # Use layer ref saved at FusedMoE.__init__ to avoid both the
+        # get_layer_from_name(self.layer_name) lookup (graph break) and
+        # the per-layer string guard from accessing self.layer_name.
         # Replicate the remaining forward_dispatch logic that we bypass:
         # 1. Sync shared experts stream for multi-stream overlap
         self._maybe_sync_shared_experts_stream(shared_experts_input)
@@ -294,7 +295,7 @@ def patched_fused_moe_forward(
         if self.gate is not None:
             router_logits, _ = self.gate(hidden_states)
 
-        result = self._forward_impl(self._hpu_cached_layer, hidden_states, router_logits, shared_experts_input)
+        result = self._forward_impl(self._hpu_layer_ref, hidden_states, router_logits, shared_experts_input)
     else:
         result = self._forward_entry(hidden_states, router_logits, shared_experts_input, self._encode_layer_name())
 
@@ -499,8 +500,6 @@ def create_fused_moe_router(
 
 
 # Apply patches
-# Keep runner forward patch compatible with upstream layer_name-based dispatch.
-_orig_default_moe_runner_init = MoERunnerBase.__init__
 _orig_default_moe_runner_forward = MoERunnerBase.forward
 
 # When enabled, bypasses the opaque torch.ops.vllm.moe_forward_shared custom
@@ -510,20 +509,28 @@ _orig_default_moe_runner_forward = MoERunnerBase.forward
 _MOE_COMPILE = os.getenv("HPU_FUSED_MOE", "1") == "1"
 
 
-def _patched_default_moe_runner_init(self, layer_name, *args, **kwargs):
-    self._hpu_cached_layer = None
-    return _orig_default_moe_runner_init(self, layer_name, *args, **kwargs)
-
-
 def _patched_default_moe_runner_forward(self, *args, **kwargs):
     if _MOE_COMPILE:
         return patched_fused_moe_forward(self, *args, **kwargs)
     return _orig_default_moe_runner_forward(self, *args, **kwargs)
 
 
-MoERunnerBase.__init__ = _patched_default_moe_runner_init
-
 MoERunnerBase.forward = _patched_default_moe_runner_forward
+
+# Save FusedMoE layer reference on runner for direct _forward_impl calls.
+# This lets patched_fused_moe_forward bypass get_layer_from_name() and the
+# self.layer_name string access for dp_size==1, avoiding both ForwardContext
+# graph breaks and dynamo per-layer string guards.
+_orig_fused_moe_init = FusedMoE.__init__
+
+
+def _hpu_fused_moe_init(self, *args, **kwargs):
+    _orig_fused_moe_init(self, *args, **kwargs)
+    if hasattr(self, 'runner'):
+        self.runner._hpu_layer_ref = self
+
+
+FusedMoE.__init__ = _hpu_fused_moe_init
 
 vllm.model_executor.layers.fused_moe.layer.get_compressed_expert_map = \
     get_compressed_expert_map

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -53,7 +53,7 @@ from vllm.model_executor.layers.mamba.abstract import MambaBase
 from vllm.model_executor.layers.vocab_parallel_embedding import (VocabParallelEmbedding)
 from vllm.model_executor.model_loader import get_model, get_model_loader
 from vllm.platforms import current_platform
-from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
+from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.inputs import (BatchedTensorInputs, MultiModalKwargsItem)
 from vllm.multimodal.utils import group_mm_kwargs_by_modality
 from vllm.model_executor.layers.rotary_embedding import MRotaryEmbedding
@@ -1228,6 +1228,7 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
             self.graphed_multimodal_buckets: set[Any] = set()
         else:
             logger.info("Bucketing is OFF.")
+        self._mm_warmup_processor = None
 
         self._PAD_SLOT_ID = -1
         self._PAD_BLOCK_ID = -1
@@ -5059,7 +5060,9 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
             # Consider the token space for draft tokens to propose
             # The draft tokens for eagle consumes block table space
             num_lookahead_tokens += self.speculative_config.num_speculative_tokens
-        seq_lengths = [min(b * block_size - num_lookahead_tokens, self.max_model_len) for b in blocks]
+        seq_lengths = [
+            min(b * block_size - num_lookahead_tokens, self.max_model_len - num_lookahead_tokens) for b in blocks
+        ]
         return seq_lengths
 
     def distribute_sum_evenly(self, total_sum, max_length):
@@ -5232,6 +5235,59 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
             return self.model.model.visual.patch_size
         return 1
 
+    def _get_dummy_mm_inputs_with_options(
+        self,
+        modality: str,
+        count: int,
+        width: int | None = None,
+        height: int | None = None,
+        num_frames: int | None = None,
+    ):
+        """Helper to get dummy multimodal inputs with custom options."""
+
+        # Create custom mm_options with specific width/height
+        mm_options = None
+        if width is not None and height is not None:
+            if modality == 'image':
+                mm_options = {"image": ImageDummyOptions(count=count, width=width, height=height)}
+            elif modality == 'video':
+                mm_options = {
+                    "video":
+                    VideoDummyOptions(count=count,
+                                      width=width,
+                                      height=height,
+                                      num_frames=num_frames if num_frames is not None else 100)
+                }
+            else:
+                logger.warning("Unsupported modality '%s' for custom mm_options, "
+                               "falling back to default options.", modality)
+
+        # Use the registry's API with custom mm_options
+        if mm_options is not None:
+            processor = self._get_mm_warmup_processor()
+            processor_inputs = processor.dummy_inputs.get_dummy_processor_inputs(
+                seq_len=self.model_config_copy.max_model_len,
+                mm_counts={modality: count},
+                mm_options=mm_options,
+            )
+            from vllm.multimodal.processing import TimingContext
+            dummy_mm_inputs = processor.apply(processor_inputs, timing_ctx=TimingContext(enabled=False))
+        else:
+            # Fallback to default options
+            dummy_mm_inputs = self.mm_registry.get_dummy_mm_inputs(
+                self.model_config_copy,
+                mm_counts={modality: count},
+                processor=self._get_mm_warmup_processor(),
+            )
+
+        return dummy_mm_inputs
+
+    def _get_mm_warmup_processor(self):
+        if self._mm_warmup_processor is None:
+            self._mm_warmup_processor = self.mm_registry.create_processor(self.model_config_copy)
+
+        return self._mm_warmup_processor
+
     def _get_mm_dummy_batch(
         self,
         modality: str,
@@ -5241,26 +5297,29 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
     ) -> BatchedTensorInputs:
         """Dummy data for profiling and precompiling multimodal models."""
         assert self.mm_budget is not None
-        num_frames = 100
-        count = 1
         if self.get_model().vision_bucket_manager.is_batch_based:
             batch = image_args
+            count = 1
         else:
             mm_options = self.model_config.get_multimodal_config().limit_per_prompt.get(modality)
-            count = mm_options.count if mm_options and hasattr(mm_options, 'count') else count
+            count = mm_options.count if mm_options and hasattr(mm_options, 'count') else 1
             batch = count
-        if modality == 'image':
-            mm_options = {"image": ImageDummyOptions(count=count, width=width, height=height), "video": None}
-        elif modality == 'video':
-            num_frames = mm_options.num_frames if mm_options and hasattr(mm_options, 'num_frames') else num_frames
-            mm_options = {
-                "image": None,
-                "video": VideoDummyOptions(count=count, num_frames=num_frames, width=width, height=height)
-            }
-        else:
-            raise NotImplementedError(f"Modality '{modality}' is not supported")
 
-        dummy_mm_inputs = MultiModalRegistry().get_dummy_mm_inputs(self.model_config_copy, mm_counts={modality: count})
+        # Get num_frames for video modality
+        num_frames = None
+        if modality == 'video':
+            mm_config_options = self.model_config.get_multimodal_config().limit_per_prompt.get(modality)
+            if mm_config_options and hasattr(mm_config_options, 'num_frames'):
+                num_frames = mm_config_options.num_frames
+
+        # Use the common helper to get dummy inputs with custom dimensions
+        dummy_mm_inputs = self._get_dummy_mm_inputs_with_options(
+            modality=modality,
+            count=count,
+            width=width,
+            height=height,
+            num_frames=num_frames,
+        )
 
         dummy_mm_item = dummy_mm_inputs["mm_kwargs"][modality][0]
         # We use the cache so that the item is saved to the cache,
@@ -5289,21 +5348,24 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
                            and "image" in self.mm_budget.mm_limits and self.mm_budget.mm_limits['image'] != 0)
         is_video_warmup = (mm_config is not None and mm_config.limit_per_prompt.get("video") is not None
                            and "video" in self.mm_budget.mm_limits and self.mm_budget.mm_limits['video'] != 999)
-        warmup_configs = {
-            "image": (0, lambda: mm_config.limit_per_prompt.get("image")),
-            "video": (999, lambda: mm_config.limit_per_prompt.get("video"))
-        }
-        width = height = None
+        # Get width/height from config if available for warmup_lists
         warmup_lists = []
-        for modality, (limit_value, get_options) in warmup_configs.items():
-            if (mm_config and mm_config.limit_per_prompt.get(modality) is not None
-                    and modality in self.mm_budget.mm_limits and self.mm_budget.mm_limits[modality] != limit_value):
-                options = get_options()
-                width = options.width if hasattr(options, 'width') else None
-                height = options.height if hasattr(options, 'height') else None
-                if width is not None and height is not None:
-                    warmup_lists.append((width, height))
-                break
+
+        if not is_batch_based and mm_config:
+            # Try to get dimensions from enabled modality config
+            for modality in ["image", "video"]:
+                if modality == "image" and not is_image_warmup:
+                    continue
+                if modality == "video" and not is_video_warmup:
+                    continue
+                mm_options = mm_config.limit_per_prompt.get(modality)
+                if mm_options:
+                    width = getattr(mm_options, 'width', None)
+                    height = getattr(mm_options, 'height', None)
+                    if width is not None and height is not None:
+                        warmup_lists.append((width, height))
+                        break
+
         if not is_batch_based and len(buckets) > 0:
             patch_size = int(self.get_patch_size_from_model())
             warmup_lists = warmup_lists + \
@@ -5402,8 +5464,11 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
         start_mem = HabanaMemoryProfiler.current_device_memory_usage()
         start_time = time.perf_counter()
 
-        # Most model's multimodal embedding has to be run without COMPILE ONLY mode.
-        if self.supports_mm_inputs:
+        # In lazy mode, run MM warmup outside PT_COMPILE_ONLY_MODE
+        # to avoid GC errors. In torch.compile mode, run it inside
+        # for faster recipe-only compilation.
+        use_torch_compile = (not htorch.utils.internal.is_lazy() and not self.model_config.enforce_eager)
+        if self.supports_mm_inputs and not use_torch_compile:
             self.warmup_multimodal_graphs(self.get_model().vision_bucket_manager.multimodal_buckets)
 
         compile_only_mode_context = functools.partial(bc.env_setting, "PT_COMPILE_ONLY_MODE", True)
@@ -5418,6 +5483,9 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
                            'Warmup time will be negatively impacted. '
                            'Please update Gaudi Software Suite.')
         with compile_only_mode_context() if can_use_compile_only_mode else contextlib.nullcontext():
+            if self.supports_mm_inputs and use_torch_compile:
+                self.warmup_multimodal_graphs(self.get_model().vision_bucket_manager.multimodal_buckets)
+
             if not self.model_config.enforce_eager and not self.is_pooling_model:
                 assert self.mem_margin is not None, \
                     ("HabanaWorker.determine_num_available_blocks needs "

--- a/vllm_gaudi/v1/worker/hpu_worker.py
+++ b/vllm_gaudi/v1/worker/hpu_worker.py
@@ -586,7 +586,7 @@ class HPUWorker(WorkerBase):
     def take_draft_token_ids(self) -> Optional[DraftTokenIds]:
         return self.model_runner.take_draft_token_ids()  # type: ignore[union-attr]
 
-    def profile(self, is_start: bool = True):
+    def profile(self, is_start: bool = True, profile_prefix: str | None = None):
         if self.profiler is None:
             raise RuntimeError("Profiler is not enabled.")
         if is_start:


### PR DESCRIPTION
* Fix warmup failure
* Propagate changes from v0.19.0 [#1368](https://github.com/vllm-project/vllm-gaudi/pull/1368)
* MoE dynamo recompilation fix (hpu_fused_moe.py): The previous workaround cached the MoE layer via get_layer_from_name(self.layer_name) at runtime, but accessing the per-layer layer_name string still triggered dynamo guards and recompilation. Now patch FusedMoE.__init__ to save self.runner._hpu_layer_ref = self at construction time, and for dp_size==1 call forward_dispatch directly via the saved ref — bypassing _encode_layer_name() and the custom op entirely. Removes the prior _patched_default_moe_runner_init, _hpu_cached_layer caching, inlined forward logic, and adds missing _maybe_add_zero_expert_output() call.
* Cache FP8 MoE weight views in VllmMixtureOfExpertsOpFP8PerChannel