### PR TITLE
fix: patch torch.accelerator.empty_cache for HPU to fix import-order dependent cleanup failures

### DIFF
--- a/vllm_gaudi/patches.py
+++ b/vllm_gaudi/patches.py
@@ -2,13 +2,21 @@
 
 Currently:
 
+* ``torch.accelerator.empty_cache`` — HPU's allocator does not implement the
+  ``c10::DeviceAllocator`` interface, so the upstream helper raises
+  ``RuntimeError: Allocator for hpu is not a DeviceAllocator``.  We replace
+  it with an HPU-safe variant that routes through
+  ``current_platform.empty_cache()`` (a no-op on HPU).  This also makes the
+  ``cleanup_dist_env_and_memory`` patch resilient to import-order issues.
+
+* ``torch._C._host_emptyCache`` — does not exist on HPU; we install a no-op
+  stub to prevent ``AttributeError`` in ``cleanup_dist_env_and_memory``.
+
 * ``vllm.distributed.parallel_state.cleanup_dist_env_and_memory`` — upstream
   (since vllm PR #34328) calls ``torch.accelerator.empty_cache()``, which
-  requires the device's allocator to be a ``c10::DeviceAllocator``. HPU's
-  allocator does not implement that interface, so the call raises
-  ``RuntimeError: Allocator for hpu is not a DeviceAllocator`` during pytest
-  fixture teardown (see GAUDISW-247825). We replace it with an HPU-safe
-  variant that uses ``current_platform.empty_cache()`` instead.
+  requires the device's allocator to be a ``c10::DeviceAllocator``.  We
+  replace it with an HPU-safe variant that uses
+  ``current_platform.empty_cache()`` instead (see GAUDISW-247825).
 """
 
 import functools
@@ -20,6 +28,19 @@ import torch
 from vllm import envs
 from vllm.distributed import parallel_state
 from vllm.platforms import current_platform
+
+
+def _hpu_accelerator_empty_cache() -> None:
+    """HPU-safe replacement for ``torch.accelerator.empty_cache()``.
+
+    HPU's allocator does not implement the ``c10::DeviceAllocator``
+    interface, so the upstream ``torch.accelerator.empty_cache()`` raises
+    ``RuntimeError``.  Route through ``current_platform.empty_cache``
+    instead (which is ``None`` on HPU, making this a no-op).
+    """
+    empty_cache = current_platform.empty_cache
+    if empty_cache is not None:
+        empty_cache()
 
 
 def _hpu_cleanup_dist_env_and_memory(shutdown_ray: bool = False) -> None:
@@ -55,6 +76,13 @@ def _hpu_cleanup_dist_env_and_memory(shutdown_ray: bool = False) -> None:
 
 def apply() -> None:
     """Install all HPU runtime monkey-patches."""
+    # --- torch.accelerator.empty_cache ---
+    torch.accelerator.empty_cache = _hpu_accelerator_empty_cache
+
+    # --- torch._C._host_emptyCache ---
+    if not hasattr(torch._C, "_host_emptyCache"):
+        torch._C._host_emptyCache = lambda: None
+
     # Patch the canonical definition.
     parallel_state.cleanup_dist_env_and_memory = _hpu_cleanup_dist_env_and_memory
     # Patch the re-export from ``vllm.distributed`` so ``from vllm.distributed


### PR DESCRIPTION
## Summary

Fixes the remaining teardown errors in kv_connector unit tests on HPU (GAUDISW-247825).

### Problem

PR #1383 patched `cleanup_dist_env_and_memory` at the module attribute level, but this is fragile: if any code (like conftest.py or QA test runners) imports the function via `from vllm.distributed import cleanup_dist_env_and_memory` **before** `patches.apply()` runs, the local binding points to the original broken function which calls `torch.accelerator.empty_cache()` — this raises `RuntimeError: Allocator for hpu is not a DeviceAllocator` on HPU.

### Fix

In addition to the existing `cleanup_dist_env_and_memory` patch, we now also:

1. **Patch `torch.accelerator.empty_cache` itself** to route through `current_platform.empty_cache` (which is `None` on HPU, making it a no-op). This makes ALL callers safe regardless of import order.
2. **Install a no-op `torch._C._host_emptyCache` stub** when it doesn't exist on HPU, preventing `AttributeError`.

### Testing

- All 26 kv_connector unit tests pass on G2 with both current main and QA's vLLM version (0.19.2rc1)
- Verified import-order resilience: original `cleanup_dist_env_and_memory` works even when imported before patches are applied