### PR TITLE
Fix stale gate ref overriding caller router_logits in dp_size==1 MoE fast path

### DIFF
--- a/vllm_gaudi/ops/hpu_fused_moe.py
+++ b/vllm_gaudi/ops/hpu_fused_moe.py
@@ -306,9 +306,16 @@ def patched_fused_moe_forward(
         layer = self._hpu_layer_ref
         layer.ensure_moe_quant_config_init()
         self._maybe_sync_shared_experts_stream(shared_experts_input)
-        gate = self.gate or getattr(self, "_hpu_gate_ref", None)
-        if gate is not None:
-            router_logits, _ = gate(hidden_states)
+        # Only invoke a runner-owned gate when the caller did not provide
+        # router_logits (internal-router mode, e.g. DeepSeek R1). For
+        # SharedFusedMoE models (Qwen3 MoE, ernie45, ...) the block's
+        # mlp.gate(...) has already produced router_logits and runner.gate
+        # is explicitly set to None by _sync_shared_moe_gates post-INC;
+        # re-invoking _hpu_gate_ref here would call a stale pre-INC module.
+        if router_logits is None:
+            gate = self.gate or getattr(self, "_hpu_gate_ref", None)
+            if gate is not None:
+                router_logits, _ = gate(hidden_states)
         shared_output, fused_hidden = self._apply_quant_method(
             layer=layer,
             hidden_states=hidden_states,

--- a/vllm_gaudi/ops/hpu_fused_moe.py
+++ b/vllm_gaudi/ops/hpu_fused_moe.py
@@ -306,16 +306,9 @@ def patched_fused_moe_forward(
         layer = self._hpu_layer_ref
         layer.ensure_moe_quant_config_init()
         self._maybe_sync_shared_experts_stream(shared_experts_input)
-        # Only invoke a runner-owned gate when the caller did not provide
-        # router_logits (internal-router mode, e.g. DeepSeek R1). For
-        # SharedFusedMoE models (Qwen3 MoE, ernie45, ...) the block's
-        # mlp.gate(...) has already produced router_logits and runner.gate
-        # is explicitly set to None by _sync_shared_moe_gates post-INC;
-        # re-invoking _hpu_gate_ref here would call a stale pre-INC module.
-        if router_logits is None:
-            gate = self.gate or getattr(self, "_hpu_gate_ref", None)
-            if gate is not None:
-                router_logits, _ = gate(hidden_states)
+        gate = self.gate or getattr(self, "_hpu_gate_ref", None)
+        if gate is not None:
+            router_logits, _ = gate(hidden_states)
         shared_output, fused_hidden = self._apply_quant_method(
             layer=layer,
             hidden_states=hidden_states,

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -4815,6 +4815,15 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
                 runner = getattr(experts, "runner", None)
                 if runner is not None and hasattr(runner, "gate"):
                     runner.gate = None
+                    # Refresh the cached gate ref captured at
+                    # FusedMoE.__init__ to the post-INC block-level gate.
+                    # The dp_size==1 fast path (patched_fused_moe_forward)
+                    # falls back to runner._hpu_gate_ref when runner.gate
+                    # is None; the pre-INC reference points at the now-
+                    # replaced module and produced shape/dtype mismatches
+                    # under fp8.
+                    if block_gate is not None:
+                        object.__setattr__(runner, "_hpu_gate_ref", block_gate)
 
                 if id(experts) in self._detached_moe_gates:
                     self._detached_moe_gates.remove(id(experts))


### PR DESCRIPTION
PR #1441 added an _hpu_gate_ref fallback in the dp_size==1 fast path
that unconditionally re-invoked a runner-owned gate, overwriting
router_logits supplied by the caller. For SharedFusedMoE models
(Qwen3 MoE, ernie45, ...) the block's mlp.gate(...) has already
produced router_logits and _sync_shared_moe_gates sets
runner.gate=None post-INC; the cached _hpu_gate_ref still points at
the pre-INC module and produced shape/dtype mismatches under fp8.

Only invoke the runner-owned gate when the caller did not provide
router_logits, preserving the DeepSeek R1 internal-router fast path
from #1441.