### PR TITLE
[FIX_FOR_VLLM_CUSTOM=54f548e9e58087f0155e4e164e416ad7efdfde6d] Fix moe_forward hidden_dim_unpadded parameter

### DIFF
--- a/vllm_gaudi/ops/hpu_fused_moe.py
+++ b/vllm_gaudi/ops/hpu_fused_moe.py
@@ -310,7 +310,7 @@ def patched_fused_moe_forward(
         result = self._forward_impl(self._hpu_layer_ref, hidden_states, router_logits, shared_experts_input, input_ids)
     else:
         result = self._forward_entry(hidden_states, router_logits, shared_experts_input, input_ids,
-                                     self._encode_layer_name())
+                                     self._encode_layer_name(), self._trtllm_mxfp4_unpadded_dim())
 
     # Mirror upstream MoERunner.forward post-_forward_entry pipeline.
     if isinstance(result, tuple):


### PR DESCRIPTION
## Root Cause

Upstream vLLM PR #41646 (commit 54f548e9e5) added a `hidden_dim_unpadded: int` parameter to the `moe_forward` and `moe_forward_shared` custom ops. The HPU plugin's `patched_fused_moe_forward()` calls `_forward_entry()` without this parameter, causing a `RuntimeError` during GraniteMoE inference in the data parallel test.

## Fix

Added `self._trtllm_mxfp4_unpadded_dim()` as the 6th argument to the `_forward_entry()` call in `patched_fused_moe_forward()`. This method is defined on MoERunner and returns 0 for HPU (no TRT-LLM MXFP4 backend), matching the upstream calling convention.

## Verification

Verified on HPU: `python -u examples/data_parallel.py --dp-size 2 --tp-size 2` passes on Gaudi3 (4 cards, g3.m).