### PR TITLE
[FIX_FOR_VLLM_CUSTOM=0a54df28471be07b3d668ea21c5e411569d3baea] Fix DynamicNTKScalingRotaryEmbedding and HPUCompressedTensorsConfig

### DIFF
--- a/tests/unit_tests/ops/test_hpu_rotary_embedding.py
+++ b/tests/unit_tests/ops/test_hpu_rotary_embedding.py
@@ -201,6 +201,7 @@ def test_dynamic_ntk_scaling_rotary_embedding(
         "head_size": head_size,
         "rotary_dim": rotary_dim,
         "max_position_embeddings": max_position_embeddings,
+        "max_trained_positions": max_position_embeddings,
         "base": base,
         "is_neox_style": is_neox_style,
         "scaling_factor": scaling_factor,

--- a/vllm_gaudi/ops/hpu_compressed_tensors.py
+++ b/vllm_gaudi/ops/hpu_compressed_tensors.py
@@ -20,7 +20,6 @@ from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tenso
     CompressedTensorsConfig,
     CompressedTensorsMoEMethod,
     CompressedTensorsKVCacheMethod,
-    SparsityCompressionConfig,
 )
 from vllm.model_executor.layers.quantization.compressed_tensors import (compressed_tensors_moe)
 from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe import (
@@ -1056,8 +1055,6 @@ class HPUCompressedTensorsConfig(CompressedTensorsConfig):
         target_scheme_map: dict[str, Any],
         ignore: list[str],
         quant_format: str,
-        sparsity_scheme_map: dict[str, SparsityCompressionConfig],
-        sparsity_ignore_list: list[str],
         kv_cache_scheme: dict[str, Any] | None = None,
         config: dict[str, Any] | None = None,
         transform_config: dict[str, Any] | None = None,
@@ -1068,8 +1065,6 @@ class HPUCompressedTensorsConfig(CompressedTensorsConfig):
             target_scheme_map,
             ignore,
             quant_format,
-            sparsity_scheme_map,
-            sparsity_ignore_list,
             kv_cache_scheme,
             config,
             transform_config,


### PR DESCRIPTION
## Root cause
Upstream vLLM at SHA 0a54df28 introduced two API changes that broke vllm-gaudi:
1. PR vllm-project/vllm#41277 added a required `max_trained_positions` parameter to `DynamicNTKScalingRotaryEmbedding.__init__()`, causing the unit test to fail with TypeError.
2. PR vllm-project/vllm#43144 removed `sparsity_scheme_map` and `sparsity_ignore_list` from `CompressedTensorsConfig.__init__()`, causing `HPUCompressedTensorsConfig` instantiation to fail during e2e tests.

## Upstream PR
https://github.com/vllm-project/vllm/pull/41277
Added max_trained_positions to DynamicNTKScalingRotaryEmbedding

https://github.com/vllm-project/vllm/pull/43144
Removed sparsity parameters from CompressedTensorsConfig

## Fix
1. Add `max_trained_positions` parameter to the rotary embedding unit test.
2. Remove stale `sparsity_scheme_map` and `sparsity_ignore_list` from HPUCompressedTensorsConfig init signature and super() call, plus the unused SparsityCompressionConfig import.