### PR TITLE
Skip materialised causal attn_bias on FSDPA for non-GDN hybrid models

### DIFF
--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -1099,6 +1099,12 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
                                              and (getattr(hf_text_config, "mamba_chunk_size", None) is not None
                                                   or getattr(hf_text_config, "chunk_size", None) is not None))
 
+        # Non-GDN hybrid: at least one mamba/linear-style layer and zero GDN
+        # (gdn_attention / linear_attention) layers. Used to gate optimizations
+        # that have only been validated on non-GDN hybrid topologies
+        # (e.g. Granite-4 Mamba2+Transformer).
+        self.is_non_gdn_hybrid = (self.num_mamba_like_layers > 0 and self.num_gdn == 0)
+
         # For HPU GDN, use configured chunk size when explicitly provided;
         # otherwise default to 128 to match bucket alignment.
         if self.num_mamba_like_layers > 0:
@@ -3821,9 +3827,24 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
         return None
 
     def set_attn_bias(self, attn_metadata, batch_size, seq_len, device, dtype):
-        if (attn_metadata is None
-                or (self.prefill_use_fusedsdpa and self.is_causal and attn_metadata.block_list is None)
-                or not attn_metadata.is_prompt):
+        if attn_metadata is None or not attn_metadata.is_prompt:
+            return attn_metadata
+
+        # FusedSDPA can handle a purely causal mask natively via
+        # is_causal=True + valid_seq_lengths, including chunked prefill where
+        # block_list is non-None. Skipping the materialised
+        # [bs, 1, q_len, total_kv_len] attn_bias avoids a large add_bf16 on the
+        # attention critical path (significant at long context). The original
+        # short-circuit only covered block_list is None; extend it to all
+        # plain-causal cases (no sliding-window / no chunked-attention / no
+        # alibi / not pooling).
+        # Conservative scope: only non-GDN hybrid models (e.g. Granite-4
+        # Mamba2+Transformer). GDN / pure-transformer / other topologies keep
+        # the materialised bias path until validated.
+        if (self.prefill_use_fusedsdpa and self.is_causal and not self.is_pooling_model
+                and not getattr(self, 'sliding_window', None)
+                and not getattr(self, 'model_has_chunked_attention', False)
+                and getattr(self, 'alibi_slopes', None) is None and self.is_non_gdn_hybrid):
             return attn_metadata
 
         if attn_metadata.attn_bias is not None:
@@ -6621,6 +6642,17 @@ class HPUAttentionMetadataProcessor:
         self.interleaved_sliding_window = (is_interleaved(vllm_config.model_config.hf_text_config)
                                            and self.sliding_window)
 
+        # Detect non-GDN hybrid topologies (e.g. Granite-4 Mamba2+Transformer).
+        # Used to gate the FSDPA-native causal short-circuit in _set_attn_bias.
+        # Mirrors the runner's num_mamba_like_layers / num_gdn computation
+        # (HPUModelRunner.__init__) so the same set of models is targeted.
+        get_num_layers = vllm_config.model_config.get_num_layers_by_block_type
+        parallel_config = vllm_config.parallel_config
+        num_mamba_like = sum(
+            get_num_layers(parallel_config, bt) for bt in ("mamba", "gdn_attention", "linear_attention"))
+        num_gdn = sum(get_num_layers(parallel_config, bt) for bt in ("gdn_attention", "linear_attention"))
+        self.is_non_gdn_hybrid = (num_mamba_like > 0 and num_gdn == 0)
+
         if self.interleaved_sliding_window:
             self.use_window_sdpa = with_default(get_config().PT_HPU_SDPA_QKV_SLICE_MODE_FWD, False)
             #os.getenv("PT_HPU_SDPA_QKV_SLICE_MODE_FWD", "false").strip().lower() in ("1", "true")
@@ -6649,8 +6681,19 @@ class HPUAttentionMetadataProcessor:
         Returns:
             Updated attention metadata with attn_bias set
         """
-        if (attn_metadata is None or (self.prefill_use_fusedsdpa and attn_metadata.block_list is None)
-                or not attn_metadata.is_prompt):
+        if attn_metadata is None or not attn_metadata.is_prompt:
+            return attn_metadata
+
+        # FusedSDPA handles a purely causal mask natively (is_causal=True +
+        # valid_seq_lengths). Skip materialising a [bs, 1, q_len,
+        # total_kv_len] attn_bias when the model is plain-causal (no
+        # sliding-window / chunked-attention). This removes a sizable
+        # add_bf16 from the attention critical path during long-context
+        # chunked prefill. interleaved_sliding_window and chunked-attention
+        # bias paths (window_attn_bias / chunked_attn_bias) are populated
+        # later in process_metadata and used by hpu_attn instead.
+        # Conservative scope: only non-GDN hybrid models (e.g. Granite-4).
+        if (self.prefill_use_fusedsdpa and not self.interleaved_sliding_window and self.is_non_gdn_hybrid):
             return attn_metadata
 
         if attn_metadata.attn_bias is not None:


### PR DESCRIPTION
# Skip materialised causal `attn_bias` on FSDPA for non-GDN hybrid models

## What

Extend the FSDPA-native causal short-circuit in both `HPUModelRunner.set_attn_bias`
and `HPUAttentionMetadataProcessor._set_attn_bias` so the materialised
`[bs, 1, q_len, total_kv_len]` `attn_bias` is no longer built for chunked-prefill
steps (i.e. `block_list is not None`) on non-GDN hybrid topologies (Mamba/SSM +
Transformer).

The previous short-circuit only fired when `block_list is None` (single-shot
prefill); any chunked-prefill step still allocated the bias and ran an
elementwise add against the attention scores. FusedSDPA can encode the same
causal mask natively via `is_causal=True` + `valid_seq_lengths`, so the bias is
pure overhead on the attention critical path — and grows with context length.

## Why

For long-context prefills, the materialised bias and its associated elementwise
add become a significant exposed cost on the attention critical path. There is
also a secondary effect in `vllm_gaudi/extension/ops.py`: when an explicit
`attn_bias` is passed, FSDPA's optimised causal kernel is disabled
(`is_causal=False` fallback). Skipping the bias re-enables the faster causal
kernel.

A general performance improvement is expected on **long-context executions**
(both throughput and TTFT / TPOT). Short-context executions are unaffected
because the bias tensor is small and other ops dominate.

## Scope (conservative)

The optimisation only fires when **all** of the following hold:

- `prefill_use_fusedsdpa` is active
- model is `is_causal` and not pooling
- no `sliding_window`
- no `model_has_chunked_attention`
- no `alibi_slopes`
- model is a **non-GDN hybrid** (`num_mamba_like_layers > 0 and num_gdn == 0`)

The non-GDN hybrid gate reuses the runner's existing `num_mamba_like_layers` /
`num_gdn` counters and re-derives the same flag in the metadata processor via
`model_config.get_num_layers_by_block_type`, exposed as a single
`self.is_non_gdn_hybrid` attribute.

| Model class | Hits short-circuit? |
|---|:---:|
| Mamba/SSM + Transformer hybrids (non-GDN) | yes |
| GDN hybrids | no — `num_gdn > 0` |
| Plain transformer (dense / MoE) | no — `num_mamba_like_layers == 0` |
| Sliding-window models | no — already excluded |
| Chunked-attention models | no — already excluded |
| Pooling / encoder | no — already excluded |
| ALiBi | no — already excluded |

## Files changed

- `vllm_gaudi/v1/worker/hpu_model_runner.py`
  - `HPUModelRunner.__init__`: define `self.is_non_gdn_hybrid` once, reusing
    `self.num_mamba_like_layers` / `self.num_gdn`.
  - `HPUModelRunner.set_attn_bias`: extend the early-return guard to all
    plain-causal cases and gate on `self.is_non_gdn_hybrid`.
  - `HPUAttentionMetadataProcessor.__init__`: compute
    `self.is_non_gdn_hybrid` via `get_num_layers_by_block_type`.
  - `HPUAttentionMetadataProcessor._set_attn_bias`: tighten guard to
    `prefill_use_fusedsdpa and not interleaved_sliding_window and is_non_gdn_hybrid`.

## Risk and validation

- A/B benchmark on a long-context workload of a non-GDN hybrid model showed a
  measurable improvement in throughput and TTFT / TPOT / E2EL, with identical
  input / generated token counts and no failed requests.
- Topologies outside the gate are byte-for-byte unchanged (the early return
  does not fire).
- Recommended follow-ups before broadening the gate to plain-causal
  transformers: accuracy validation (e.g. GSM8K / lm-eval), a sliding-window
  sanity check, and a long-context perplexity check.
