### PR TITLE
ci: route HF_TOKEN-using jobs through approved-workflow environment

### DIFF
--- a/.github/workflows/create-release-branch.yaml
+++ b/.github/workflows/create-release-branch.yaml
@@ -164,6 +164,7 @@ jobs:
     needs: [prepare-release-branch, setup_and_build, discover_runner]
     # --- UPDATED: Run on the specific node ---
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
+    environment: approved-workflow
     steps:
       - name: Run pytest in tests/unit_tests
         run: |
@@ -216,6 +217,7 @@ jobs:
     needs: [prepare-release-branch, setup_and_build, discover_tests, discover_runner]
     # --- UPDATED: Run on the specific node ---
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
+    environment: approved-workflow
     strategy:
       fail-fast: false
       matrix:
@@ -248,6 +250,7 @@ jobs:
     needs: [prepare-release-branch, setup_and_build, discover_runner]
     # --- UPDATED: Run on the specific node ---
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
+    environment: approved-workflow
     steps:
       - name: Run Data Parallel test
         run: |
@@ -275,6 +278,7 @@ jobs:
     needs: [prepare-release-branch, setup_and_build, discover_runner]
     # --- UPDATED: Run on the specific node ---
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
+    environment: approved-workflow
     steps:
       - name: Run PD disaggregate test
         run: |
@@ -305,6 +309,7 @@ jobs:
     needs: [prepare-release-branch, setup_and_build, discover_runner]
     # --- UPDATED: Run on the specific node ---
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
+    environment: approved-workflow
     steps:
       - name: Run Sharegpt performance tests with warmup
         run: |

--- a/.github/workflows/hourly-ci.yaml
+++ b/.github/workflows/hourly-ci.yaml
@@ -101,6 +101,7 @@ jobs:
     needs: [setup_and_build, discover_runner]
     # <-- UPDATED: Runs on the specific runner
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
+    environment: approved-workflow
     steps:
       - name: Run pytest in tests/unit_tests
         run: |
@@ -157,6 +158,7 @@ jobs:
     needs: [setup_and_build, discover_tests, discover_runner]
     # <-- UPDATED: Runs on the specific runner
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
+    environment: approved-workflow
     strategy:
       fail-fast: false
       matrix:
@@ -192,6 +194,7 @@ jobs:
     needs: [setup_and_build, discover_runner]
     # <-- UPDATED: Runs on the specific runner
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
+    environment: approved-workflow
     steps:
       - name: Run Data Parallel test
         run: |
@@ -220,6 +223,7 @@ jobs:
     needs: [setup_and_build, discover_runner]
     # <-- UPDATED: Runs on the specific runner
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
+    environment: approved-workflow
     steps:
       - name: Run PD disaggregate test
         run: |

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -361,6 +361,7 @@ jobs:
     needs: [pre_merge_hpu_test_build, discover_runner, retrieve_head_sha]
     # --- UPDATED: Run on the specific node ---
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
+    environment: approved-workflow
     timeout-minutes: 720
     steps:
       - name: Run pytest in tests/unit_tests
@@ -386,6 +387,7 @@ jobs:
     needs: [pre_merge_hpu_test_build, hpu_unit_tests, discover_runner, retrieve_head_sha]
     # --- UPDATED: Run on the specific node ---
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
+    environment: approved-workflow
     timeout-minutes: 720
     steps:
       - name: Run test scripts
@@ -417,6 +419,7 @@ jobs:
     needs: [pre_merge_hpu_test_build, hpu_unit_tests, discover_runner, retrieve_head_sha]
     # --- UPDATED: Run on the specific node ---
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
+    environment: approved-workflow
     timeout-minutes: 720
     steps:
       - name: Run test scripts
@@ -443,6 +446,7 @@ jobs:
     needs: [pre_merge_hpu_test_build, hpu_unit_tests, discover_runner, retrieve_head_sha]
     # --- UPDATED: Run on the specific node ---
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
+    environment: approved-workflow
     timeout-minutes: 720
     steps:
       - name: Run test scripts
@@ -470,6 +474,7 @@ jobs:
     needs: [pre_merge_hpu_test_build, hpu_unit_tests, discover_tests, discover_runner, retrieve_head_sha]
     # --- UPDATED: Run on the specific node ---
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
+    environment: approved-workflow
     timeout-minutes: 720
     strategy:
       fail-fast: false
@@ -503,6 +508,7 @@ jobs:
   calibration_tests:
     needs: [pre_merge_hpu_test_build, hpu_unit_tests, discover_calibration_tests, discover_runner, retrieve_head_sha]
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
+    environment: approved-workflow
     timeout-minutes: 720
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

Adds `environment: approved-workflow` to every job that consumes `secrets.HF_TOKEN` across the three CI workflows. Together with the existing approval gate in `pre-merge-trigger.yaml` (`environment: pre-merge-approval`, added in #1471), this completes the two-layer protection model:

```
PR opened
  -> pre-merge-trigger `gate` job: pauses for required reviewer (approval #1)
  -> on approval, pre-merge.yaml is dispatched
  -> downstream secret-using jobs resolve HF_TOKEN from the
     `approved-workflow` environment (no second per-job approval)
```

## Why

With `HF_TOKEN` previously at repo-secret scope, any matrix entry of any e2e/test job had direct access the moment CI started. The recent malicious fork PR exfiltrated it via an auto-discovered `run_*` function. After this change, the token is only released from a GitHub Environment that a maintainer-controlled deployment-branch rule restricts to `main` / `releases/**`, and only after the upstream gate has approved the dispatch.

We deliberately add the environment only on jobs that actually use the secret (15 jobs). Helper jobs (`gatekeeper`, `discover_*`, `retrieve_*`, `pre-commit`, `post-comment`, `cleanup_*`, `build_nixl_dockerfile`, `check_dockerfile_changes`, `prepare-release-branch`, `summarize_and_notify`, `setup_and_build`, `store_last_stable_vllm_commit`) do not touch HF_TOKEN and are not modified, to avoid pointless extra gate evaluations.

## Affected jobs (15)

- `pre-merge.yaml`: `hpu_unit_tests`, `hpu_pd_tests`, `hpu_perf_tests`, `hpu_dp_tests`, `e2e`, `calibration_tests`
- `hourly-ci.yaml`: `run_unit_tests`, `e2e`, `run_data_parallel_test`, `run_pd_disaggregate_test`
- `create-release-branch.yaml`: `run_unit_tests`, `e2e`, `run_data_parallel_test`, `run_pd_disaggregate_test`, `run_hpu_perf_tests`

## Diff

+15 lines, 0 deletions. Each touched job gets exactly one new line: `environment: approved-workflow`, inserted immediately after `runs-on:`.

## Required repo configuration (before this PR can be merged safely)

1. Settings → Environments → create environment **`approved-workflow`**.
2. Add **`HF_TOKEN`** as an environment secret (the rotated value).
3. **No required reviewers** on this environment (the upstream `pre-merge-approval` gate already enforces approval; adding reviewers here would prompt once per job).
4. **Deployment branches and tags**: Selected branches → `main`, `releases/**`. Prevents a fork PR from claiming the environment from a non-trusted ref.
5. **Delete** `HF_TOKEN` from repository-level secrets so the environment value is the only source.

## Testing

Validated end-to-end against `bmyrcha/vllm-gaudi` first using a benign fork PR. With the two environments configured as above, the gate paused as expected, jobs received the secret after approval without a second prompt, and a deliberately mis-authored downstream PR could not reach the secret.

Close-cross-ref: builds on #1471.