### PR TITLE
[FIX_FOR_VLLM_CUSTOM=66d1cc0c77628e36df8e5e245c116e6aac3045fb] Fix upstream regressions: MoE PluggableLayer recursion, MLA attention init crashes, KV offload module consolidation

### DIFF
--- a/tests/unit_tests/kv_offload/offloading_connector/test_scheduler.py
+++ b/tests/unit_tests/kv_offload/offloading_connector/test_scheduler.py
@@ -8,7 +8,7 @@ from tests.unit_tests.kv_offload.offloading_connector.utils import (
     generate_store_output, )
 from tests.unit_tests.kv_offload.utils import EOS_TOKEN_ID
 from vllm.distributed.kv_events import BlockRemoved, BlockStored
-from vllm.v1.kv_offload.abstract import OffloadingEvent, OffloadKey, make_offload_key
+from vllm.v1.kv_offload.base import OffloadingEvent, OffloadKey, make_offload_key
 from vllm.v1.request import RequestStatus
 
 

--- a/tests/unit_tests/kv_offload/offloading_connector/utils.py
+++ b/tests/unit_tests/kv_offload/offloading_connector/utils.py
@@ -37,15 +37,15 @@ from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheGroupSpec,
 )
-from vllm.v1.kv_offload.abstract import (
+from vllm.v1.kv_offload.base import (
+    GPULoadStoreSpec,
     LoadStoreSpec,
     OffloadingManager,
+    OffloadingSpec,
     OffloadKey,
     PrepareStoreOutput,
     make_offload_key,
 )
-from vllm.v1.kv_offload.mediums import GPULoadStoreSpec
-from vllm.v1.kv_offload.spec import OffloadingSpec
 from vllm.v1.kv_offload.worker.worker import (
     OffloadingHandler,
     TransferResult,

--- a/vllm_gaudi/attention/oot_mla.py
+++ b/vllm_gaudi/attention/oot_mla.py
@@ -16,12 +16,25 @@ import vllm_gaudi.extension.kernels as kernels
 from vllm.forward_context import ForwardContext, get_forward_context
 
 
+class _DummyPrefillBackend:
+    """No-op MLA prefill backend for HPU (which has its own attention impl)."""
+
+    def __init__(self, **kwargs):
+        pass
+
+
 class HPUMLAAttention(MLAAttention):
 
     scale: float
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        import vllm.model_executor.layers.attention.mla_attention as mla_mod
+        original_get_prefill = mla_mod.get_mla_prefill_backend
+        mla_mod.get_mla_prefill_backend = lambda vllm_config: _DummyPrefillBackend
+        try:
+            super().__init__(*args, **kwargs)
+        finally:
+            mla_mod.get_mla_prefill_backend = original_get_prefill
         self.enable_fp8_attn = self.kv_cache_dtype == 'fp8_inc' and os.environ.get('QUANT_CONFIG', None) is None
         self.scale = float(self.scale)
         self.matmul_qk = Matmul() if not self.enable_fp8_attn \

--- a/vllm_gaudi/attention/oot_mla.py
+++ b/vllm_gaudi/attention/oot_mla.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import torch
+import torch.nn as nn
 import os
 
 from vllm.config import get_current_vllm_config
@@ -223,21 +224,39 @@ class HPUMultiHeadLatentAttentionWrapper(MultiHeadLatentAttentionWrapper):
         prefix: str = "",
         skip_topk: bool = False,
     ) -> None:
-        super().__init__(
-            hidden_size=hidden_size,
-            num_heads=num_heads,
-            scale=scale,
-            qk_nope_head_dim=qk_nope_head_dim,
-            qk_rope_head_dim=qk_rope_head_dim,
-            v_head_dim=v_head_dim,
-            q_lora_rank=q_lora_rank,
-            kv_lora_rank=kv_lora_rank,
-            mla_modules=mla_modules,
-            cache_config=cache_config,
-            quant_config=quant_config,
-            prefix=prefix,
-            skip_topk=skip_topk,
-        )
+        # Skip MultiHeadLatentAttentionWrapper.__init__() because it creates
+        # MLAAttention → FlashAttnPrefillBackend which crashes on HPU.
+        # Instead, inline the field assignments and create HPUMLAAttention.
+        nn.Module.__init__(self)
+        self.hidden_size = hidden_size
+        self.qk_nope_head_dim = qk_nope_head_dim
+        self.qk_rope_head_dim = qk_rope_head_dim
+        self.qk_head_dim = qk_nope_head_dim + qk_rope_head_dim
+        self.v_head_dim = v_head_dim
+        self.q_lora_rank = q_lora_rank
+        self.kv_lora_rank = kv_lora_rank
+        self.num_heads = num_heads
+        self.fused_qkv_a_proj = mla_modules.fused_qkv_a_proj
+        self.kv_a_proj_with_mqa = mla_modules.kv_a_proj_with_mqa
+        self.q_a_layernorm = mla_modules.q_a_layernorm
+        self.q_b_proj = mla_modules.q_b_proj
+        self.q_proj = mla_modules.q_proj
+        self.kv_a_layernorm = mla_modules.kv_a_layernorm
+        self.kv_b_proj = mla_modules.kv_b_proj
+        self.rotary_emb = mla_modules.rotary_emb
+        self.o_proj = mla_modules.o_proj
+        self.indexer = mla_modules.indexer
+        self.indexer_rope_emb = mla_modules.indexer_rotary_emb
+        self.is_sparse = mla_modules.is_sparse
+
+        self.skip_topk = skip_topk
+        if self.indexer is not None:
+            assert hasattr(self.indexer, "topk_tokens")
+            self.topk_tokens = self.indexer.topk_tokens
+            self.topk_indices_buffer = mla_modules.topk_indices_buffer
+
+        self.prefix = prefix
+
         layer_name = f"{prefix}.attn"
         static_ctx = get_current_vllm_config().compilation_config.static_forward_context
         static_ctx.pop(layer_name, None)

--- a/vllm_gaudi/attention/oot_mla.py
+++ b/vllm_gaudi/attention/oot_mla.py
@@ -221,6 +221,7 @@ class HPUMultiHeadLatentAttentionWrapper(MultiHeadLatentAttentionWrapper):
         cache_config=None,
         quant_config=None,
         prefix: str = "",
+        skip_topk: bool = False,
     ) -> None:
         super().__init__(
             hidden_size=hidden_size,
@@ -235,6 +236,7 @@ class HPUMultiHeadLatentAttentionWrapper(MultiHeadLatentAttentionWrapper):
             cache_config=cache_config,
             quant_config=quant_config,
             prefix=prefix,
+            skip_topk=skip_topk,
         )
         layer_name = f"{prefix}.attn"
         static_ctx = get_current_vllm_config().compilation_config.static_forward_context

--- a/vllm_gaudi/ops/hpu_fused_moe.py
+++ b/vllm_gaudi/ops/hpu_fused_moe.py
@@ -547,7 +547,7 @@ _orig_fused_moe_init = FusedMoE.__init__
 def _hpu_fused_moe_init(self, *args, **kwargs):
     _orig_fused_moe_init(self, *args, **kwargs)
     if hasattr(self, 'runner'):
-        self.runner._hpu_layer_ref = self
+        object.__setattr__(self.runner, '_hpu_layer_ref', self)
 
 
 FusedMoE.__init__ = _hpu_fused_moe_init

--- a/vllm_gaudi/v1/kv_offload/worker/cpu_hpu.py
+++ b/vllm_gaudi/v1/kv_offload/worker/cpu_hpu.py
@@ -10,20 +10,24 @@ from collections.abc import Iterator
 from vllm.logger import init_logger
 from vllm.utils.platform_utils import is_pin_memory_available
 from vllm.v1.kv_cache_interface import AttentionSpec, UniformTypeKVCacheSpecs
-from vllm.v1.kv_offload.mediums import BlockIDsLoadStoreSpec
-from vllm.v1.kv_offload.spec import (
+from vllm.v1.kv_offload.base import (
+    BlockIDsLoadStoreSpec,
     CanonicalKVCacheRef,
     CanonicalKVCaches,
     CanonicalKVCacheTensor,
+    GPULoadStoreSpec,
+    LoadStoreSpec,
 )
+from vllm.v1.kv_offload.cpu.common import CPULoadStoreSpec
+from vllm.v1.kv_offload.cpu.gpu_worker import (
+    CpuGpuOffloadingHandlers,
+    SingleDirectionOffloadingHandler,
+)
+from vllm.v1.kv_offload.cpu.spec import CPUOffloadingSpec
 from vllm.v1.kv_offload.worker.worker import (
     OffloadingHandler,
     TransferSpec,
 )
-from vllm.v1.kv_offload.cpu.spec import CPUOffloadingSpec
-from vllm.v1.kv_offload.abstract import LoadStoreSpec
-from vllm.v1.kv_offload.mediums import CPULoadStoreSpec, GPULoadStoreSpec
-from vllm.v1.kv_offload.worker.cpu_gpu import (SingleDirectionOffloadingHandler, CpuGpuOffloadingHandlers)
 from vllm.distributed.kv_transfer.kv_connector.v1.offloading.worker import OffloadingConnectorWorker
 
 logger = init_logger(__name__)


### PR DESCRIPTION
## Summary

Fix two upstream regressions that break HPU unit tests at vLLM commit `66d1cc0c77`.

### 1. MoE RecursionError on `.to("hpu")`

**Upstream regression:** https://github.com/vllm-project/vllm/pull/35178

PR #35178 made `MoERunnerInterface` inherit from `PluggableLayer(nn.Module)`. This caused
vllm-gaudi's `_hpu_layer_ref` back-reference (stored on the runner to bypass ForwardContext
graph breaks) to create a circular `nn.Module` hierarchy:
`FusedMoE → runner (now nn.Module) → _hpu_layer_ref → FusedMoE`.
PyTorch's `Module._apply()` (called by `.to()`) recurses infinitely through this cycle.

**Fix:** Use `object.__setattr__()` to store the reference as a plain Python attribute,
invisible to `nn.Module._apply()` traversal.

**Affected tests:**
- `test_unquantized_fused_moe_method`
- `test_compressed_tensors_wna16_moe_method`
- `test_compressed_tensors_w8a8fp8_block_moe_method`

### 2. KV offload import errors after module consolidation

**Upstream regression:** https://github.com/vllm-project/vllm/pull/40538

PR #40538 reorganized the `vllm.v1.kv_offload` package — `abstract.py` was renamed to
`base.py`, `mediums.py` classes were moved into `base.py`, `spec.py` was consolidated,
and `worker/cpu_gpu.py` was moved to `cpu/gpu_worker.py`.

**Fix:** Update all import paths in vllm-gaudi to match the new module layout.

**Affected files:**
- `vllm_gaudi/v1/kv_offload/worker/cpu_hpu.py`
- `tests/unit_tests/kv_offload/offloading_connector/test_scheduler.py`
- `tests/unit_tests/kv_offload/offloading_connector/utils.py`

### 3. MLA `skip_topk` parameter missing from HPU wrapper

**Upstream regression:** https://github.com/vllm-project/vllm/pull/37735

PR #37735 added a `skip_topk: bool` parameter to `MultiHeadLatentAttentionWrapper.__init__()`.
The HPU wrapper `HPUMultiHeadLatentAttentionWrapper` did not accept this parameter, causing
`TypeError: __init__() got an unexpected keyword argument 'skip_topk'`.

**Fix:** Add `skip_topk: bool = False` parameter and the associated conditional initialization
(`self.topk_tokens`, `self.topk_indices_buffer`) matching upstream behavior.

**Affected file:**
- `vllm_gaudi/attention/oot_mla.py`

### 4. MLA FlashAttnPrefillBackend assertion on HPU

**Upstream regression:** https://github.com/vllm-project/vllm/pull/32623

PR #32623 introduced `FlashAttnPrefillBackend` as a mandatory prefill backend in
`MLAAttention.__init__()`. This backend requires `flash_attn_varlen_func`, which is not
available on HPU, causing `AssertionError` during model initialization.

The crash occurs in two code paths:
1. `HPUMultiHeadLatentAttentionWrapper.__init__()` → `super().__init__()` → `MLAAttention()`
2. `HPUMLAAttention.__init__()` → `super().__init__()` → `MLAAttention.__init__()`

**Fix:**
1. In `HPUMultiHeadLatentAttentionWrapper`: bypass `super().__init__()` entirely, inline all
   parent field assignments from `MultiHeadLatentAttentionWrapper`, and create `HPUMLAAttention`
   directly instead of `MLAAttention`.
2. In `HPUMLAAttention`: temporarily monkey-patch `get_mla_prefill_backend` to return a no-op
   `_DummyPrefillBackend` during `super().__init__()`, restoring the original in a `try/finally`.
   HPU uses its own attention implementation (FusedSDPA) and never invokes the prefill backend.

**Affected file:**
- `vllm_gaudi/attention/oot_mla.py`