### PR TITLE
Add few v0.19.0 single-process examples

### DIFF
--- a/gaudi3Benchmarks/1.24.0/v0.19.0/single-process_models_swap/meta-llama_llama-guard-4-12b_w_ibm-granite_granite-guardian-3.3/pt_vllm_0_meta-llama_llama-guard-4-12b_ibm_granite_granite-guardian-3.3.sh
+++ b/gaudi3Benchmarks/1.24.0/v0.19.0/single-process_models_swap/meta-llama_llama-guard-4-12b_w_ibm-granite_granite-guardian-3.3/pt_vllm_0_meta-llama_llama-guard-4-12b_ibm_granite_granite-guardian-3.3.sh
@@ -36,9 +36,9 @@ models:
     enable_prefix_caching: False
     gpu_memory_utilization: 0.90
     override_generation_config:
-     temperature: 0.0
-     top_p: 1.0
-     max_new_tokens: 512
+      temperature: 0.0
+      top_p: 1.0
+      max_new_tokens: 512
 EOF
 
 VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \

--- a/gaudi3Benchmarks/1.24.0/v0.19.0/single-process_models_swap/meta-llama_llama-guard-4-12b_w_ibm-granite_granite-guardian-3.3/pt_vllm_0_meta-llama_llama-guard-4-12b_ibm_granite_granite-guardian-3.3.sh
+++ b/gaudi3Benchmarks/1.24.0/v0.19.0/single-process_models_swap/meta-llama_llama-guard-4-12b_w_ibm-granite_granite-guardian-3.3/pt_vllm_0_meta-llama_llama-guard-4-12b_ibm_granite_granite-guardian-3.3.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+set -e
+
+# =========================
+# SERVER CONFIG
+# =========================
+
+export VLLM_HPU_MULTI_MODEL_CONFIG=multi_models.yaml && \
+cat > "$VLLM_HPU_MULTI_MODEL_CONFIG" << 'EOF'
+default_model: meta-llama/Llama-Guard-4-12B
+models:
+  meta-llama/Llama-Guard-4-12B:
+    model: meta-llama/Llama-Guard-4-12B
+    tensor_parallel_size: 1
+    max_num_seqs: 4
+    dtype: bfloat16
+    block_size: 128
+    max_model_len: 131072
+    async_scheduling: True
+    enable_prefix_caching: False
+    gpu_memory_utilization: 0.95
+    max_num_batched_tokens: 8192
+    override_generation_config:
+      temperature: 0.0
+      top_p: 1.0
+      max_new_tokens: 20
+  
+  ibm-granite/granite-guardian-3.3-8b:
+    model: ibm-granite/granite-guardian-3.3-8b
+    tensor_parallel_size: 1
+    max_num_seqs: 4
+    dtype: bfloat16
+    block_size: 128
+    max_model_len: 131072
+    async_scheduling: True
+    enable_prefix_caching: False
+    gpu_memory_utilization: 0.90
+    override_generation_config:
+     temperature: 0.0
+     top_p: 1.0
+     max_new_tokens: 512
+EOF
+
+VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
+VLLM_ENGINE_ITERATION_TIMEOUT_S=3600 \
+VLLM_RPC_TIMEOUT=100000 \
+VLLM_EXPONENTIAL_BUCKETING=true \
+PT_HPU_ENABLE_LAZY_COLLECTIVES=true \
+FUSER_ENABLE_LOW_UTILIZATION=true \
+ENABLE_FUSION_BEFORE_NORM=true \
+PT_HPU_LAZY_MODE=0 \
+VLLM_USE_V1=1 \
+VLLM_CONTIGUOUS_PA=true \
+VLLM_DEFRAG=true \
+VLLM_FUSED_BLOCK_SOFTMAX=true \
+VLLM_WEIGHT_LOAD_FORCE_SYNC=1 \
+PT_HPU_WEIGHT_SHARING=0 \
+VLLM_GRAPH_RESERVED_MEM=0.3 \
+VLLM_SERVER_DEV_MODE=1 \
+VLLM_ALLOW_INSECURE_SERIALIZATION=1 \
+VLLM_HPU_MULTI_MODEL_CONFIG=multi_models.yaml \
+python -m vllm_gaudi.entrypoints.openai.multi_model_api_server \
+    --port 8090 \
+    --disable-log-stats \
+    --trust-remote-code
+	
+
+
+# =========================
+# BENCHMARK COMMAND - Model 1
+# =========================
+
+PYTHONUNBUFFERED=1 vllm bench serve \
+    --model meta-llama/Llama-Guard-4-12B \
+    --dataset-name custom \
+    --dataset-path /tmp/aegis-benchmark.jsonl \
+    --base-url http://localhost:8090 \
+    --num-prompts 40 \
+    --max-concurrency 4 \
+    --request-rate inf \
+    --port 8090 \
+    --percentile-metrics ttft,tpot,itl,e2el \
+    --metric-percentiles 50,90,95,99 \
+    --save-result \
+    --save-detailed \
+    --temperature 0 \
+    --trust-remote-code
+
+# =========================
+# ONLINE SWAP COMMAND 
+# =========================
+curl -s http://localhost:8090/v1/models/switch \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "ibm-granite/granite-guardian-3.3-8b",
+    "drain_timeout": 60
+  }' | jq
+
+# =========================
+# BENCHMARK COMMAND - Model 2
+# =========================
+
+PYTHONUNBUFFERED=1 vllm bench serve \
+    --model ibm-granite/granite-guardian-3.3-8b \
+    --dataset-name custom \
+    --dataset-path /tmp/aegis-benchmark-granite-guardian-3.3-8b.jsonl \
+    --base-url http://localhost:8090 \
+    --num-prompts 40 \
+    --max-concurrency 4 \
+    --request-rate inf \
+    --port 8090 \
+    --percentile-metrics ttft,tpot,itl,e2el \
+    --metric-percentiles 50,90,95,99 \
+    --save-result \
+    --save-detailed \
+    --temperature 0 \
+    --trust-remote-code

--- a/gaudi3Benchmarks/1.24.0/v0.19.0/single-process_models_swap/meta-llama_llama-guard-4-12b_w_ibm-granite_granite-guardian-3.3/pt_vllm_1_meta-llama_llama-guard-4-12b_ibm_granite_granite-guardian-3.3.sh
+++ b/gaudi3Benchmarks/1.24.0/v0.19.0/single-process_models_swap/meta-llama_llama-guard-4-12b_w_ibm-granite_granite-guardian-3.3/pt_vllm_1_meta-llama_llama-guard-4-12b_ibm_granite_granite-guardian-3.3.sh
@@ -36,9 +36,9 @@ models:
     enable_prefix_caching: False
     gpu_memory_utilization: 0.90
     override_generation_config:
-     temperature: 0.0
-     top_p: 1.0
-     max_new_tokens: 512
+      temperature: 0.0
+      top_p: 1.0
+      max_new_tokens: 512
 EOF
 
 VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \

--- a/gaudi3Benchmarks/1.24.0/v0.19.0/single-process_models_swap/meta-llama_llama-guard-4-12b_w_ibm-granite_granite-guardian-3.3/pt_vllm_1_meta-llama_llama-guard-4-12b_ibm_granite_granite-guardian-3.3.sh
+++ b/gaudi3Benchmarks/1.24.0/v0.19.0/single-process_models_swap/meta-llama_llama-guard-4-12b_w_ibm-granite_granite-guardian-3.3/pt_vllm_1_meta-llama_llama-guard-4-12b_ibm_granite_granite-guardian-3.3.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+set -e
+
+# =========================
+# SERVER CONFIG
+# =========================
+
+export VLLM_HPU_MULTI_MODEL_CONFIG=multi_models.yaml && \
+cat > "$VLLM_HPU_MULTI_MODEL_CONFIG" << 'EOF'
+default_model: meta-llama/Llama-Guard-4-12B
+models:
+  meta-llama/Llama-Guard-4-12B:
+    model: meta-llama/Llama-Guard-4-12B
+    tensor_parallel_size: 1
+    max_num_seqs: 4
+    dtype: bfloat16
+    block_size: 128
+    max_model_len: 131072
+    async_scheduling: True
+    enable_prefix_caching: False
+    gpu_memory_utilization: 0.95
+    max_num_batched_tokens: 8192
+    override_generation_config:
+      temperature: 0.0
+      top_p: 1.0
+      max_new_tokens: 20
+  
+  ibm-granite/granite-guardian-3.3-8b:
+    model: ibm-granite/granite-guardian-3.3-8b
+    tensor_parallel_size: 1
+    max_num_seqs: 4
+    dtype: bfloat16
+    block_size: 128
+    max_model_len: 131072
+    async_scheduling: True
+    enable_prefix_caching: False
+    gpu_memory_utilization: 0.90
+    override_generation_config:
+     temperature: 0.0
+     top_p: 1.0
+     max_new_tokens: 512
+EOF
+
+VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
+VLLM_ENGINE_ITERATION_TIMEOUT_S=3600 \
+VLLM_RPC_TIMEOUT=100000 \
+VLLM_EXPONENTIAL_BUCKETING=true \
+PT_HPU_ENABLE_LAZY_COLLECTIVES=true \
+FUSER_ENABLE_LOW_UTILIZATION=true \
+ENABLE_FUSION_BEFORE_NORM=true \
+PT_HPU_LAZY_MODE=0 \
+VLLM_USE_V1=1 \
+VLLM_CONTIGUOUS_PA=true \
+VLLM_DEFRAG=true \
+VLLM_FUSED_BLOCK_SOFTMAX=true \
+VLLM_WEIGHT_LOAD_FORCE_SYNC=1 \
+PT_HPU_WEIGHT_SHARING=0 \
+VLLM_GRAPH_RESERVED_MEM=0.3 \
+VLLM_SERVER_DEV_MODE=1 \
+VLLM_ALLOW_INSECURE_SERIALIZATION=1 \
+VLLM_HPU_MULTI_MODEL_CONFIG=multi_models.yaml \
+python -m vllm_gaudi.entrypoints.openai.multi_model_api_server \
+    --port 8090 \
+    --disable-log-stats \
+    --trust-remote-code
+	
+
+
+# =========================
+# BENCHMARK COMMAND - Model 1
+# =========================
+
+PYTHONUNBUFFERED=1 vllm bench serve \
+    --model meta-llama/Llama-Guard-4-12B \
+    --dataset-name custom \
+    --dataset-path /tmp/aegis-benchmark.jsonl \
+    --base-url http://localhost:8090 \
+    --num-prompts 40 \
+    --max-concurrency 4 \
+    --request-rate inf \
+    --port 8090 \
+    --percentile-metrics ttft,tpot,itl,e2el \
+    --metric-percentiles 50,90,95,99 \
+    --save-result \
+    --save-detailed \
+    --temperature 0 \
+    --skip-chat-template \
+    --trust-remote-code
+
+# =========================
+# ONLINE SWAP COMMAND 
+# =========================
+curl -s http://localhost:8090/v1/models/switch \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "ibm-granite/granite-guardian-3.3-8b",
+    "drain_timeout": 60
+  }' | jq
+
+# =========================
+# BENCHMARK COMMAND - Model 2
+# =========================
+
+PYTHONUNBUFFERED=1 vllm bench serve \
+    --model ibm-granite/granite-guardian-3.3-8b \
+    --dataset-name custom \
+    --dataset-path /tmp/aegis-benchmark-granite-guardian-3.3-8b.jsonl \
+    --base-url http://localhost:8090 \
+    --num-prompts 40 \
+    --max-concurrency 4 \
+    --request-rate inf \
+    --port 8090 \
+    --percentile-metrics ttft,tpot,itl,e2el \
+    --metric-percentiles 50,90,95,99 \
+    --save-result \
+    --save-detailed \
+    --temperature 0 \
+    --trust-remote-code

--- a/gaudi3Benchmarks/1.24.0/v0.19.0/single-process_models_swap/meta-llama_llama-guard-4-12b_w_ibm-granite_granite-guardian-3.3/pt_vllm_2_meta-llama_llama-guard-4-12b_ibm_granite_granite-guardian-3.3.sh
+++ b/gaudi3Benchmarks/1.24.0/v0.19.0/single-process_models_swap/meta-llama_llama-guard-4-12b_w_ibm-granite_granite-guardian-3.3/pt_vllm_2_meta-llama_llama-guard-4-12b_ibm_granite_granite-guardian-3.3.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+set -e
+
+# =========================
+# SERVER CONFIG
+# =========================
+
+export VLLM_HPU_MULTI_MODEL_CONFIG=multi_models.yaml && \
+cat > "$VLLM_HPU_MULTI_MODEL_CONFIG" << 'EOF'
+default_model: meta-llama/Llama-Guard-4-12B
+models:
+  meta-llama/Llama-Guard-4-12B:
+    model: meta-llama/Llama-Guard-4-12B
+    tensor_parallel_size: 1
+    max_num_seqs: 256
+    dtype: bfloat16
+    block_size: 128
+    max_model_len: 131072
+    async_scheduling: True
+    enable_prefix_caching: False
+    gpu_memory_utilization: 0.95
+    max_num_batched_tokens: 8192
+  
+  ibm-granite/granite-guardian-3.3-8b:
+    model: ibm-granite/granite-guardian-3.3-8b
+    tensor_parallel_size: 1
+    max_num_seqs: 4
+    dtype: bfloat16
+    block_size: 128
+    max_model_len: 131072
+    async_scheduling: True
+    enable_prefix_caching: False
+    gpu_memory_utilization: 0.90
+    override_generation_config:
+     temperature: 0.0
+     top_p: 1.0
+     max_new_tokens: 512
+EOF
+
+VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
+VLLM_ENGINE_ITERATION_TIMEOUT_S=3600 \
+VLLM_RPC_TIMEOUT=100000 \
+VLLM_EXPONENTIAL_BUCKETING=true \
+PT_HPU_ENABLE_LAZY_COLLECTIVES=true \
+FUSER_ENABLE_LOW_UTILIZATION=true \
+ENABLE_FUSION_BEFORE_NORM=true \
+PT_HPU_LAZY_MODE=0 \
+VLLM_USE_V1=1 \
+VLLM_CONTIGUOUS_PA=true \
+VLLM_DEFRAG=true \
+VLLM_FUSED_BLOCK_SOFTMAX=true \
+VLLM_WEIGHT_LOAD_FORCE_SYNC=1 \
+PT_HPU_WEIGHT_SHARING=0 \
+VLLM_GRAPH_RESERVED_MEM=0.3 \
+VLLM_SERVER_DEV_MODE=1 \
+VLLM_ALLOW_INSECURE_SERIALIZATION=1 \
+VLLM_HPU_MULTI_MODEL_CONFIG=multi_models.yaml \
+python -m vllm_gaudi.entrypoints.openai.multi_model_api_server \
+    --port 8130 \
+    --disable-log-stats \
+    --trust-remote-code
+	
+
+
+# =========================
+# BENCHMARK COMMAND - Model 1
+# =========================
+
+PYTHONUNBUFFERED=1 vllm bench serve \
+    --model meta-llama/Llama-Guard-4-12B \
+    --dataset-name random \
+    --num-prompts 1280 \
+    --max-concurrency 256 \
+    --request-rate inf \
+    --random-input-len 4096 \
+    --random-output-len 1024 \
+    --port 8130 \
+    --percentile-metrics ttft,tpot,itl,e2el \
+    --metric-percentiles 50,90,95,99 \
+    --ready-check-timeout-sec 600 \
+    --ignore-eos \
+    --trust-remote-code
+
+# =========================
+# ONLINE SWAP COMMAND 
+# =========================
+curl -s http://localhost:8130/v1/models/switch \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "ibm-granite/granite-guardian-3.3-8b",
+    "drain_timeout": 60
+  }' | jq
+
+# =========================
+# BENCHMARK COMMAND - Model 2
+# =========================
+
+PYTHONUNBUFFERED=1 vllm bench serve \
+    --model ibm-granite/granite-guardian-3.3-8b \
+    --dataset-name custom \
+    --dataset-path /tmp/aegis-benchmark-granite-guardian-3.3-8b.jsonl \
+    --base-url http://localhost:8130 \
+    --num-prompts 40 \
+    --max-concurrency 4 \
+    --request-rate inf \
+    --port 8130 \
+    --percentile-metrics ttft,tpot,itl,e2el \
+    --metric-percentiles 50,90,95,99 \
+    --save-result \
+    --save-detailed \
+    --temperature 0 \
+    --trust-remote-code

--- a/gaudi3Benchmarks/1.24.0/v0.19.0/single-process_models_swap/meta-llama_llama-guard-4-12b_w_ibm-granite_granite-guardian-3.3/pt_vllm_2_meta-llama_llama-guard-4-12b_ibm_granite_granite-guardian-3.3.sh
+++ b/gaudi3Benchmarks/1.24.0/v0.19.0/single-process_models_swap/meta-llama_llama-guard-4-12b_w_ibm-granite_granite-guardian-3.3/pt_vllm_2_meta-llama_llama-guard-4-12b_ibm_granite_granite-guardian-3.3.sh
@@ -32,9 +32,9 @@ models:
     enable_prefix_caching: False
     gpu_memory_utilization: 0.90
     override_generation_config:
-     temperature: 0.0
-     top_p: 1.0
-     max_new_tokens: 512
+      temperature: 0.0
+      top_p: 1.0
+      max_new_tokens: 512
 EOF
 
 VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \

--- a/gaudi3Benchmarks/1.24.0/v0.19.0/single-process_models_swap/qwen3-vl-32b-instruct-fp8_w_qwen3-vl-32b-thinking-fp8/pt_vllm_0_qwen-qwen3-vl-32b-instruct-fp8_qwen-qwen3-vl-32b-thinking-fp8.sh
+++ b/gaudi3Benchmarks/1.24.0/v0.19.0/single-process_models_swap/qwen3-vl-32b-instruct-fp8_w_qwen3-vl-32b-thinking-fp8/pt_vllm_0_qwen-qwen3-vl-32b-instruct-fp8_qwen-qwen3-vl-32b-thinking-fp8.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+set -e
+
+# =========================
+# SERVER CONFIG
+# =========================
+
+export VLLM_HPU_MULTI_MODEL_CONFIG=multi_models.yaml && \
+cat > "$VLLM_HPU_MULTI_MODEL_CONFIG" << 'EOF'
+default_model: Qwen/Qwen3-VL-32B-Instruct-FP8
+models:
+  Qwen/Qwen3-VL-32B-Instruct-FP8:
+    model: Qwen/Qwen3-VL-32B-Instruct-FP8
+    tensor_parallel_size: 1
+    max_num_seqs: 8
+    dtype: bfloat16
+    block_size: 128
+    max_model_len: 32768
+    async_scheduling: True
+    enable_prefix_caching: False
+    gpu_memory_utilization: 0.65
+    max_num_batched_tokens: 32768
+    limit_mm_per_prompt:
+      image:
+        count: 20
+        width: 864
+        height: 480
+    enable_chunked_prefill: False
+
+  Qwen/Qwen3-VL-32B-Thinking-FP8:
+    model: Qwen/Qwen3-VL-32B-Thinking-FP8
+    tensor_parallel_size: 1
+    max_num_seqs: 8
+    dtype: bfloat16
+    block_size: 128
+    max_model_len: 32768
+    async_scheduling: True
+    enable_prefix_caching: False
+    gpu_memory_utilization: 0.65
+    reasoning_parser: qwen3
+    max_num_batched_tokens: 32768
+    limit_mm_per_prompt:
+      image:
+        count: 20
+        width: 864
+        height: 480 
+    enable_chunked_prefill: False
+EOF
+
+VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
+VLLM_ENGINE_ITERATION_TIMEOUT_S=3600 \
+VLLM_RPC_TIMEOUT=100000 \
+VLLM_EXPONENTIAL_BUCKETING=true \
+PT_HPU_ENABLE_LAZY_COLLECTIVES=true \
+FUSER_ENABLE_LOW_UTILIZATION=true \
+ENABLE_FUSION_BEFORE_NORM=true \
+PT_HPU_LAZY_MODE=0 \
+VLLM_USE_V1=1 \
+VLLM_CONTIGUOUS_PA=true \
+VLLM_DEFRAG=true \
+VLLM_FUSED_BLOCK_SOFTMAX=true \
+VLLM_DELAYED_SAMPLING=true \
+VLLM_FUSED_BLOCK_SOFTMAX_ADJUSTMENT=False \
+EXPERIMENTAL_WEIGHT_SHARING=0 \
+VLLM_SKIP_WARMUP=false \
+VLLM_GRAPH_PROMPT_RATIO=0.3 \
+VLLM_SERVER_DEV_MODE=1 \
+VLLM_ALLOW_INSECURE_SERIALIZATION=1 \
+VLLM_HPU_MULTI_MODEL_CONFIG=multi_models.yaml \
+python -m vllm_gaudi.entrypoints.openai.multi_model_api_server \
+    --port 8220 \ 
+    --disable-log-stats \
+    --trust-remote-code
+
+# =============================
+# BENCHMARK COMMAND - Model 1
+# =============================
+
+PYTHONUNBUFFERED=1 vllm bench serve \
+    --model Qwen/Qwen3-VL-32B-Instruct-FP8 \
+    --dataset-name random-mm \
+    --base-url http://localhost:8220 \
+    --num-prompts 20 \
+    --max-concurrency 8 \
+    --request-rate inf \
+    --random-input-len 6300 \
+    --random-output-len 380 \
+    --endpoint /v1/chat/completions \
+    --port 8220 \
+    --percentile-metrics ttft,tpot,itl,e2el \
+    --metric-percentiles 50,90,95,99 \
+    --ready-check-timeout-sec 600 \
+    --backend openai-chat \
+    --tokenizer Qwen/Qwen3-VL-32B-Instruct-FP8 \
+    --random-mm-base-items-per-request 20 \
+    --random-mm-bucket-config "{(480, 864, 1): 1.0}" \
+    --random-mm-num-mm-items-range-ratio 0.0 \
+    --ignore-eos \
+    --trust-remote-code
+
+# =========================
+# ONLINE SWAP COMMAND 
+# =========================
+curl -s http://localhost:8220/v1/models/switch \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen3-VL-32B-Thinking-FP8",
+    "drain_timeout": 60
+  }' | jq
+  
+# =========================
+# BENCHMARK COMMAND - Model 2
+# =========================
+
+PYTHONUNBUFFERED=1 vllm bench serve \
+    --model Qwen/Qwen3-VL-32B-Thinking-FP8 \
+    --dataset-name random-mm \
+    --base-url http://localhost:8220 \
+    --num-prompts 20 \
+    --max-concurrency 8 \
+    --request-rate inf \
+    --random-input-len 6300 \
+    --random-output-len 380 \
+    --endpoint /v1/chat/completions \
+    --port 8220 \
+    --percentile-metrics ttft,tpot,itl,e2el \
+    --metric-percentiles 50,90,95,99 \
+    --ready-check-timeout-sec 600 \
+    --backend openai-chat \
+    --tokenizer Qwen/Qwen3-VL-32B-Thinking-FP8 \
+    --random-mm-base-items-per-request 20 \
+    --random-mm-bucket-config "{(480, 864, 1): 1.0}" \
+    --random-mm-num-mm-items-range-ratio 0.0 \
+    --ignore-eos \
+    --trust-remote-code

--- a/gaudi3Benchmarks/1.24.0/v0.19.0/single-process_models_swap/qwen3-vl-32b-instruct-fp8_w_qwen3-vl-32b-thinking-fp8/pt_vllm_0_qwen-qwen3-vl-32b-instruct-fp8_qwen-qwen3-vl-32b-thinking-fp8.sh
+++ b/gaudi3Benchmarks/1.24.0/v0.19.0/single-process_models_swap/qwen3-vl-32b-instruct-fp8_w_qwen3-vl-32b-thinking-fp8/pt_vllm_0_qwen-qwen3-vl-32b-instruct-fp8_qwen-qwen3-vl-32b-thinking-fp8.sh
@@ -68,10 +68,54 @@ VLLM_SERVER_DEV_MODE=1 \
 VLLM_ALLOW_INSECURE_SERIALIZATION=1 \
 VLLM_HPU_MULTI_MODEL_CONFIG=multi_models.yaml \
 python -m vllm_gaudi.entrypoints.openai.multi_model_api_server \
-    --port 8220 \ 
-    --disable-log-stats \
-    --trust-remote-code
+	--port 8220 \
+	--enable-auto-tool-choice \
+	--tool-call-parser \
+	hermes \
+	--disable-log-stats \
+	--trust-remote-code
 
+# ====================================
+# TOOL VALIDATION CURL ONLY - Model 1
+# ====================================
+
+cat > /tmp/tool_probe_8220.json <<'JSON'
+{
+  "model": "Qwen/Qwen3-VL-32B-Instruct-FP8",
+  "messages": [
+    {
+      "role": "user",
+      "content": "What is 2+2? Use the tool and return the final answer."
+    }
+  ],
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "name": "add",
+        "description": "Add two numbers",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "a": {"type": "number"},
+            "b": {"type": "number"}
+          },
+          "required": ["a", "b"]
+        }
+      }
+    }
+  ],
+  "tool_choice": "auto",
+  "temperature": 0,
+  "max_tokens": 256,
+  "logprobs": true
+}
+JSON
+
+curl -sS http://localhost:8220/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  --data @/tmp/tool_probe_8220.json
+  
 # =============================
 # BENCHMARK COMMAND - Model 1
 # =============================
@@ -107,6 +151,47 @@ curl -s http://localhost:8220/v1/models/switch \
     "model": "Qwen/Qwen3-VL-32B-Thinking-FP8",
     "drain_timeout": 60
   }' | jq
+ 
+# ====================================
+# TOOL VALIDATION CURL ONLY - Model 2
+# ====================================
+
+cat > /tmp/tool_probe_8220_bis.json <<'JSON'
+{
+  "model": "Qwen/Qwen3-VL-32B-Thinking-FP8",
+  "messages": [
+    {
+      "role": "user",
+      "content": "What is 2+2? Use the tool and return the final answer."
+    }
+  ],
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "name": "add",
+        "description": "Add two numbers",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "a": {"type": "number"},
+            "b": {"type": "number"}
+          },
+          "required": ["a", "b"]
+        }
+      }
+    }
+  ],
+  "tool_choice": "auto",
+  "temperature": 0,
+  "max_tokens": 256,
+  "logprobs": true
+}
+JSON
+
+curl -sS http://localhost:8220/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  --data @/tmp/tool_probe_8220_bis.json
   
 # =========================
 # BENCHMARK COMMAND - Model 2


### PR DESCRIPTION
This pull request adds new benchmark scripts to evaluate multi-model serving and online model swapping capabilities for various large language models using vLLM on Gaudi3 hardware. The scripts automate server configuration, benchmarking, and online swapping between two models, covering both text-only and multimodal (vision-language) scenarios.

**Multi-model serving and benchmarking scripts:**

* Added three new scripts for text models (`meta-llama/Llama-Guard-4-12B` and `ibm-granite/granite-guardian-3.3-8b`) with different concurrency and prompt configurations. Each script sets up a multi-model server, runs a benchmark for the first model, performs an online swap to the second model, and benchmarks the second model. 
* Introduced a new script for multimodal models (`Qwen/Qwen3-VL-32B-Instruct-FP8` and `Qwen/Qwen3-VL-32B-Thinking-FP8`), including configuration for image input limits and additional benchmarking parameters for vision-language tasks. 