### PR TITLE
[MiniMax-M2] Remove reduce_results kwarg from FusedMoE init

### DIFF
--- a/vllm_gaudi/models/minimax_m2.py
+++ b/vllm_gaudi/models/minimax_m2.py
@@ -81,7 +81,6 @@ class HpuMiniMaxM2MoE(nn.Module):
             e_score_correction_bias=self.e_score_correction_bias,
             hidden_size=config.hidden_size,
             intermediate_size=config.intermediate_size,
-            reduce_results=False,
             renormalize=True,
             quant_config=quant_config,
             prefix=f"{prefix}.experts",


### PR DESCRIPTION
Removes the reduce_results=False argument passed to FusedMoE in HpuMiniMaxM2MoE which is no longer accepted by upstream VLLM and causes worker startup to fail.

Upstream VLLM removed the reduce_results parameter from Fused MoE_init_ (vllm/model_executor/layers/fused_moe/layer.py). THe MoE output reduction is now decided internally based on TP/EP topology. The corresponding upstream model MiniMaxM2MoE (vllm/model_executor/models/minimax_m2.py) was updated accordingly, but the HPU port HpuMiniMaxM2MoE was not, so it still passes the now-unknown kwarg.

Fix :
Drop the reduce_results=False kwarg from the FusedMoE construction in HpuMiniMaxM2MoE. Behavior is unchanged because upstream now governs MoE output reduction internally based on TP/EP configuration.