### PR TITLE
Add Qwen3NextForCausalLM to mamba_like_arch

### DIFF
--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -506,7 +506,8 @@ def maybe_set_mamba_kv_cache_groups_ids(model, kv_cache_config: KVCacheConfig):
         model = model.model
 
     mamba_like_arch = [
-        "GraniteMoeHybridForCausalLM", "Qwen3_5MoeForConditionalGeneration", "Qwen3_5ForConditionalGeneration"
+        "GraniteMoeHybridForCausalLM", "Qwen3_5MoeForConditionalGeneration", "Qwen3_5ForConditionalGeneration",
+        "Qwen3NextForCausalLM"
     ]
     if not any(arch in getattr(model.config, 'architectures', []) for arch in mamba_like_arch):
         return


### PR DESCRIPTION
Qwen3Next uses a hybrid GDN+attention architecture that requires separate KV cache groups for GDN vs standard attention layers. Add it to the mamba_like_arch list so maybe_set_mamba_kv_cache_groups_ids() sets up the cache groups correctly.