### PR TITLE
Fix the FP8 KV Cache accuracy issue (Minimax-M2.5) by using B2BMatmul only

### DIFF
--- a/vllm_gaudi/attention/backends/hpu_attn.py
+++ b/vllm_gaudi/attention/backends/hpu_attn.py
@@ -238,10 +238,11 @@ class HPUMLAImpl(MLACommonImpl[HPUAttentionMetadata], torch.nn.Module):
         self.softmax = Softmax()
         self.matmul_av = Matmul() if not self.enable_fp8_attn \
             else FP8Matmul()
-        self.batch2block_matmul = B2BMatmul() if not self.enable_fp8_attn \
-            else FP8Matmul()
-        self.block2batch_matmul = B2BMatmul() if not self.enable_fp8_attn \
-            else FP8Matmul()
+        # B2B matmuls are used for softmax rescaling normalization,
+        # not attention computation. They must use bf16 to preserve
+        # precision when summing across many blocks (long sequences).
+        self.batch2block_matmul = B2BMatmul()
+        self.block2batch_matmul = B2BMatmul()
         self.latent_cache_k = VLLMKVCache() if not self.enable_fp8_attn \
             else VLLMFP8KVCache()
         HPUFusedSDPA = kernels.fsdpa()
@@ -443,10 +444,11 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
         self.softmax = Softmax()
         self.matmul_av = Matmul() if not self.enable_fp8_attn \
             else FP8Matmul()
-        self.batch2block_matmul = B2BMatmul() if not self.enable_fp8_attn \
-            else FP8Matmul()
-        self.block2batch_matmul = B2BMatmul() if not self.enable_fp8_attn \
-            else FP8Matmul()
+        # B2B matmuls are used for softmax rescaling normalization,
+        # not attention computation. They must use bf16 to preserve
+        # precision when summing across many blocks (long sequences).
+        self.batch2block_matmul = B2BMatmul()
+        self.block2batch_matmul = B2BMatmul()
         self.k_cache = VLLMKVCache() if not self.enable_fp8_attn \
             else VLLMFP8KVCache()
         self.v_cache = VLLMKVCache(is_v_cache=True) if not self.enable_fp8_attn \


### PR DESCRIPTION
This issue happens when input context length is greater than 20000 tokens

GSM8K on G2D
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9257|±  |0.0072|
|     |       |strict-match    |     5|exact_match|↑  |0.9204|±  |0.0075|
