### PR TITLE
Add torchaudio-free copies of CD Dockerfiles

### DIFF
--- a/.cd/Dockerfile.rhel.ubi.vllm.no-torchaudio
+++ b/.cd/Dockerfile.rhel.ubi.vllm.no-torchaudio
@@ -1,0 +1,230 @@
+# Copyright (C) 2025 Habana Labs, Ltd. an Intel Company
+# SPDX-License-Identifier: Apache-2.0
+#
+# NOTE: This is a copy of Dockerfile.rhel.ubi.vllm with torchaudio removed.
+# Used to validate that vllm + vllm-gaudi can be built and run on Gaudi without
+# pulling the CPU torchaudio wheel.
+
+# Global build arguments - declared before first FROM to be available in all stages
+ARG ARTIFACTORY_URL="vault.habana.ai"
+ARG SYNAPSE_VERSION=1.24.0
+# Use an exact revision (e.g. 695) or "latest" to auto-detect the newest available revision.
+# If you do not want metadata to show "latest", pass an exact SYNAPSE_REVISION.
+ARG SYNAPSE_REVISION=1007
+ARG BASE_NAME=rhel9.6
+ARG OS_VERSION=9.6
+ARG OS_STRING=rhel96
+ARG PT_VERSION=2.10.0
+ARG PT_MODULES_REPO_NAME=gaudi-pt-modules
+# for internal use - to support a different package name for RHEL 9.4 with Python 3.12
+ARG PT_PACKAGE_NAME_NON_DEFAULT_PYTHON_SUBSTRING=
+ARG PYPI_INDEX_URL="https://pypi.org/simple/"
+ARG HABANA_RPM_REPO_PATH="rhel/9/${OS_VERSION}"
+ARG VLLM_GAUDI_COMMIT=main
+ARG VLLM_PROJECT_COMMIT=
+ARG VLLM_REPO="https://github.com/vllm-project/vllm.git"
+ARG VLLM_GAUDI_REPO="https://github.com/vllm-project/vllm-gaudi.git"
+
+# ============================================================================
+# Stage 1: gaudi-base - Base system setup with Habana drivers
+# ============================================================================
+FROM registry.access.redhat.com/ubi9/ubi:${OS_VERSION} AS gaudi-base
+
+# Re-declare global ARGs to use them in this stage
+ARG ARTIFACTORY_URL
+ARG SYNAPSE_VERSION
+ARG SYNAPSE_REVISION
+ARG OS_VERSION
+ARG OS_STRING
+ARG PT_VERSION
+ARG PYPI_INDEX_URL
+ARG HABANA_RPM_REPO_PATH
+
+# Labels for RHEL certification.
+# Note: when SYNAPSE_REVISION=latest, this metadata intentionally records "latest"
+# (the requested input), not the detected numeric revision.
+LABEL vendor="Habanalabs Ltd." \
+    release="${SYNAPSE_VERSION}-${SYNAPSE_REVISION}"
+
+# Environment variables - Habana-specific paths and configurations
+ENV PT_VERSION=${PT_VERSION} \
+    OS_STRING="${OS_STRING}" \
+    VLLM_TARGET_DEVICE="hpu" \
+    GC_KERNEL_PATH=/usr/lib/habanalabs/libtpc_kernels.so \
+    HABANA_LOGS=/var/log/habana_logs/ \
+    HABANA_SCAL_BIN_PATH=/opt/habanalabs/engines_fw \
+    HABANA_PLUGINS_LIB_PATH=/opt/habanalabs/habana_plugins
+
+# Copy license
+COPY LICENSE /licenses/
+
+# System setup - Remove FIPS provider and add EPEL
+RUN dnf install -y --allowerasing python3-dnf-plugin-versionlock && \
+    dnf versionlock add redhat-release* && \
+    dnf -y update && \
+    # '|| true' is added to support RHEL 9.4 in which openssl-fips-provider-so is not installed
+    rpm -e --nodeps openssl-fips-provider-so || true && \
+    dnf install -y --allowerasing https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
+    dnf clean all
+
+# Add CentOS repositories for additional packages
+RUN printf "[BaseOS]\\nname=CentOS Linux 9 - BaseOS\\nbaseurl=https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os\\ngpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official-SHA256\\ngpgcheck=1\\n" > /etc/yum.repos.d/CentOS-Linux-BaseOS.repo && \
+    printf "[centos9]\\nname=CentOS Linux 9 - AppStream\\nbaseurl=https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os\\ngpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official-SHA256\\ngpgcheck=1\\n" > /etc/yum.repos.d/CentOS-Linux-AppStream.repo && \
+    printf "[CRB]\\nname=CentOS Linux 9 - CRB\\nbaseurl=https://mirror.stream.centos.org/9-stream/CRB/x86_64/os\\ngpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official-SHA256\\ngpgcheck=1\\n" > /etc/yum.repos.d/CentOS-Linux-CRB.repo
+
+# Install system dependencies
+RUN dnf install -y --allowerasing \
+    wget git-core jq libomp \
+    # Image processing dependencies (needed for pillow-simd -> habana-media-loader)
+    zlib-devel libjpeg-turbo-devel \
+    # habanalabs-thunk dependency
+    libfdt-devel \
+    # Python development
+    python3-devel python3.12 python3.12-devel python3.12-pip \
+    # NUMA support
+    numactl-libs numactl-devel && \
+    dnf clean all
+
+# Configure Python 3.12 as default
+RUN alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 2 && \
+    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1 && \
+    alternatives --set python3 /usr/bin/python3.12 && \
+    ln -s /usr/bin/python3 /usr/bin/python
+
+# Install base Python packages
+RUN pip install --no-cache-dir setuptools==79.0.1 wheel setuptools_scm && \
+    pip install --no-cache-dir --upgrade Jinja2 protobuf urllib3 requests
+
+# Setup Habana repository and install Habana packages
+RUN printf "[habanalabs]\\nname=Habana RH9 Linux repo\\nbaseurl=https://${ARTIFACTORY_URL}/artifactory/${HABANA_RPM_REPO_PATH}\\ngpgkey=https://${ARTIFACTORY_URL}/artifactory/${HABANA_RPM_REPO_PATH}/repodata/repomd.xml.key\\ngpgcheck=1\\n" > /etc/yum.repos.d/habanalabs.repo && \
+    echo "=== Content of habanalabs.repo ===" && \
+    cat /etc/yum.repos.d/habanalabs.repo && \
+    echo "=== End of habanalabs.repo ===" && \
+    _GPG_TEMP=$(mktemp -d) && \
+    wget -q -O "${_GPG_TEMP}/habana_pubkey" "https://${ARTIFACTORY_URL}/artifactory/gaudi-general/keyPairs/primary/public" && \
+    rpm --import "${_GPG_TEMP}/habana_pubkey" && \
+    rm -rf "${_GPG_TEMP}" && \
+    dnf makecache && \
+    if [ "${SYNAPSE_REVISION}" = "latest" ]; then \
+    dnf install -y \
+    habanalabs-rdma-core-"$SYNAPSE_VERSION"* \
+    habanalabs-thunk-"$SYNAPSE_VERSION"* \
+    habanalabs-firmware-tools-"$SYNAPSE_VERSION"* \
+    habanalabs-graph-"$SYNAPSE_VERSION"*; \
+    else \
+    dnf install -y \
+    habanalabs-rdma-core-"$SYNAPSE_VERSION"-"$SYNAPSE_REVISION"* \
+    habanalabs-thunk-"$SYNAPSE_VERSION"-"$SYNAPSE_REVISION"* \
+    habanalabs-firmware-tools-"$SYNAPSE_VERSION"-"$SYNAPSE_REVISION"* \
+    habanalabs-graph-"$SYNAPSE_VERSION"-"$SYNAPSE_REVISION"*; \
+    fi && \
+    DETECTED_SYNAPSE_REVISION=$(rpm -q --qf '%{RELEASE}\n' habanalabs-rdma-core | head -n1 | sed 's/\..*$//') && \
+    mkdir -p /etc/habanalabs && \
+    echo "${DETECTED_SYNAPSE_REVISION}" > /etc/habanalabs/synapse_revision && \
+    echo "Detected Synapse revision: ${DETECTED_SYNAPSE_REVISION}" && \
+    dnf clean all && \
+    chmod +t /var/log/habana_logs && \
+    rm -f /etc/yum.repos.d/habanalabs.repo
+
+# Install Habana media loader and configure Python path
+RUN SYNAPSE_REVISION_RUNTIME=$(cat /etc/habanalabs/synapse_revision) && \
+    pip install --no-cache-dir habana-media-loader=="${SYNAPSE_VERSION}"."${SYNAPSE_REVISION_RUNTIME}" --extra-index-url ${PYPI_INDEX_URL} && \
+    echo "/usr/lib/habanalabs" > $(python3 -c "import sysconfig; print(sysconfig.get_path('platlib'))")/habanalabs-graph.pth
+
+# ============================================================================
+# Stage 2: gaudi-pytorch - Install PyTorch for Habana
+# ============================================================================
+FROM gaudi-base AS gaudi-pytorch
+
+# Re-declare global ARGs needed in this stage
+ARG ARTIFACTORY_URL
+ARG OS_STRING
+ARG PT_VERSION
+ARG PT_MODULES_REPO_NAME
+ARG PT_PACKAGE_NAME_NON_DEFAULT_PYTHON_SUBSTRING
+ARG PYPI_INDEX_URL
+ARG SYNAPSE_VERSION
+ARG SYNAPSE_REVISION
+
+# Environment variables inherited from base, OS_STRING needed for PyTorch install
+ENV OS_STRING="${OS_STRING}"
+
+# Use installer script from Habana to install Pytorch
+RUN SYNAPSE_REVISION_RUNTIME=$(cat /etc/habanalabs/synapse_revision) && \
+    PT_PACKAGE_NAME="pytorch_modules${PT_PACKAGE_NAME_NON_DEFAULT_PYTHON_SUBSTRING}-v${PT_VERSION}_${SYNAPSE_VERSION}_${SYNAPSE_REVISION_RUNTIME}.tgz" && \
+    PT_ARTIFACT_PATH="https://${ARTIFACTORY_URL}/artifactory/${PT_MODULES_REPO_NAME}/${SYNAPSE_VERSION}/${SYNAPSE_REVISION_RUNTIME}/pytorch/${OS_STRING}" && \
+    TMP_PATH=$(mktemp --directory) && \
+    wget --no-verbose "${PT_ARTIFACT_PATH}/${PT_PACKAGE_NAME}" && \
+    tar -zxf "${PT_PACKAGE_NAME}" -C "${TMP_PATH}" && \
+    cd "${TMP_PATH}" && \
+    export SKIP_INSTALL_DEPENDENCIES=1 && \
+    PYTHON_INDEX_URL="--extra-index-url ${PYPI_INDEX_URL}" ./install.sh $SYNAPSE_VERSION $SYNAPSE_REVISION_RUNTIME upstream && \
+    cd / && \
+    rm -rf "${TMP_PATH}" "${PT_PACKAGE_NAME}" && \
+    dnf clean all
+
+# torchaudio install removed.
+
+WORKDIR /workspace
+
+# ============================================================================
+# Stage 3: vllm-final - Install vLLM and configure runtime
+# ============================================================================
+FROM gaudi-pytorch AS vllm-openai
+
+# Re-declare global ARGs needed in this stage
+ARG VLLM_REPO
+ARG VLLM_GAUDI_REPO
+ARG VLLM_GAUDI_COMMIT
+ARG VLLM_PROJECT_COMMIT
+ARG BASE_NAME
+
+# Environment variables for this stage
+ENV BASE_NAME=${BASE_NAME} \
+    OMPI_MCA_btl_vader_single_copy_mechanism=none \
+    VLLM_PATH=/workspace/vllm-project \
+    VLLM_PATH2=/workspace/vllm-gaudi
+
+# Install additional system dependencies
+RUN dnf install -y gettext --allowerasing && \
+    dnf clean all && \
+    ln -sf /usr/bin/python3 /usr/bin/python
+
+WORKDIR /root
+
+# Clone and install vLLM
+RUN set -e && \
+    mkdir -p $VLLM_PATH2 && \
+    git clone $VLLM_GAUDI_REPO $VLLM_PATH2 && \
+    cd $VLLM_PATH2 && \
+    if [ -z "${VLLM_PROJECT_COMMIT}" ]; then \
+    VLLM_PROJECT_COMMIT=$(git show "origin/vllm/last-good-commit-for-vllm-gaudi:VLLM_STABLE_COMMIT" 2>/dev/null || { echo >&2 "Warning: Could not fetch last-good-commit, using main branch"; echo "main"; }) && \
+    echo "Found vLLM commit hash: ${VLLM_PROJECT_COMMIT}"; \
+    else \
+    echo "Using vLLM commit: ${VLLM_PROJECT_COMMIT}"; \
+    fi && \
+    mkdir -p $VLLM_PATH && \
+    echo "Clone vllm-project/vllm and use configured or last good commit hash" && \
+    git clone $VLLM_REPO $VLLM_PATH && \
+    cd $VLLM_PATH && \
+    git remote add upstream $VLLM_REPO && \
+    git fetch upstream --tags && \
+    git checkout ${VLLM_PROJECT_COMMIT} && \
+    pip install --no-cache-dir -r <(sed '/^torch/d' requirements/build/cuda.txt) && \
+    VLLM_TARGET_DEVICE=empty pip install --no-cache-dir --no-build-isolation . && \
+    cd $VLLM_PATH2 && \
+    git checkout ${VLLM_GAUDI_COMMIT} && \
+    VLLM_TARGET_DEVICE=hpu pip install --no-cache-dir -v . --no-build-isolation && \
+    pip check
+
+# Setup non-root user for OpenShift compatibility
+RUN umask 002 && \
+    useradd --uid 2000 --gid 0 vllm && \
+    chmod g+rwx /home/vllm /usr/src /workspace && \
+    chmod -R g+rwx /var/log/habana_logs
+
+# Copy license
+COPY LICENSE /licenses/vllm.md
+
+USER 2000
+ENTRYPOINT ["python3", "-m", "vllm.entrypoints.openai.api_server"]

--- a/.cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest.no-torchaudio
+++ b/.cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest.no-torchaudio
@@ -1,0 +1,89 @@
+# Copyright (C) 2025 Habana Labs, Ltd. an Intel Company
+# SPDX-License-Identifier: Apache-2.0
+#
+# NOTE: This is a copy of Dockerfile.ubuntu.pytorch.vllm.nixl.latest with
+# torchaudio removed. Used to validate that vllm + vllm-gaudi can be built and
+# run on Gaudi without pulling the CPU torchaudio wheel.
+
+# Parameterize base image components
+ARG DOCKER_URL=vault.habana.ai/gaudi-docker
+ARG VERSION=1.24.0
+ARG BASE_NAME=ubuntu24.04
+ARG PT_VERSION=2.10.0
+ARG REVISION=latest
+ARG REPO_TYPE=habanalabs
+ARG TORCH_TYPE_SUFFIX
+
+FROM ${DOCKER_URL}/${VERSION}/${BASE_NAME}/${REPO_TYPE}/pytorch-${TORCH_TYPE_SUFFIX}installer-${PT_VERSION}:${REVISION}
+
+# Parameterize commit/branch for vllm-project & vllm-gaudi checkout
+# leave empty to use last-good-commit-for-vllm-gaudi
+ARG PT_VERSION
+ARG VLLM_PROJECT_COMMIT=
+ARG VLLM_GAUDI_COMMIT=main
+
+ENV OMPI_MCA_btl_vader_single_copy_mechanism=none
+
+RUN apt update && \
+    apt install -y gettext moreutils jq && \
+    ln -sf /usr/bin/python3 /usr/bin/python
+WORKDIR /root
+
+ENV VLLM_PATH=/workspace/vllm-project
+ENV VLLM_PATH2=/workspace/vllm-gaudi
+ENV HABANA_VISIBLE_DEVICES=all
+
+RUN echo "dash dash/sh boolean false" | debconf-set-selections && \
+    DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
+ENV ENV=~/.profile
+
+# Clone the vllm-project repository and install inside the container
+# --- START: COMBINED RUN COMMAND ---
+RUN \
+    # Clone vllm-gaudi and get the commit hash for the vllm-project/vllm
+    set -e && \
+    mkdir -p $VLLM_PATH2 && \
+    git clone https://github.com/vllm-project/vllm-gaudi.git $VLLM_PATH2 && \
+    cd $VLLM_PATH2 && \
+    if [ -z "${VLLM_PROJECT_COMMIT}" ]; then \
+       VLLM_PROJECT_COMMIT=$(git show "origin/vllm/last-good-commit-for-vllm-gaudi:VLLM_STABLE_COMMIT" 2>/dev/null) && \
+       echo "Found vLLM commit hash: ${VLLM_PROJECT_COMMIT}"; \
+    else \
+       echo "Using vLLM commit : ${VLLM_PROJECT_COMMIT}"; \
+    fi && \
+    mkdir -p $VLLM_PATH && \
+    # Clone vllm-project/vllm and use configured or last good commit hash    
+    git clone https://github.com/vllm-project/vllm.git $VLLM_PATH && \
+    cd $VLLM_PATH && \
+    git remote add upstream https://github.com/vllm-project/vllm.git && \
+    git fetch upstream --tags || true && \
+    git checkout ${VLLM_PROJECT_COMMIT} && \
+    # Install vllm-project/vllm
+    bash -c 'pip install -r <(sed "/^torch/d" requirements/build/cuda.txt)' && \
+    VLLM_TARGET_DEVICE=empty pip install --no-build-isolation . && \
+    # Install vllm-gaudi plugin
+    cd $VLLM_PATH2 && \
+    git checkout ${VLLM_GAUDI_COMMIT} && \
+    VLLM_TARGET_DEVICE=hpu pip install -v . --no-build-isolation && \
+    python install_nixl.py
+# --- END: COMBINED RUN COMMAND ---
+
+# torchaudio install removed.
+
+# Workaround: Gaudi base image bundles HPU-patched PyTorch (e.g. 2.10.0a0+git...)
+# which doesn't satisfy torchvision's strict torch==X.Y.Z pin.
+# Relax the requirement in installed package metadata so pip check passes.
+# (torchaudio metadata patch removed together with torchaudio install.)
+RUN SITE=$(python3 -c "import site; print(site.getsitepackages()[0])") && \
+    TORCH_VER=$(python3 -c "import torch; v=torch.__version__.split('+')[0].split('a')[0]; print(v)") && \
+    find "$SITE" -path "*/torchvision*.dist-info/METADATA" \
+      -exec sed -i "s/Requires-Dist: torch (==${TORCH_VER})/Requires-Dist: torch (>=${TORCH_VER}a0,<${TORCH_VER%.*}.$((${TORCH_VER##*.}+1)))/" {} +
+RUN pip install datasets && \
+    pip install pandas && pip install lm-eval lm-eval[api] && \
+    pip install pytest pytest_asyncio pytest-timeout
+
+# Copy utility scripts and configuration
+WORKDIR /workspace
+RUN ln -s /workspace/vllm/tests /workspace/tests \
+    && ln -s /workspace/vllm/examples /workspace/examples \
+    && ln -s /workspace/vllm/benchmarks /workspace/benchmarks

--- a/.cd/Dockerfile.ubuntu.pytorch.vllm.no-torchaudio
+++ b/.cd/Dockerfile.ubuntu.pytorch.vllm.no-torchaudio
@@ -1,0 +1,84 @@
+# Copyright (C) 2025 Habana Labs, Ltd. an Intel Company
+# SPDX-License-Identifier: Apache-2.0
+#
+# NOTE: This is a copy of Dockerfile.ubuntu.pytorch.vllm with torchaudio removed.
+# Used to validate that vllm + vllm-gaudi can be built and run on Gaudi without
+# pulling the CPU torchaudio wheel.
+
+# Parameterize base image components
+ARG DOCKER_URL=vault.habana.ai/gaudi-docker
+ARG VERSION=1.24.0
+ARG BASE_NAME=ubuntu24.04
+ARG PT_VERSION=2.10.0
+ARG REVISION=latest
+ARG REPO_TYPE=habanalabs
+ARG TORCH_TYPE_SUFFIX
+
+FROM ${DOCKER_URL}/${VERSION}/${BASE_NAME}/${REPO_TYPE}/pytorch-${TORCH_TYPE_SUFFIX}installer-${PT_VERSION}:${REVISION}
+
+# Re-declare ARGs needed after FROM (they go out of scope)
+ARG PT_VERSION
+
+# Parameterize commit/branch for vllm-project & vllm-gaudi checkout
+ARG VLLM_GAUDI_COMMIT=main
+# leave empty to use last-good-commit-for-vllm-gaudi
+ARG VLLM_PROJECT_COMMIT=
+ENV OMPI_MCA_btl_vader_single_copy_mechanism=none
+
+RUN apt update && \
+    apt install -y gettext moreutils jq && \
+    ln -sf /usr/bin/python3 /usr/bin/python
+WORKDIR /root
+
+ENV VLLM_PATH=/workspace/vllm-project
+ENV VLLM_PATH2=/workspace/vllm-gaudi
+ENV HABANA_VISIBLE_DEVICES=all
+
+RUN echo "dash dash/sh boolean false" | debconf-set-selections && \
+    DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
+ENV ENV=~/.profile
+
+# Clone the vllm-project repository and install inside the container
+# --- START: COMBINED RUN COMMAND ---
+RUN \
+    # Clone vllm-gaudi and get the commit hash for the vllm-project/vllm
+    set -e && \
+    mkdir -p $VLLM_PATH2 && \
+    git clone https://github.com/vllm-project/vllm-gaudi.git $VLLM_PATH2 && \
+    cd $VLLM_PATH2 && \
+    if [ -z "${VLLM_PROJECT_COMMIT}" ]; then \
+       VLLM_PROJECT_COMMIT=$(git show "origin/vllm/last-good-commit-for-vllm-gaudi:VLLM_STABLE_COMMIT" 2>/dev/null) && \
+       echo "Found vLLM commit hash: ${VLLM_PROJECT_COMMIT}"; \
+    else \
+       echo "Using vLLM commit : ${VLLM_PROJECT_COMMIT}"; \
+    fi && \
+    mkdir -p $VLLM_PATH && \
+    # Clone vllm-project/vllm and use configured or last good commit hash
+    git clone https://github.com/vllm-project/vllm.git $VLLM_PATH && \
+    cd $VLLM_PATH && \
+    git remote add upstream https://github.com/vllm-project/vllm.git && \
+    git fetch upstream --tags || true && \
+    git checkout ${VLLM_PROJECT_COMMIT} && \
+    # Install vllm-project/vllm
+    bash -c "pip install -r <(sed '/^torch/d' requirements/build/cuda.txt)" && \
+    VLLM_TARGET_DEVICE=empty pip install --no-build-isolation . && \
+    # Install vllm-gaudi plugin
+    cd $VLLM_PATH2 && \
+    git checkout ${VLLM_GAUDI_COMMIT} && \
+    VLLM_TARGET_DEVICE=hpu pip install -v . --no-build-isolation
+# --- END: COMBINED RUN COMMAND ---
+
+# Install additional Python packages (torchaudio install removed)
+RUN pip install datasets && \
+    pip install pandas
+
+# Copy utility scripts and configuration
+RUN mkdir -p /root/scripts/
+COPY templates /root/scripts/templates/
+COPY entrypoints /root/scripts/entrypoints/
+COPY server /root/scripts/server/
+COPY benchmark /root/scripts/benchmark/
+WORKDIR /root/scripts
+
+# Set entrypoint script
+ENTRYPOINT ["python3", "-m", "entrypoints.entrypoint_main"]


### PR DESCRIPTION
## Summary

- Adds three `.no-torchaudio` copies of the CD Dockerfiles in `.cd/`
  (`Dockerfile.ubuntu.pytorch.vllm`, `Dockerfile.ubuntu.pytorch.vllm.nixl.latest`,
  `Dockerfile.rhel.ubi.vllm`) with the `torchaudio` install step removed.
- `torchaudio` is not required for the documented Gaudi use cases and
  its strict `torch==X.Y.Z` pin does not match the HPU-patched
  `X.Y.Za0+git…` PyTorch in the Habana base image — dropping it removes
  the corresponding `pip check` finding and the metadata-patch workaround
  in the nixl variant (narrowed to `torchvision` only).
- **Forward-looking context:** starting with PyTorch 2.12, `torchaudio`
  becomes obsolete, so vLLM Gaudi needs to work without it. These
  parallel Dockerfiles are intended to validate that path as part of the
  PT 2.12 enablement work.
- Originals are kept unchanged; once validated downstream, they can be
  replaced in a follow-up PR.

## Test plan

Built and ran on Gaudi2 (Synapse 1.24.0-1007):

- `docker build` of both ubuntu and rhel `.no-torchaudio` Dockerfiles → EXIT=0
- RHEL: `pip check` → `No broken requirements found.`
- `importlib.util.find_spec("torchaudio")` → `None` in both images
- End-to-end inference of `Qwen/Qwen2.5-0.5B-Instruct` on HPU
  (`HPUAttentionV1`, bf16, `enforce_eager`) produces correct output
  from both images