### PR TITLE
fix: restore mamba_decode_corrector for hybrid models (GAUDISW-248274)

### DIFF
--- a/vllm_gaudi/extension/bucketing/common.py
+++ b/vllm_gaudi/extension/bucketing/common.py
@@ -414,6 +414,11 @@ def generate_buckets(bs_range,
     def correct_for_max_model_len(bs, query, ctx):
         return (bs, query, min(ctx, bs * math.ceil(max_model_len / block_size)))
 
+    def mamba_decode_corrector(bs, query, ctx):
+        # GAUDISW-248274: cap decode ctx using floor for hybrid Mamba models
+        # to prevent IndexError in input_batch.token_ids_cpu_tensor index_select.
+        return (bs, query, min(ctx, bs * math.floor(max_model_len / block_size)))
+
     def batch_size_smaller_than_blocks(bs, query, ctx):
         if not bs <= ctx:
             omitted_buckets.add(("condition: bs <= ctx, ", "-> bs, query, ctx: ", bs, query, ctx))
@@ -442,6 +447,8 @@ def generate_buckets(bs_range,
         if is_prompt or use_contiguous_pa:
             return no_corrections
         else:
+            if mamba_chunk_size > 0:
+                return mamba_decode_corrector
             return correct_for_max_model_len
 
     def get_max_bucket_per_query(bs, query):


### PR DESCRIPTION
## Summary

Fixes [GAUDISW-248274](https://jira.devtools.intel.com/browse/GAUDISW-248274) — `ibm-granite/granite-4.0-h-small` (hybrid Mamba+Transformer) crashes during decode warmup on `releases/v0.19.0`:

```
File "vllm_gaudi/v1/worker/hpu_model_runner.py", line 3197, in _prepare_inputs
  torch.index_select(self.input_batch.token_ids_cpu_tensor.flatten(), ...)
IndexError: index out of range in self
```

## Root cause

PR #1389 ("Bucketing edge cases finetune for longer ctx") removed the `mamba_decode_corrector` helper and the branch in `get_corrector` that selected it for non-contiguous-PA decode of hybrid Mamba models.

Without that floor-based cap, decode buckets for hybrid models can request more context blocks than `input_batch.token_ids_cpu_tensor` can index, leading to the IndexError above when warmup calls `_prepare_inputs`.

## Fix

Re-add `mamba_decode_corrector` (the original `min(ctx, bs * floor(max_model_len / block_size))` cap) and select it in `get_corrector` when `mamba_chunk_size > 0` and contiguous PA is not in use. For non-Mamba models the behavior is unchanged.

## Validation

Reproduced and verified on `1.24.0-1007` (`docker-local/1.24.0/rhel9.6/habanalabs/vllm-0.19.0-ptupstream-2.10.0:1.24.0-1007`) using the exact serve command from the ticket on `ibm-granite/granite-4.0-h-small`:

- **Before:** crash at decode warmup (same stack trace as the ticket).
- **After:** prompt warmup `100/100` ✅, decode warmup `75/75` ✅, `Application startup complete.` ✅.

## Targeting

Targeting `releases/v0.19.0` for the immediate IBM unblock. A cherry-pick to `main` should follow.
