### PR TITLE
fix: always include boundary block in sliding window decode

### DIFF
--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -2832,12 +2832,7 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
             )
 
         if self.interleaved_sliding_window:
-            sliding_block_size = (self.sliding_window // decode_block_size)
-
-            # Adjust sliding block size for specific model types
-            model_type = self._get_model_type()
-            if model_type is not None and model_type in ["gpt_oss"]:
-                sliding_block_size += 1
+            sliding_block_size = (self.sliding_window // decode_block_size) + 1
 
             window_block_tables = [block_table[-sliding_block_size:] for block_table in block_tables_list]
             window_block_list, window_block_groups, window_block_usage = \


### PR DESCRIPTION
The sliding_block_size calculation used integer division (sliding_window // block_size) which truncates, causing the partial boundary block to be dropped during decode. This silently loses up to (block_size - 1) tokens.

Previously the +1 fix was only applied for gpt_oss model type. Make it universal since the off-by-one affects all models with interleaved sliding window attention.