### PR TITLE
Fix IndexError during decode warmup when seq_length equals max_model_…

### DIFF
--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -5108,9 +5108,11 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
             # Consider the token space for draft tokens to propose
             # The draft tokens for eagle consumes block table space
             num_lookahead_tokens += self.speculative_config.num_speculative_tokens
-        seq_lengths = [
-            min(b * block_size - num_lookahead_tokens, self.max_model_len - num_lookahead_tokens) for b in blocks
-        ]
+        # Cap at max_model_len - 1 to avoid off-by-one in _prepare_inputs
+        # where position = num_computed_tokens is used as an index into
+        # token_ids_cpu_tensor of shape (max_num_reqs, max_model_len).
+        max_seq = self.max_model_len - 1 - num_lookahead_tokens
+        seq_lengths = [min(b * block_size - num_lookahead_tokens, max_seq) for b in blocks]
         return seq_lengths
 
     def distribute_sum_evenly(self, total_sum, max_length):


### PR DESCRIPTION
…len (#1408)

During warmup, _generate_seq_lengths computes dummy sequence lengths for graph capture. When num_blocks * block_size exactly equals max_model_len, the generated seq_length would be max_model_len (e.g. 131072). This value is later used as num_computed_tokens in _prepare_inputs, producing a position index equal to max_model_len. Since token_ids_cpu_tensor has shape (max_num_reqs, max_model_len), the flat index for the last request becomes max_num_reqs * max_model_len — exactly one past the end of the tensor — causing an IndexError in torch.index_select.

This manifests with Granite 4.0 Hybrid (GraniteMoeHybridForCausalLM) using exponential bucketing, where block_size=528 and a decode bucket of (32, 1, 7968) yields 249 blocks per request: 249 * 528 - 1 = 131,071 rounds up to min(..., 131072) = 131072, triggering the crash.

Fix: cap the generated seq_length at max_model_len - 1 instead of max_model_len. This ensures position indices stay within tensor bounds during warmup while preserving the same bucket selection (the bucket is determined by num_blocks, not seq_length).