### PR TITLE
ci: enforce egress allow-list on jobs that consume HF_TOKEN

### DIFF
--- a/.github/workflows/create-release-branch.yaml
+++ b/.github/workflows/create-release-branch.yaml
@@ -165,6 +165,33 @@ jobs:
     # --- UPDATED: Run on the specific node ---
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
     steps:
+      - name: Harden runner (egress block)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: block
+          disable-sudo: false
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            *.actions.githubusercontent.com:443
+            results-receiver.actions.githubusercontent.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            *.blob.core.windows.net:443
+            vault.habana.ai:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            download.pytorch.org:443
+            huggingface.co:443
+            cdn-lfs.huggingface.co:443
+            cdn-lfs.hf.co:443
+            cdn-lfs-us-1.hf.co:443
+            cas-bridge.xethub.hf.co:443
+            xet-lfs-us-1.hf.co:443
       - name: Run pytest in tests/unit_tests
         run: |
           EXITCODE=1
@@ -222,6 +249,33 @@ jobs:
         test_function: ${{ fromJson(needs.discover_tests.outputs.matrix) }}
 
     steps:
+      - name: Harden runner (egress block)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: block
+          disable-sudo: false
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            *.actions.githubusercontent.com:443
+            results-receiver.actions.githubusercontent.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            *.blob.core.windows.net:443
+            vault.habana.ai:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            download.pytorch.org:443
+            huggingface.co:443
+            cdn-lfs.huggingface.co:443
+            cdn-lfs.hf.co:443
+            cdn-lfs-us-1.hf.co:443
+            cas-bridge.xethub.hf.co:443
+            xet-lfs-us-1.hf.co:443
       - name: Run test suite - ${{ matrix.test_function }}
         run: |
           EXITCODE=1
@@ -249,6 +303,33 @@ jobs:
     # --- UPDATED: Run on the specific node ---
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
     steps:
+      - name: Harden runner (egress block)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: block
+          disable-sudo: false
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            *.actions.githubusercontent.com:443
+            results-receiver.actions.githubusercontent.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            *.blob.core.windows.net:443
+            vault.habana.ai:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            download.pytorch.org:443
+            huggingface.co:443
+            cdn-lfs.huggingface.co:443
+            cdn-lfs.hf.co:443
+            cdn-lfs-us-1.hf.co:443
+            cas-bridge.xethub.hf.co:443
+            xet-lfs-us-1.hf.co:443
       - name: Run Data Parallel test
         run: |
           EXITCODE=1
@@ -276,6 +357,33 @@ jobs:
     # --- UPDATED: Run on the specific node ---
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
     steps:
+      - name: Harden runner (egress block)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: block
+          disable-sudo: false
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            *.actions.githubusercontent.com:443
+            results-receiver.actions.githubusercontent.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            *.blob.core.windows.net:443
+            vault.habana.ai:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            download.pytorch.org:443
+            huggingface.co:443
+            cdn-lfs.huggingface.co:443
+            cdn-lfs.hf.co:443
+            cdn-lfs-us-1.hf.co:443
+            cas-bridge.xethub.hf.co:443
+            xet-lfs-us-1.hf.co:443
       - name: Run PD disaggregate test
         run: |
           EXITCODE=1
@@ -306,6 +414,33 @@ jobs:
     # --- UPDATED: Run on the specific node ---
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
     steps:
+      - name: Harden runner (egress block)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: block
+          disable-sudo: false
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            *.actions.githubusercontent.com:443
+            results-receiver.actions.githubusercontent.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            *.blob.core.windows.net:443
+            vault.habana.ai:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            download.pytorch.org:443
+            huggingface.co:443
+            cdn-lfs.huggingface.co:443
+            cdn-lfs.hf.co:443
+            cdn-lfs-us-1.hf.co:443
+            cas-bridge.xethub.hf.co:443
+            xet-lfs-us-1.hf.co:443
       - name: Run Sharegpt performance tests with warmup
         run: |
           EXITCODE=1

--- a/.github/workflows/hourly-ci.yaml
+++ b/.github/workflows/hourly-ci.yaml
@@ -102,6 +102,33 @@ jobs:
     # <-- UPDATED: Runs on the specific runner
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
     steps:
+      - name: Harden runner (egress block)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: block
+          disable-sudo: false
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            *.actions.githubusercontent.com:443
+            results-receiver.actions.githubusercontent.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            *.blob.core.windows.net:443
+            vault.habana.ai:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            download.pytorch.org:443
+            huggingface.co:443
+            cdn-lfs.huggingface.co:443
+            cdn-lfs.hf.co:443
+            cdn-lfs-us-1.hf.co:443
+            cas-bridge.xethub.hf.co:443
+            xet-lfs-us-1.hf.co:443
       - name: Run pytest in tests/unit_tests
         run: |
           EXITCODE=1
@@ -164,6 +191,33 @@ jobs:
         test_function: ${{ fromJson(needs.discover_tests.outputs.matrix) }}
 
     steps:
+      - name: Harden runner (egress block)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: block
+          disable-sudo: false
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            *.actions.githubusercontent.com:443
+            results-receiver.actions.githubusercontent.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            *.blob.core.windows.net:443
+            vault.habana.ai:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            download.pytorch.org:443
+            huggingface.co:443
+            cdn-lfs.huggingface.co:443
+            cdn-lfs.hf.co:443
+            cdn-lfs-us-1.hf.co:443
+            cas-bridge.xethub.hf.co:443
+            xet-lfs-us-1.hf.co:443
       - name: Run test suite - ${{ matrix.test_function }}
         run: |
           EXITCODE=1
@@ -193,6 +247,33 @@ jobs:
     # <-- UPDATED: Runs on the specific runner
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
     steps:
+      - name: Harden runner (egress block)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: block
+          disable-sudo: false
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            *.actions.githubusercontent.com:443
+            results-receiver.actions.githubusercontent.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            *.blob.core.windows.net:443
+            vault.habana.ai:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            download.pytorch.org:443
+            huggingface.co:443
+            cdn-lfs.huggingface.co:443
+            cdn-lfs.hf.co:443
+            cdn-lfs-us-1.hf.co:443
+            cas-bridge.xethub.hf.co:443
+            xet-lfs-us-1.hf.co:443
       - name: Run Data Parallel test
         run: |
           EXITCODE=1
@@ -221,6 +302,33 @@ jobs:
     # <-- UPDATED: Runs on the specific runner
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
     steps:
+      - name: Harden runner (egress block)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: block
+          disable-sudo: false
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            *.actions.githubusercontent.com:443
+            results-receiver.actions.githubusercontent.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            *.blob.core.windows.net:443
+            vault.habana.ai:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            download.pytorch.org:443
+            huggingface.co:443
+            cdn-lfs.huggingface.co:443
+            cdn-lfs.hf.co:443
+            cdn-lfs-us-1.hf.co:443
+            cas-bridge.xethub.hf.co:443
+            xet-lfs-us-1.hf.co:443
       - name: Run PD disaggregate test
         run: |
           EXITCODE=1

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -363,6 +363,33 @@ jobs:
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
     timeout-minutes: 720
     steps:
+      - name: Harden runner (egress block)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: block
+          disable-sudo: false
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            *.actions.githubusercontent.com:443
+            results-receiver.actions.githubusercontent.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            *.blob.core.windows.net:443
+            vault.habana.ai:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            download.pytorch.org:443
+            huggingface.co:443
+            cdn-lfs.huggingface.co:443
+            cdn-lfs.hf.co:443
+            cdn-lfs-us-1.hf.co:443
+            cas-bridge.xethub.hf.co:443
+            xet-lfs-us-1.hf.co:443
       - name: Run pytest in tests/unit_tests
         run: |
           EXITCODE=1
@@ -388,6 +415,33 @@ jobs:
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
     timeout-minutes: 720
     steps:
+      - name: Harden runner (egress block)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: block
+          disable-sudo: false
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            *.actions.githubusercontent.com:443
+            results-receiver.actions.githubusercontent.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            *.blob.core.windows.net:443
+            vault.habana.ai:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            download.pytorch.org:443
+            huggingface.co:443
+            cdn-lfs.huggingface.co:443
+            cdn-lfs.hf.co:443
+            cdn-lfs-us-1.hf.co:443
+            cas-bridge.xethub.hf.co:443
+            xet-lfs-us-1.hf.co:443
       - name: Run test scripts
         run: |
           EXITCODE=1
@@ -419,6 +473,33 @@ jobs:
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
     timeout-minutes: 720
     steps:
+      - name: Harden runner (egress block)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: block
+          disable-sudo: false
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            *.actions.githubusercontent.com:443
+            results-receiver.actions.githubusercontent.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            *.blob.core.windows.net:443
+            vault.habana.ai:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            download.pytorch.org:443
+            huggingface.co:443
+            cdn-lfs.huggingface.co:443
+            cdn-lfs.hf.co:443
+            cdn-lfs-us-1.hf.co:443
+            cas-bridge.xethub.hf.co:443
+            xet-lfs-us-1.hf.co:443
       - name: Run test scripts
         run: |
           EXITCODE=1
@@ -445,6 +526,33 @@ jobs:
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
     timeout-minutes: 720
     steps:
+      - name: Harden runner (egress block)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: block
+          disable-sudo: false
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            *.actions.githubusercontent.com:443
+            results-receiver.actions.githubusercontent.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            *.blob.core.windows.net:443
+            vault.habana.ai:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            download.pytorch.org:443
+            huggingface.co:443
+            cdn-lfs.huggingface.co:443
+            cdn-lfs.hf.co:443
+            cdn-lfs-us-1.hf.co:443
+            cas-bridge.xethub.hf.co:443
+            xet-lfs-us-1.hf.co:443
       - name: Run test scripts
         run: |
           EXITCODE=1
@@ -478,6 +586,33 @@ jobs:
         test_function: ${{ fromJson(needs.discover_tests.outputs.matrix) }}
 
     steps:
+      - name: Harden runner (egress block)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: block
+          disable-sudo: false
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            *.actions.githubusercontent.com:443
+            results-receiver.actions.githubusercontent.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            *.blob.core.windows.net:443
+            vault.habana.ai:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            download.pytorch.org:443
+            huggingface.co:443
+            cdn-lfs.huggingface.co:443
+            cdn-lfs.hf.co:443
+            cdn-lfs-us-1.hf.co:443
+            cas-bridge.xethub.hf.co:443
+            xet-lfs-us-1.hf.co:443
       - name: Run test suite - ${{ matrix.test_function }}
         run: |
           EXITCODE=1
@@ -510,6 +645,33 @@ jobs:
         test_function: ${{ fromJson(needs.discover_calibration_tests.outputs.matrix) }}
 
     steps:
+      - name: Harden runner (egress block)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: block
+          disable-sudo: false
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            *.actions.githubusercontent.com:443
+            results-receiver.actions.githubusercontent.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            *.blob.core.windows.net:443
+            vault.habana.ai:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            download.pytorch.org:443
+            huggingface.co:443
+            cdn-lfs.huggingface.co:443
+            cdn-lfs.hf.co:443
+            cdn-lfs-us-1.hf.co:443
+            cas-bridge.xethub.hf.co:443
+            xet-lfs-us-1.hf.co:443
       - name: Run calibration test - ${{ matrix.test_function }}
         run: |
           EXITCODE=1


### PR DESCRIPTION
## Summary

Adds [`step-security/harden-runner@v2.19.3`](https://github.com/step-security/harden-runner) (SHA-pinned) as the first step of every CI job that consumes `secrets.HF_TOKEN`, configured with **`egress-policy: block`** and a curated allow-list of endpoints that the current build + test pipeline actually needs.

> Reopen of #1474 on a clearer branch name (`feat/harden-runner-egress-block`). No content change.

## Why

Even with #1471 (pre-merge approval gate) and #1473 (`approved-workflow` environment for `HF_TOKEN`), a planted payload that activates inside a trusted job today has **unrestricted egress**. 

Layered together, these three PRs mean a planted payload in a PR cannot:
1. **Run at all** without maintainer approval &mdash; #1471 (merged)
2. **Receive `HF_TOKEN`** without environment approval &mdash; #1473
3. **Exfiltrate to an attacker-controlled host** &mdash; this PR

## Allow-list (derived from code, not collected from runs)

Walked through `.github/Dockerfile.ci`, the three workflow YAMLs, and `tests/full_tests/ci_e2e_discoverable_tests.sh`:

| Purpose | Endpoints |
|---|---|
| GitHub Actions infra | `api.github.com`, `github.com`, `codeload.github.com`, `objects.githubusercontent.com`, `raw.githubusercontent.com`, `release-assets.githubusercontent.com`, `*.actions.githubusercontent.com`, `results-receiver.actions.githubusercontent.com`, `ghcr.io`, `pkg-containers.githubusercontent.com`, `*.blob.core.windows.net` |
| Docker base image (build phase) | `vault.habana.ai` |
| Python packages (build + test) | `pypi.org`, `files.pythonhosted.org`, `download.pytorch.org` |
| Model weights (test phase) | `huggingface.co`, `cdn-lfs.huggingface.co`, `cdn-lfs.hf.co`, `cdn-lfs-us-1.hf.co`, `cas-bridge.xethub.hf.co`, `xet-lfs-us-1.hf.co` |

If something legitimate gets blocked, the harden-runner check-run identifies the denied host and we add it in a follow-up one-liner.

## How it covers the docker containers

Every test container is launched with `--network=host`, so the eBPF filter installed by harden-runner on the runner host sees and enforces on the container's outbound traffic &mdash; no per-container instrumentation needed.

## Affected jobs (15 &mdash; same set as #1473)

| Workflow | Jobs |
|---|---|
| `pre-merge.yaml` | `hpu_unit_tests`, `hpu_pd_tests`, `hpu_perf_tests`, `hpu_dp_tests`, `e2e`, `calibration_tests` |
| `hourly-ci.yaml` | `run_unit_tests`, `e2e`, `run_data_parallel_test`, `run_pd_disaggregate_test` |
| `create-release-branch.yaml` | `run_unit_tests`, `e2e`, `run_data_parallel_test`, `run_pd_disaggregate_test`, `run_hpu_perf_tests` |

## Snippet inserted (identical in every job)

```yaml
      - name: Harden runner (egress block)
        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
        with:
          egress-policy: block
          disable-sudo: false
          allowed-endpoints: >
            api.github.com:443
            github.com:443
            codeload.github.com:443
            objects.githubusercontent.com:443
            raw.githubusercontent.com:443
            release-assets.githubusercontent.com:443
            *.actions.githubusercontent.com:443
            results-receiver.actions.githubusercontent.com:443
            ghcr.io:443
            pkg-containers.githubusercontent.com:443
            *.blob.core.windows.net:443
            vault.habana.ai:443
            pypi.org:443
            files.pythonhosted.org:443
            download.pytorch.org:443
            huggingface.co:443
            cdn-lfs.huggingface.co:443
            cdn-lfs.hf.co:443
            cdn-lfs-us-1.hf.co:443
            cas-bridge.xethub.hf.co:443
            xet-lfs-us-1.hf.co:443
```

## Self-hosted runner notes

- `harden-runner` installs a small monitoring agent on the runner host. Requires `sudo` (already available on `pr-ci` / `hourly-ci` pools).
- `disable-sudo: false` is kept because some CI steps need `docker` via group/sudo.
- The `--privileged` flag on test containers means a sufficiently sophisticated payload could try to tamper with the host firewall from inside the container. This is a residual risk; closing it would require moving the harden-runner step **inside** the container or dropping `--privileged`. Out of scope here.
