### PR TITLE
fix: guard CUDA sync in hf3fs mock client for HPU compatibility

### DIFF
--- a/pytest_compat.py
+++ b/pytest_compat.py
@@ -24,8 +24,7 @@ def _patch_hf3fs_mock_client():
 
     try:
         from vllm.distributed.kv_transfer.kv_connector.v1.hf3fs.utils import (
-            hf3fs_mock_client,
-        )
+            hf3fs_mock_client, )
     except ImportError:
         return
 

--- a/pytest_compat.py
+++ b/pytest_compat.py
@@ -1,0 +1,39 @@
+"""Standalone pytest plugin for HPU compatibility with upstream vLLM tests.
+
+Registered via ``pytest11`` entry-point.  Intentionally placed outside the
+``vllm_gaudi`` package so that importing it does **not** trigger
+``vllm_gaudi/__init__.py`` (which pulls in ``habana_frameworks.torch`` and
+would break pytest on non-HPU machines).
+"""
+
+import functools
+from unittest.mock import MagicMock, patch
+
+import torch
+
+
+def pytest_configure(config):
+    """Apply HPU compatibility patches after all imports are resolved."""
+    _patch_hf3fs_mock_client()
+
+
+def _patch_hf3fs_mock_client():
+    """Guard CUDA sync in the HF3FS mock client on non-CUDA platforms."""
+    if torch.cuda.is_available():
+        return
+
+    try:
+        from vllm.distributed.kv_transfer.kv_connector.v1.hf3fs.utils import (
+            hf3fs_mock_client,
+        )
+    except ImportError:
+        return
+
+    _orig_batch_write = hf3fs_mock_client.Hf3fsClient.batch_write
+
+    @functools.wraps(_orig_batch_write)
+    def _safe_batch_write(self, offsets, tensors, event):
+        with patch("torch.cuda.current_stream", return_value=MagicMock()):
+            return _orig_batch_write(self, offsets, tensors, event)
+
+    hf3fs_mock_client.Hf3fsClient.batch_write = _safe_batch_write

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=("docs", "examples", "tests*", "csrc")),
+    py_modules=["pytest_compat"],
     install_requires=get_requirements(),
     ext_modules=ext_modules,
     extras_require={},
@@ -69,5 +70,6 @@ setup(
             "02.hpu_custom_ops = vllm_gaudi:register_ops",
             "03.hpu_custom_models = vllm_gaudi:register_models",
         ],
+        "pytest11": ["vllm_gaudi_compat = pytest_compat"],
     },
 )

--- a/vllm_gaudi/__init__.py
+++ b/vllm_gaudi/__init__.py
@@ -64,6 +64,7 @@ def register():
     # Apply HPU runtime monkey-patches (e.g. cleanup_dist_env_and_memory).
     # See vllm_gaudi/patches.py for details (GAUDISW-247825).
     from vllm_gaudi import patches as _hpu_patches
+
     _hpu_patches.apply()
 
     return "vllm_gaudi.platform.HpuPlatform"
@@ -83,10 +84,16 @@ def register_utils():
 
         install_engine_core_patch()
 
+    # Guard CUDA sync in upstream HF3FS mock client for non-CUDA platforms.
+    from vllm_gaudi import patches as _hpu_patches
+
+    _hpu_patches.patch_hf3fs_mock_client()
+
 
 def register_ops():
     """Register custom PluggableLayers for the HPU platform"""
     import vllm_gaudi.attention.oot_mla  # noqa: F401
+
     """Register custom ops for the HPU platform."""
     import vllm_gaudi.v1.sample.hpu_rejection_sampler  # noqa: F401
     import vllm_gaudi.distributed.kv_transfer.kv_connector.v1.hpu_nixl_connector  # noqa: F401

--- a/vllm_gaudi/__init__.py
+++ b/vllm_gaudi/__init__.py
@@ -93,7 +93,6 @@ def register_utils():
 def register_ops():
     """Register custom PluggableLayers for the HPU platform"""
     import vllm_gaudi.attention.oot_mla  # noqa: F401
-
     """Register custom ops for the HPU platform."""
     import vllm_gaudi.v1.sample.hpu_rejection_sampler  # noqa: F401
     import vllm_gaudi.distributed.kv_transfer.kv_connector.v1.hpu_nixl_connector  # noqa: F401

--- a/vllm_gaudi/patches.py
+++ b/vllm_gaudi/patches.py
@@ -10,7 +10,10 @@ Currently:
   fixture teardown (see GAUDISW-247825). We replace it with an HPU-safe
   variant that uses ``current_platform.empty_cache()`` instead.
 """
+
+import functools
 import gc
+from unittest.mock import MagicMock, patch
 
 import torch
 
@@ -60,3 +63,37 @@ def apply() -> None:
     import vllm.distributed as _vllm_distributed
 
     _vllm_distributed.cleanup_dist_env_and_memory = _hpu_cleanup_dist_env_and_memory
+
+
+def patch_hf3fs_mock_client():
+    """Guard CUDA sync in the HF3FS mock client on non-CUDA platforms.
+
+    The upstream mock client's ``batch_write`` unconditionally calls
+    ``torch.cuda.current_stream().wait_event(event)``, which raises
+    ``RuntimeError`` on platforms without CUDA (e.g. HPU).  We wrap
+    ``batch_write`` to stub ``torch.cuda.current_stream`` with a no-op
+    mock for the duration of the call.
+
+    Called from ``register_utils()`` (general plugin) rather than
+    ``apply()`` (platform plugin) to avoid circular imports — the mock
+    client transitively imports ``vllm.config`` which is not yet fully
+    initialized during platform registration.
+    """
+    if torch.cuda.is_available():
+        return
+
+    try:
+        from vllm.distributed.kv_transfer.kv_connector.v1.hf3fs.utils import (
+            hf3fs_mock_client,
+        )
+    except ImportError:
+        return
+
+    _orig_batch_write = hf3fs_mock_client.Hf3fsClient.batch_write
+
+    @functools.wraps(_orig_batch_write)
+    def _safe_batch_write(self, offsets, tensors, event):
+        with patch("torch.cuda.current_stream", return_value=MagicMock()):
+            return _orig_batch_write(self, offsets, tensors, event)
+
+    hf3fs_mock_client.Hf3fsClient.batch_write = _safe_batch_write

--- a/vllm_gaudi/patches.py
+++ b/vllm_gaudi/patches.py
@@ -84,8 +84,7 @@ def patch_hf3fs_mock_client():
 
     try:
         from vllm.distributed.kv_transfer.kv_connector.v1.hf3fs.utils import (
-            hf3fs_mock_client,
-        )
+            hf3fs_mock_client, )
     except ImportError:
         return
 


### PR DESCRIPTION
## Problem

The upstream HF3FS mock client (`vllm/distributed/kv_transfer/kv_connector/v1/hf3fs/utils/hf3fs_mock_client.py`) unconditionally calls `torch.cuda.current_stream().wait_event(event)` in its `batch_write()` method, which raises:

```
RuntimeError: Torch not compiled with CUDA enabled
```

on non-CUDA platforms such as Intel Gaudi HPU (where `torch.cuda.is_available()` returns `False`).

This mock client is used as a **production fallback** when `hf3fs_fuse` is not installed, and also during test execution.

Fixes: GAUDISW-248413

## Solution

Two complementary patches:

### 1. Runtime patch (`vllm_gaudi/patches.py` + `__init__.py`)

`patch_hf3fs_mock_client()` wraps `batch_write` to stub `torch.cuda.current_stream` with a no-op mock on non-CUDA platforms. Called from `register_utils()` (general plugin) rather than `apply()` (platform plugin) to avoid circular imports — the mock client transitively imports `vllm.config` which is not yet fully initialized during platform registration.

### 2. Test patch (`pytest_compat.py`)

Standalone pytest plugin registered via `pytest11` entry-point. **Intentionally placed outside the `vllm_gaudi` package** so importing it does NOT trigger `vllm_gaudi/__init__.py` (which pulls in `habana_frameworks.torch`). Applies the same patch at `pytest_configure` time.

## Testing

All 16 HF3FS tests pass on G2 HPU pod:

```
pytest tests/v1/kv_connector/unit/test_hf3fs_connector.py -v
======================== 16 passed in 6.52s ========================
```
