### PR TITLE
Fix graph (re)compilation warnings for single process models swap

### DIFF
--- a/tests/unit_tests/test_bucketing.py
+++ b/tests/unit_tests/test_bucketing.py
@@ -55,6 +55,40 @@ def test_get_bucketing_strategy_default_when_env_not_set(monkeypatch):
     assert isinstance(strategy, ExponentialBucketingStrategy)
 
 
+def test_constructing_standby_manager_does_not_replace_active_instance():
+    HPUBucketingManager._active_instance = None
+
+    active_manager = HPUBucketingManager()
+    active_manager.initialize(max_num_seqs=8,
+                              max_num_prefill_seqs=4,
+                              block_size=128,
+                              max_num_batched_tokens=1024,
+                              max_model_len=1024)
+
+    standby_manager = HPUBucketingManager()
+
+    assert standby_manager.initialized is False
+    assert HPUBucketingManager.get_instance() is active_manager
+
+
+def test_activate_switches_active_manager_without_reinitializing():
+    HPUBucketingManager._active_instance = None
+
+    first_manager = HPUBucketingManager()
+    first_manager.initialize(max_num_seqs=8,
+                             max_num_prefill_seqs=4,
+                             block_size=128,
+                             max_num_batched_tokens=1024,
+                             max_model_len=1024)
+
+    restored_manager = HPUBucketingManager()
+    restored_manager.initialized = True
+
+    restored_manager.activate()
+
+    assert HPUBucketingManager.get_instance() is restored_manager
+
+
 @patch('vllm_gaudi.extension.bucketing.common.logger')
 def test_get_bucketing_strategy_deprecated_env_overrides_to_exponential(mock_logger, monkeypatch):
     monkeypatch.setenv("VLLM_BUCKETING_STRATEGY", "lin")

--- a/tests/unit_tests/test_bucketing.py
+++ b/tests/unit_tests/test_bucketing.py
@@ -55,6 +55,13 @@ def test_get_bucketing_strategy_default_when_env_not_set(monkeypatch):
     assert isinstance(strategy, ExponentialBucketingStrategy)
 
 
+def test_get_instance_raises_when_no_active_manager(monkeypatch):
+    monkeypatch.setattr(HPUBucketingManager, "_active_instance", None)
+
+    with pytest.raises(RuntimeError, match="No active HPUBucketingManager instance"):
+        HPUBucketingManager.get_instance()
+
+
 def test_constructing_standby_manager_does_not_replace_active_instance():
     HPUBucketingManager._active_instance = None
 

--- a/tests/unit_tests/test_bucketing.py
+++ b/tests/unit_tests/test_bucketing.py
@@ -62,8 +62,8 @@ def test_get_instance_raises_when_no_active_manager(monkeypatch):
         HPUBucketingManager.get_instance()
 
 
-def test_constructing_standby_manager_does_not_replace_active_instance():
-    HPUBucketingManager._active_instance = None
+def test_constructing_standby_manager_does_not_replace_active_instance(monkeypatch):
+    monkeypatch.setattr(HPUBucketingManager, "_active_instance", None)
 
     active_manager = HPUBucketingManager()
     active_manager.initialize(max_num_seqs=8,
@@ -78,8 +78,8 @@ def test_constructing_standby_manager_does_not_replace_active_instance():
     assert HPUBucketingManager.get_instance() is active_manager
 
 
-def test_activate_switches_active_manager_without_reinitializing():
-    HPUBucketingManager._active_instance = None
+def test_activate_switches_active_manager_without_reinitializing(monkeypatch):
+    monkeypatch.setattr(HPUBucketingManager, "_active_instance", None)
 
     first_manager = HPUBucketingManager()
     first_manager.initialize(max_num_seqs=8,

--- a/vllm_gaudi/extension/bucketing/common.py
+++ b/vllm_gaudi/extension/bucketing/common.py
@@ -60,6 +60,10 @@ class HPUBucketingManager():
         HPUBucketingManager._active_instance = self
         return self
 
+    @classmethod
+    def deactivate(cls):
+        cls._active_instance = None
+
     def initialize(self,
                    max_num_seqs,
                    max_num_prefill_seqs,

--- a/vllm_gaudi/extension/bucketing/common.py
+++ b/vllm_gaudi/extension/bucketing/common.py
@@ -42,18 +42,20 @@ def calc_fallback_value(n: int, base_step: int):
 
 
 class HPUBucketingManager():
-    _instance = None
-    prompt_buckets: List[Tuple[int, int, int]] = []
-    decode_buckets: List[Tuple[int, int, int]] = []
-    # Seed buckets are the buckets originally generated from bucketing configuration
-    # Spec decode may automatically add new buckets based on the seed buckets
-    seed_decode_buckets: List[Tuple[int, int, int]] = None
-    initialized = False
+    # Keep an active-manager handle for code paths that cannot access
+    # the runner-local manager object directly (for example, fsdpa setup).
+    _active_instance = None
 
-    def __new__(cls, *args, **kwargs):
-        if not cls._instance:
-            cls._instance = super(HPUBucketingManager, cls).__new__(cls)
-        return cls._instance
+    def __init__(self):
+        # All mutable state must be instance-local to avoid cross-model
+        # contamination when multiple runners are stashed/restored.
+        self.prompt_buckets: List[Tuple[int, int, int]] = []
+        self.decode_buckets: List[Tuple[int, int, int]] = []
+        # Seed buckets are the buckets originally generated from bucketing configuration
+        # Spec decode may automatically add new buckets based on the seed buckets
+        self.seed_decode_buckets: List[Tuple[int, int, int]] | None = None
+        self.initialized = False
+        HPUBucketingManager._active_instance = self
 
     def initialize(self,
                    max_num_seqs,
@@ -64,6 +66,7 @@ class HPUBucketingManager():
                    num_speculative_tokens=0,
                    mamba_chunk_size=0,
                    mamba_chunk_size_is_explicit=False):
+        HPUBucketingManager._active_instance = self
         self.max_num_seqs = max_num_seqs
         self.max_num_prefill_seqs = max_num_prefill_seqs
         self.block_size = block_size
@@ -354,10 +357,8 @@ class HPUBucketingManager():
 
     @classmethod
     def get_instance(cls):
-        """
-        Retrieve the singleton instance of the class.
-        """
-        return cls._instance
+        """Retrieve the currently active bucketing manager instance."""
+        return cls._active_instance
 
 
 def get_bucketing_manager():

--- a/vllm_gaudi/extension/bucketing/common.py
+++ b/vllm_gaudi/extension/bucketing/common.py
@@ -55,7 +55,10 @@ class HPUBucketingManager():
         # Spec decode may automatically add new buckets based on the seed buckets
         self.seed_decode_buckets: List[Tuple[int, int, int]] | None = None
         self.initialized = False
+
+    def activate(self):
         HPUBucketingManager._active_instance = self
+        return self
 
     def initialize(self,
                    max_num_seqs,
@@ -66,7 +69,7 @@ class HPUBucketingManager():
                    num_speculative_tokens=0,
                    mamba_chunk_size=0,
                    mamba_chunk_size_is_explicit=False):
-        HPUBucketingManager._active_instance = self
+        self.activate()
         self.max_num_seqs = max_num_seqs
         self.max_num_prefill_seqs = max_num_prefill_seqs
         self.block_size = block_size

--- a/vllm_gaudi/extension/bucketing/common.py
+++ b/vllm_gaudi/extension/bucketing/common.py
@@ -361,6 +361,8 @@ class HPUBucketingManager():
     @classmethod
     def get_instance(cls):
         """Retrieve the currently active bucketing manager instance."""
+        if cls._active_instance is None:
+            raise RuntimeError("No active HPUBucketingManager instance. Call initialize() or activate() first.")
         return cls._active_instance
 
 

--- a/vllm_gaudi/utils.py
+++ b/vllm_gaudi/utils.py
@@ -303,7 +303,8 @@ def _hpu_get_by_source(self, source: str) -> int:
     return max(0, _stats_get_by_source_orig(self, source))
 
 
-_stats_module.PromptTokenStats.get_by_source = _hpu_get_by_source
+_prompt_token_stats_cls: Any = _stats_module.PromptTokenStats
+_prompt_token_stats_cls.get_by_source = _hpu_get_by_source
 
 
 def patch_nixl_utils_for_hpu():

--- a/vllm_gaudi/v1/worker/hpu_worker.py
+++ b/vllm_gaudi/v1/worker/hpu_worker.py
@@ -30,6 +30,7 @@ from vllm.utils.torch_utils import (STR_DTYPE_TO_TORCH_DTYPE, get_dtype_size, se
 from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig, KVCacheSpec, MambaSpec)
 from vllm.v1.outputs import (DraftTokenIds, AsyncModelRunnerOutput, ModelRunnerOutput)
 from vllm.v1.worker.utils import bind_kv_cache
+from vllm_gaudi.extension.bucketing.common import HPUBucketingManager
 from vllm_gaudi.utils import is_fake_hpu
 from vllm_gaudi.v1.worker.hpu_model_runner import HPUModelRunner, _GDN_MAMBA_TYPES
 from vllm.v1.worker.worker_base import CompilationTimes, WorkerBase
@@ -199,6 +200,7 @@ class HPUWorker(WorkerBase):
                     "kv_cache_config": self.kv_cache_config,
                 }
                 self.model_runner = None
+                HPUBucketingManager.deactivate()
             # Preserve previous KV cache metadata in stash for rollback.
             self.model_sleeping = False
             self.kv_cache_sleeping = False

--- a/vllm_gaudi/v1/worker/hpu_worker.py
+++ b/vllm_gaudi/v1/worker/hpu_worker.py
@@ -286,6 +286,10 @@ class HPUWorker(WorkerBase):
         self.model_runner = self._model_runner_stash.pop(stash_key)
         stashed_state = self._model_runner_state_stash.pop(stash_key, {})
 
+        bucketing_manager = getattr(self.model_runner, "bucketing_manager", None)
+        if bucketing_manager is not None:
+            bucketing_manager.activate()
+
         restored_config = stashed_state.get("vllm_config", getattr(self.model_runner, "vllm_config", target_config))
         self._apply_vllm_config(restored_config)
 

--- a/vllm_gaudi/v1/worker/hpu_worker.py
+++ b/vllm_gaudi/v1/worker/hpu_worker.py
@@ -198,9 +198,6 @@ class HPUWorker(WorkerBase):
                     "kv_cache_sleeping": self.kv_cache_sleeping,
                     "kv_cache_config": self.kv_cache_config,
                 }
-                bucketing_manager = getattr(self.model_runner, "bucketing_manager", None)
-                if bucketing_manager is not None:
-                    bucketing_manager._active_instance = None
                 self.model_runner = None
             # Preserve previous KV cache metadata in stash for rollback.
             self.model_sleeping = False

--- a/vllm_gaudi/v1/worker/hpu_worker.py
+++ b/vllm_gaudi/v1/worker/hpu_worker.py
@@ -198,6 +198,9 @@ class HPUWorker(WorkerBase):
                     "kv_cache_sleeping": self.kv_cache_sleeping,
                     "kv_cache_config": self.kv_cache_config,
                 }
+                bucketing_manager = getattr(self.model_runner, "bucketing_manager", None)
+                if bucketing_manager is not None:
+                    bucketing_manager._active_instance = None
                 self.model_runner = None
             # Preserve previous KV cache metadata in stash for rollback.
             self.model_sleeping = False


### PR DESCRIPTION
This PR refactors the HPUBucketingManager() to improve support for multiple model runners and safe state restoration. The main change is replacing the singleton pattern with an explicit "active instance" approach, ensuring that each model runner can have its own independent bucketing manager without cross-contamination of state. Additional tests are added to verify the correct behavior of the new activation logic.

**Miscellaneous:**

* Minor refactor in `utils.py` to improve how the `get_by_source` method is patched for prompt token stats. (`vllm_gaudi/utils.py`). Due to a mypy error. 

Please note, the change has been extensively tested for multiple models swap, while for the classical vllm-gaudi scenario (one model per card) I run only the unit tests for buckets and fsdp.