### PR TITLE
Increase timeout from default 6h to 12h

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -29,6 +29,7 @@ concurrency:
 jobs:
   retrieve_head_sha:
     runs-on: ubuntu-latest
+    timeout-minutes: 720
     outputs:
       head_sha: ${{ steps.set_sha.outputs.head_sha }}
     steps:
@@ -40,6 +41,7 @@ jobs:
   gatekeeper:
     needs: retrieve_head_sha
     runs-on: ubuntu-latest
+    timeout-minutes: 720
     permissions:
       # Required to read the status of checks and PR details
       checks: read
@@ -136,6 +138,7 @@ jobs:
   discover_runner:
     needs: gatekeeper
     runs-on: ${{ inputs.use_hourly_runner == 'true' && 'hourly-ci' || 'pr-ci' }}
+    timeout-minutes: 720
     outputs:
       runner_name: ${{ steps.get_name.outputs.name }}
     steps:
@@ -150,6 +153,7 @@ jobs:
     needs: [discover_runner, retrieve_head_sha]
     # --- UPDATED: Run on the specific node ---
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
+    timeout-minutes: 720
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -180,6 +184,7 @@ jobs:
   discover_calibration_tests:
     needs: [discover_runner, retrieve_head_sha]
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
+    timeout-minutes: 720
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -207,6 +212,7 @@ jobs:
     # This job runs in parallel with the build job
     needs: [gatekeeper, retrieve_head_sha]
     runs-on: ubuntu-latest
+    timeout-minutes: 720
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -235,6 +241,7 @@ jobs:
     if: inputs.skip_tests != 'true'
     # --- UPDATED: Run on the specific node ---
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
+    timeout-minutes: 720
     permissions:
       contents: read # Required to checkout code and read history
     outputs:
@@ -354,6 +361,7 @@ jobs:
     needs: [pre_merge_hpu_test_build, discover_runner, retrieve_head_sha]
     # --- UPDATED: Run on the specific node ---
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
+    timeout-minutes: 720
     steps:
       - name: Run pytest in tests/unit_tests
         run: |
@@ -378,6 +386,7 @@ jobs:
     needs: [pre_merge_hpu_test_build, hpu_unit_tests, discover_runner, retrieve_head_sha]
     # --- UPDATED: Run on the specific node ---
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
+    timeout-minutes: 720
     steps:
       - name: Run test scripts
         run: |
@@ -408,6 +417,7 @@ jobs:
     needs: [pre_merge_hpu_test_build, hpu_unit_tests, discover_runner, retrieve_head_sha]
     # --- UPDATED: Run on the specific node ---
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
+    timeout-minutes: 720
     steps:
       - name: Run test scripts
         run: |
@@ -433,6 +443,7 @@ jobs:
     needs: [pre_merge_hpu_test_build, hpu_unit_tests, discover_runner, retrieve_head_sha]
     # --- UPDATED: Run on the specific node ---
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
+    timeout-minutes: 720
     steps:
       - name: Run test scripts
         run: |
@@ -459,6 +470,7 @@ jobs:
     needs: [pre_merge_hpu_test_build, hpu_unit_tests, discover_tests, discover_runner, retrieve_head_sha]
     # --- UPDATED: Run on the specific node ---
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
+    timeout-minutes: 720
     strategy:
       fail-fast: false
       matrix:
@@ -491,6 +503,7 @@ jobs:
   calibration_tests:
     needs: [pre_merge_hpu_test_build, hpu_unit_tests, discover_calibration_tests, discover_runner, retrieve_head_sha]
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
+    timeout-minutes: 720
     strategy:
       fail-fast: false
       matrix:
@@ -522,6 +535,7 @@ jobs:
   calibration_arg_parsing_tests:
     needs: [pre_merge_hpu_test_build, discover_runner, retrieve_head_sha]
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
+    timeout-minutes: 720
     steps:
       - name: Run calibration arg parsing tests
         run: |
@@ -544,6 +558,7 @@ jobs:
     needs: [retrieve_head_sha]
     if: inputs.is_merge_group != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 720
     outputs:
       nixl_changed: ${{ steps.check.outputs.nixl_changed }}
     steps:
@@ -571,6 +586,7 @@ jobs:
     needs: [check_dockerfile_changes, discover_runner, retrieve_head_sha]
     if: needs.check_dockerfile_changes.outputs.nixl_changed == 'true'
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
+    timeout-minutes: 720
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -595,6 +611,7 @@ jobs:
     needs: [hpu_unit_tests, e2e, hpu_perf_tests, calibration_tests, calibration_arg_parsing_tests, discover_runner]
     # --- UPDATED: Run on the specific node ---
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
+    timeout-minutes: 720
     # This job is required to pass for pre-merge CI. By itself it does nothing, and will only pass if all jobs specified in "needs" list pass.
     steps:
       - name: Succeeded if all previous jobs passed
@@ -605,6 +622,7 @@ jobs:
     # This job runs after hpu-test-suite completes
     needs: [pre_merge_hpu_test, pre_merge_hpu_test_build]
     runs-on: ubuntu-latest
+    timeout-minutes: 720
     permissions:
       # Permissions are required on a per-job basis
       pull-requests: write
@@ -624,6 +642,7 @@ jobs:
     if: always()
     needs: [discover_runner, hpu_unit_tests, hpu_pd_tests, hpu_perf_tests, hpu_dp_tests, e2e, calibration_tests, calibration_arg_parsing_tests]
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
+    timeout-minutes: 720
     steps:
       - name: Remove Docker image to free up space
         env:


### PR DESCRIPTION
This pull request updates the `.github/workflows/pre-merge.yaml` workflow configuration to add a `timeout-minutes: 720` (12 hours) limit to all jobs. This change ensures that no individual job in the pre-merge workflow can run indefinitely, which helps prevent stuck or runaway jobs in CI and improves overall pipeline reliability.

**CI/CD Workflow Improvements:**

* Added `timeout-minutes: 720` to all jobs in `.github/workflows/pre-merge.yaml` to enforce a 12-hour maximum runtime per job. This applies to jobs such as `retrieve_head_sha`, `gatekeeper`, `discover_runner`, `discover_tests`, `discover_calibration_tests`, test execution jobs, and finalization/cleanup jobs.

No other logic or behavior changes were made—this is a configuration-only update to improve CI robustness.