### PR TITLE
Global patch for t.compile high warmup time on MoE models

### DIFF
--- a/vllm_gaudi/models/__init__.py
+++ b/vllm_gaudi/models/__init__.py
@@ -41,9 +41,6 @@ def register_model():
     from vllm_gaudi.models.seed_oss import HpuSeedOssForCausalLM  # noqa: F401
     ModelRegistry.register_model("SeedOssForCausalLM", "vllm_gaudi.models.seed_oss:HpuSeedOssForCausalLM")
 
-    from vllm_gaudi.models.qwen3_moe import HpuQwen3MoeForCausalLM  # noqa: F401
-    ModelRegistry.register_model("Qwen3MoeForCausalLM", "vllm_gaudi.models.qwen3_moe:HpuQwen3MoeForCausalLM")
-
     from vllm_gaudi.models.llama4 import HpuLlama4ForConditionalGeneration  # noqa: F401
     ModelRegistry.register_model("Llama4ForConditionalGeneration",
                                  "vllm_gaudi.models.llama4:HpuLlama4ForConditionalGeneration")

--- a/vllm_gaudi/models/llama4.py
+++ b/vllm_gaudi/models/llama4.py
@@ -6,82 +6,34 @@ Llama4 has 48 decoder layers with heterogeneous configurations:
   - RoPE layers: has rotary_emb, no temperature tuning, ChunkedLocalAttention
 
 This module provides:
-  1. HpuLlama4Model — overrides forward() to initialize residual as zeros
-     instead of None, eliminating torch._dynamo type guard.
-  2. HpuLlama4ForCausalLM — registered via ModelRegistry, applies branch-free
-     attention patches and attention type unification in __init__.
-  3. Branch-free attention patching — boolean buffer masks + torch.where
+  1. HpuLlama4ForCausalLM — registered via ModelRegistry, applies Llama4-
+     specific attention patches and attention type unification in __init__.
+  2. Branch-free attention patching — boolean buffer masks + torch.where
      eliminate Python if/else guards on nope/rotary_emb/temperature_tuning.
-  4. Attention type unification — swaps ChunkedLocalAttention → Attention
+  3. Attention type unification — swaps ChunkedLocalAttention → Attention
      to eliminate torch._dynamo type guards across layers.
 """
 
 import types
-from itertools import islice
 
 import habana_frameworks.torch as htorch
 import torch
 import torch.nn as nn
 from vllm.config import VllmConfig
-from vllm.distributed import get_pp_group
 from vllm.logger import init_logger
 from vllm.model_executor.models.llama4 import (
     Llama4ForCausalLM as UpstreamLlama4ForCausalLM,
-    Llama4Model as UpstreamLlama4Model,
 )
 from vllm.model_executor.models.mllama4 import (
     Llama4ForConditionalGeneration as UpstreamLlama4ForConditionalGeneration, )
-from vllm.sequence import IntermediateTensors
 
 logger = init_logger(__name__)
-
-
-class HpuLlama4Model(UpstreamLlama4Model):
-    """Llama4Model with residual initialized as zeros instead of None.
-
-    The upstream LlamaModel.forward() sets ``residual = None`` for the first
-    rank, which creates a torch._dynamo type guard (None vs Tensor) that
-    causes recompilation between layer 0 and layers 1-47. Initializing
-    residual as ``torch.zeros_like(hidden_states)`` eliminates this guard.
-    """
-
-    def forward(
-        self,
-        input_ids: torch.Tensor | None,
-        positions: torch.Tensor,
-        intermediate_tensors: IntermediateTensors | None,
-        inputs_embeds: torch.Tensor | None = None,
-        **extra_layer_kwargs,
-    ) -> torch.Tensor | IntermediateTensors | tuple[torch.Tensor, list[torch.Tensor]]:
-        if get_pp_group().is_first_rank:
-            hidden_states = inputs_embeds if inputs_embeds is not None else self.embed_input_ids(input_ids)
-            residual = torch.zeros_like(hidden_states)
-        else:
-            assert intermediate_tensors is not None
-            hidden_states = intermediate_tensors["hidden_states"]
-            residual = intermediate_tensors["residual"]
-
-        aux_hidden_states = []
-        for idx, layer in enumerate(islice(self.layers, self.start_layer, self.end_layer)):
-            if idx in self.aux_hidden_state_layers:
-                aux_hidden_states.append(hidden_states + residual)
-            hidden_states, residual = layer(positions, hidden_states, residual, **extra_layer_kwargs)
-
-        if not get_pp_group().is_last_rank:
-            return IntermediateTensors({"hidden_states": hidden_states, "residual": residual})
-
-        hidden_states, _ = self.norm(hidden_states, residual)
-
-        if len(aux_hidden_states) > 0:
-            return hidden_states, aux_hidden_states
-        return hidden_states
 
 
 class HpuLlama4ForCausalLM(UpstreamLlama4ForCausalLM):
     """HPU-optimized Llama4ForCausalLM registered via ModelRegistry.
 
-    Applies branch-free attention patches, attention type unification,
-    and swaps the inner model class to HpuLlama4Model for residual fix.
+    Applies branch-free attention patches and attention type unification.
     """
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
@@ -92,13 +44,12 @@ class HpuLlama4ForCausalLM(UpstreamLlama4ForCausalLM):
 def _apply_hpu_llama4_init_patches(model_root: nn.Module) -> None:
     """Shared init-time patches for both CausalLM and ConditionalGeneration.
 
-    Swaps the inner model class for the residual=zeros fix and applies
-    attention type unification in compile mode.
+    Applies attention type unification in compile mode.
+    The residual=zeros warmup workaround is installed by the global MoE
+    warmup patch in HpuModelAdapter.
     _unify_feed_forward_types is deferred to post-load via
     apply_hpu_llama4_post_load_patches() to avoid breaking weight loading.
     """
-    model_root.__class__ = HpuLlama4Model
-
     if not htorch.utils.internal.is_lazy():
         layers = getattr(model_root, "layers", [])
         # NOTE: _apply_branch_free_attention is SKIPPED.

--- a/vllm_gaudi/models/qwen3_moe.py
+++ b/vllm_gaudi/models/qwen3_moe.py
@@ -2,7 +2,8 @@ import torch
 from torch import nn
 
 from vllm.model_executor.models.qwen3_moe import (
-    Qwen3MoeSparseMoeBlock as UpstreamQwen3MoeSparseMoeBlock, )
+    Qwen3MoeSparseMoeBlock as UpstreamQwen3MoeSparseMoeBlock,
+)
 from vllm.model_executor.models.utils import sequence_parallel_chunk
 from vllm.distributed import tensor_model_parallel_all_gather
 

--- a/vllm_gaudi/models/qwen3_moe.py
+++ b/vllm_gaudi/models/qwen3_moe.py
@@ -1,15 +1,10 @@
 import torch
 from torch import nn
 
-from vllm.config import VllmConfig
-from vllm.distributed import get_pp_group, tensor_model_parallel_all_gather
 from vllm.model_executor.models.qwen3_moe import (
-    Qwen3MoeForCausalLM as UpstreamQwen3MoeForCausalLM,
-    Qwen3MoeModel as UpstreamQwen3MoeModel,
-    Qwen3MoeSparseMoeBlock as UpstreamQwen3MoeSparseMoeBlock,
-)
+    Qwen3MoeSparseMoeBlock as UpstreamQwen3MoeSparseMoeBlock, )
 from vllm.model_executor.models.utils import sequence_parallel_chunk
-from vllm.sequence import IntermediateTensors
+from vllm.distributed import tensor_model_parallel_all_gather
 
 
 class HpuQwen3MoeSparseMoeBlock(UpstreamQwen3MoeSparseMoeBlock):
@@ -75,49 +70,3 @@ def upgrade_qwen3_moe_blocks_inplace(language_model: nn.Module) -> int:
             upgraded += 1
 
     return upgraded
-
-
-class HpuQwen3MoeModel(UpstreamQwen3MoeModel):
-    """Initialize residual as zeros instead of None to eliminate Dynamo type guard."""
-
-    def forward(
-        self,
-        input_ids: torch.Tensor | None,
-        positions: torch.Tensor,
-        intermediate_tensors: IntermediateTensors | None = None,
-        inputs_embeds: torch.Tensor | None = None,
-    ) -> torch.Tensor | IntermediateTensors | tuple[torch.Tensor, list[torch.Tensor]]:
-        if get_pp_group().is_first_rank:
-            hidden_states = inputs_embeds if inputs_embeds is not None else self.embed_input_ids(input_ids)
-            residual = torch.zeros_like(hidden_states)
-        else:
-            assert intermediate_tensors is not None
-            hidden_states = intermediate_tensors["hidden_states"]
-            residual = intermediate_tensors["residual"]
-
-        aux_hidden_states = []
-        for layer_idx, layer in enumerate(
-                self.layers[self.start_layer:self.end_layer],
-                start=self.start_layer,
-        ):
-            if layer_idx in self.aux_hidden_state_layers:
-                aux_hidden_state = hidden_states + residual
-                aux_hidden_states.append(aux_hidden_state)
-            hidden_states, residual = layer(positions, hidden_states, residual)
-
-        if not get_pp_group().is_last_rank:
-            return IntermediateTensors({"hidden_states": hidden_states, "residual": residual})
-        hidden_states, _ = self.norm(hidden_states, residual)
-
-        if len(aux_hidden_states) > 0:
-            return hidden_states, aux_hidden_states
-        return hidden_states
-
-
-class HpuQwen3MoeForCausalLM(UpstreamQwen3MoeForCausalLM):
-
-    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
-        super().__init__(vllm_config=vllm_config, prefix=prefix)
-        upgrade_qwen3_moe_blocks_inplace(self)
-        if hasattr(self, "model") and isinstance(self.model, UpstreamQwen3MoeModel):
-            self.model.__class__ = HpuQwen3MoeModel

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -6,6 +6,7 @@ import contextlib
 from copy import deepcopy
 import functools
 from functools import partial, wraps
+import inspect
 import itertools
 import math
 import os
@@ -688,6 +689,7 @@ class HpuModelAdapter(torch.nn.Module, HpuKVConnectorModelRunnerMixin):
     def __init__(self, model, vllm_config):
         super().__init__()
         self.model = model
+        _maybe_install_global_moe_warmup_patch(self.model)
         self.recompute_cos_sin = os.getenv('VLLM_COS_SIN_RECOMPUTE', 'false').lower() in ['1', 'true']
         self.vllm_config = vllm_config
         self.block_size = vllm_config.cache_config.block_size
@@ -831,6 +833,153 @@ class HpuModelAdapter(torch.nn.Module, HpuKVConnectorModelRunnerMixin):
 @torch.compiler.disable
 def _mark_unbacked_dim0(tensor: torch.Tensor):
     torch._dynamo.decorators.mark_unbacked(tensor, 0)
+
+
+def _get_language_model_for_moe_patch(model: torch.nn.Module) -> torch.nn.Module:
+    language_model = model
+
+    if supports_multimodal(language_model) and hasattr(language_model, 'get_language_model'):
+        try:
+            multimodal_language_model = language_model.get_language_model()
+            if isinstance(multimodal_language_model, torch.nn.Module):
+                language_model = multimodal_language_model
+        except Exception:
+            pass
+
+    # Most text-generation wrappers keep the decoder stack on `.model`.
+    # Walk through those wrappers until we reach the layer-owning module.
+    while True:
+        inner_model = getattr(language_model, 'model', None)
+        if not isinstance(inner_model, torch.nn.Module):
+            return language_model
+
+        if hasattr(language_model, 'embed_input_ids') and hasattr(language_model, 'norm') and hasattr(language_model, 'layers'):
+            return language_model
+
+        language_model = inner_model
+
+
+def _has_moe_layers(model: torch.nn.Module) -> bool:
+    return any(isinstance(module, FusedMoE) for module in model.modules())
+
+
+def _get_first_decoder_layer(language_model: torch.nn.Module) -> torch.nn.Module | None:
+    layers = getattr(language_model, 'layers', None)
+    start_layer = getattr(language_model, 'start_layer', 0)
+    end_layer = getattr(language_model, 'end_layer', None)
+    if layers is None or end_layer is None:
+        return None
+
+    for layer in itertools.islice(layers, start_layer, end_layer):
+        return layer
+    return None
+
+
+def _decoder_layer_uses_none_residual_sentinel(layer: torch.nn.Module) -> bool:
+    try:
+        source = inspect.getsource(layer.forward)
+    except (OSError, TypeError):
+        return False
+    return 'residual is None' in source
+
+
+def _get_moe_warmup_patch_skip_reason(language_model: torch.nn.Module) -> str | None:
+    if not _has_moe_layers(language_model):
+        return 'no FusedMoE layers found'
+    if not hasattr(language_model, 'embed_input_ids') or not hasattr(language_model, 'norm'):
+        return 'missing embed_input_ids or norm'
+    if not hasattr(language_model, 'layers') or not hasattr(language_model, 'start_layer') or not hasattr(language_model, 'end_layer'):
+        return 'missing layers/start_layer/end_layer decoder attributes'
+
+    first_layer = _get_first_decoder_layer(language_model)
+    if first_layer is None:
+        return 'decoder layer list is empty for this pipeline rank'
+
+    try:
+        signature = inspect.signature(first_layer.forward)
+    except (TypeError, ValueError):
+        return 'unable to inspect first decoder layer forward signature'
+
+    required_positional = [
+        parameter for parameter in signature.parameters.values()
+        if parameter.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+        and parameter.default is inspect._empty
+    ]
+    if len(required_positional) > 3:
+        return f'first decoder layer forward requires {len(required_positional)} positional args'
+    if _decoder_layer_uses_none_residual_sentinel(first_layer):
+        return 'first decoder layer branches on residual is None'
+
+    return None
+
+
+def _build_zero_residual_forward(language_model: torch.nn.Module):
+    original_forward = language_model.forward
+
+    @wraps(original_forward)
+    def _patched_forward(
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors=None,
+        inputs_embeds: torch.Tensor | None = None,
+        *args,
+        **kwargs,
+    ):
+        if args:
+            return original_forward(
+                input_ids,
+                positions,
+                intermediate_tensors=intermediate_tensors,
+                inputs_embeds=inputs_embeds,
+                *args,
+                **kwargs,
+            )
+
+        if get_pp_group().is_first_rank:
+            if inputs_embeds is not None:
+                hidden_states = inputs_embeds
+            else:
+                hidden_states = language_model.embed_input_ids(input_ids)
+            residual = torch.zeros_like(hidden_states)
+        else:
+            assert intermediate_tensors is not None
+            hidden_states = intermediate_tensors['hidden_states']
+            residual = intermediate_tensors['residual']
+
+        aux_hidden_state_layers = tuple(getattr(language_model, 'aux_hidden_state_layers', ()))
+        aux_hidden_states = []
+        for layer_idx, layer in enumerate(
+            itertools.islice(language_model.layers, language_model.start_layer, language_model.end_layer),
+            start=language_model.start_layer,
+        ):
+            if layer_idx in aux_hidden_state_layers:
+                aux_hidden_states.append(hidden_states + residual)
+            hidden_states, residual = layer(positions, hidden_states, residual, **kwargs)
+
+        if not get_pp_group().is_last_rank:
+            return IntermediateTensors({"hidden_states": hidden_states, "residual": residual})
+
+        norm_output = language_model.norm(hidden_states, residual)
+        hidden_states = norm_output[0] if isinstance(norm_output, tuple) else norm_output
+        if aux_hidden_states:
+            return hidden_states, aux_hidden_states
+        return hidden_states
+
+    return _patched_forward
+
+
+def _maybe_install_global_moe_warmup_patch(model: torch.nn.Module) -> None:
+    language_model = _get_language_model_for_moe_patch(model)
+    if getattr(language_model, '_hpu_global_moe_warmup_patch_installed', False):
+        return
+    skip_reason = _get_moe_warmup_patch_skip_reason(language_model)
+    if skip_reason is not None:
+        logger.info('Global MoE warmup patch not applied to %s: %s', type(language_model).__name__, skip_reason)
+        return
+
+    language_model.forward = _build_zero_residual_forward(language_model)
+    language_model._hpu_global_moe_warmup_patch_installed = True
+    logger.info('Installed global MoE warmup patch for %s', type(language_model).__name__)
 
 
 def _maybe_wrap_in_hpu_graph(*args, **kwargs):

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -974,7 +974,7 @@ def _maybe_install_global_moe_warmup_patch(model: torch.nn.Module) -> None:
         return
     skip_reason = _get_moe_warmup_patch_skip_reason(language_model)
     if skip_reason is not None:
-        logger.info('Global MoE warmup patch not applied to %s: %s', type(language_model).__name__, skip_reason)
+        logger.debug('Global MoE warmup patch not applied to %s: %s', type(language_model).__name__, skip_reason)
         return
 
     language_model.forward = _build_zero_residual_forward(language_model)


### PR DESCRIPTION
Removes model specific override forward() to initialize residual as zeros instead of None which eliminating torch._dynamo type guards. This is now applied Globally for all applicable MoE models.