### PR TITLE
fix: enable Llama4 Maverick FP8 torch.compile without breaking DeepSeek

### DIFF
--- a/vllm_gaudi/attention/backends/hpu_attn.py
+++ b/vllm_gaudi/attention/backends/hpu_attn.py
@@ -565,10 +565,10 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
                                            block_size=attn_metadata.block_size,
                                            is_prompt=attn_metadata.is_prompt)
 
-        if attn_metadata.is_prompt:
+        if attn_metadata.is_prompt or seq_len > 1:
             # Prompt run.
             query_shape = (batch_size, seq_len, self.num_heads, self.head_size)
-            kv_shape = (batch_size, seq_len_kv, self.num_kv_heads, self.head_size)
+            kv_shape = (batch_size, -1, self.num_kv_heads, self.head_size)
 
             attn_bias = attn_metadata.attn_bias
             position_bias = None

--- a/vllm_gaudi/attention/backends/hpu_attn.py
+++ b/vllm_gaudi/attention/backends/hpu_attn.py
@@ -530,8 +530,6 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
         else:
             batch_size, seq_len, hidden_size = query.shape
 
-        seq_len_kv = key.shape[0] // batch_size if key.dim() == 2 else key.shape[1]
-
         key = key.view(-1, self.num_kv_heads, self.head_size)
         value = value.view(-1, self.num_kv_heads, self.head_size)
         slot_mapping = attn_metadata.slot_mapping.flatten() if attn_metadata.slot_mapping is not None else None

--- a/vllm_gaudi/models/llama4.py
+++ b/vllm_gaudi/models/llama4.py
@@ -93,7 +93,7 @@ def _apply_hpu_llama4_init_patches(model_root: nn.Module) -> None:
     """Shared init-time patches for both CausalLM and ConditionalGeneration.
 
     Swaps the inner model class for the residual=zeros fix and applies
-    branch-free attention + attention type unification in compile mode.
+    attention type unification in compile mode.
     _unify_feed_forward_types is deferred to post-load via
     apply_hpu_llama4_post_load_patches() to avoid breaking weight loading.
     """

--- a/vllm_gaudi/models/llama4.py
+++ b/vllm_gaudi/models/llama4.py
@@ -101,11 +101,14 @@ def _apply_hpu_llama4_init_patches(model_root: nn.Module) -> None:
 
     if not htorch.utils.internal.is_lazy():
         layers = getattr(model_root, "layers", [])
-        _apply_branch_free_attention(layers)
+        # NOTE: _apply_branch_free_attention is SKIPPED.
+        # The branchfree forward uses 3D hidden_states (batch, seq, hidden)
+        # that cause FakeTensor validation errors under torch.compile when
+        # batch==seq==1 during decode warmup (symbols unify). Regional
+        # compilation handles the NoPE/RoPE graph breaks instead.
         unified = _unify_attention_types(layers)
         logger.info(
-            "HpuLlama4: applied branch-free attention patches, "
-            "unified %d ChunkedLocalAttention -> Attention",
+            "HpuLlama4: unified %d ChunkedLocalAttention -> Attention",
             unified,
         )
 

--- a/vllm_gaudi/ops/hpu_layernorm.py
+++ b/vllm_gaudi/ops/hpu_layernorm.py
@@ -16,10 +16,10 @@ class HPURMSNorm(RMSNorm):
         HPUFusedRMSNorm = rms_norm()
         if residual is not None:
             orig_shape = x.shape
-            residual = residual + x.view(residual.shape)
+            residual = residual + x.reshape(residual.shape)
             # Note: HPUFusedRMSNorm requires 3D tensors as inputs
             x = HPUFusedRMSNorm.apply(residual, self.weight, self.variance_epsilon)
-            return x.view(orig_shape), residual
+            return x.reshape(orig_shape), residual
 
         x = HPUFusedRMSNorm.apply(x, self.weight, self.variance_epsilon)
         return x
@@ -39,10 +39,10 @@ class HPUGemmaRMSNorm(GemmaRMSNorm):
         gemma_weight = self.weight + 1.0
         if residual is not None:
             orig_shape = x.shape
-            residual = residual + x.view(residual.shape)
+            residual = residual + x.reshape(residual.shape)
             # Note: HPUFusedRMSNorm requires 3D tensors as inputs
             x = HPUFusedRMSNorm.apply(residual, gemma_weight, self.variance_epsilon)
-            return x.view(orig_shape), residual
+            return x.reshape(orig_shape), residual
 
         x = HPUFusedRMSNorm.apply(x, gemma_weight, self.variance_epsilon)
         return x


### PR DESCRIPTION
## Summary

Alternative approach to PR #1391 that fixes Llama4 Maverick FP8 torch.compile **without breaking DeepSeek models**.

## Problem

PR #1391 removed `.view()` calls in HPU layernorm ops and added `seq_len > 1` routing in attention. While this fixed Llama4 Maverick FP8 torch.compile warmup, it broke DeepSeek V2 with:
```
RuntimeError: view size is not compatible with input tensor's size and stride
```
The root cause: DeepSeek MLA produces non-contiguous tensors that `.view()` cannot handle, but simply removing `.view()` breaks symbolic shape handling needed by torch.compile.

## Solution

Three surgical changes:

1. **`vllm_gaudi/ops/hpu_layernorm.py`** — Replace `.view()` with `.reshape()` in both `HPURMSNorm` and `HPUGemmaRMSNorm`. `.reshape()` handles both non-contiguous tensors (DeepSeek MLA) AND symbolic shapes from torch.compile FakeTensor (Llama4 Maverick).

2. **`vllm_gaudi/attention/backends/hpu_attn.py`** — Add `seq_len > 1` routing in `HPUAttentionImpl.forward()` to properly route multi-token sequences during torch.compile warmup. Use `-1` instead of `seq_len_kv` in kv_shape for dynamic shape compatibility.

3. **`vllm_gaudi/models/llama4.py`** — Skip branch-free attention patches as they are incompatible with torch.compile FakeTensor symbolic shape guards.

## Testing

| Test | Result |
|------|--------|
| DeepSeek V2 Lite INC (FP8) | **PASS** — 4/4 prompts correct, exit code 0 |
| Llama4 Maverick 17B-128E FP8 serve | **PASS** — 144 prompt + 90 decode warmup buckets, 0 errors, server started successfully |

### DeepSeek command:
```bash
QUANT_CONFIG=$VLLM_GAUDI_ROOT/tests/models/language/generation/inc_unit_scale_quant.json \
HABANA_VISIBLE_DEVICES=all VLLM_SKIP_WARMUP=true PT_HPU_LAZY_MODE=1 \
python -u tests/full_tests/generate.py --model DeepSeek-V2-Lite-Chat \
  --trust-remote-code --quantization inc --kv_cache_dtype fp8_inc
```

### Llama4 Maverick command:
```bash
QUANT_CONFIG=maxabs_quant_g3.json VLLM_GRAPH_RESERVED_MEM=0.2 \
VLLM_ENGINE_ITERATION_TIMEOUT_S=3600 PT_HPU_LAZY_MODE=0 PT_HPU_WEIGHT_SHARING=0 \
VLLM_USE_V1=1 vllm serve Llama-4-Maverick-17B-128E-Instruct \
  --port 18080 --tensor-parallel-size 8 --max-num-seqs 8 --dtype bfloat16 \
  --max-model-len 131072 --max-num-batched-tokens 8192 --block-size 128 \
  --kv-cache-dtype fp8_inc --enable-expert-parallel --gpu_memory_utilization 0.95 \
  --quantization inc --async_scheduling --no-enable-prefix-caching --trust_remote_code
```

## Related

- Alternative to #1391
- Tested on Gaudi3 (8x HL-325), vllm `v0.19.2rc1.dev17`, vllm-gaudi `v0.20.0rc1.dev17`