### PR TITLE
QWN35: fix occasional segfault 

### DIFF
--- a/vllm_gaudi/ops/hpu_rotary_embedding.py
+++ b/vllm_gaudi/ops/hpu_rotary_embedding.py
@@ -7,25 +7,8 @@ from vllm.model_executor.layers.rotary_embedding import (RotaryEmbedding, Phi3Lo
                                                          LinearScalingRotaryEmbedding, DynamicNTKScalingRotaryEmbedding,
                                                          YaRNScalingRotaryEmbedding, DeepseekScalingRotaryEmbedding,
                                                          MRotaryEmbedding)
+
 from vllm.model_executor.custom_op import CustomOp
-
-
-def _apply_interleaved_rope(x: torch.Tensor,
-                            mrope_section: list[int]) -> torch.Tensor:
-    """Apply interleaved MRoPE to 3D rotary embeddings.
-    Reorganizes frequency layout from chunked [TTT...HHH...WWW] to
-    interleaved [THTHWHTHW...TT], preserving frequency continuity.
-    Uses index_copy_ / index_select on last dim.
-    """
-    x_t = torch.empty_like(x[0])
-    x_t.copy_(x[0])
-    idx_h = torch.tensor(range(1, mrope_section[1] * 3, 3),
-                         device=x.device)
-    idx_w = torch.tensor(range(2, mrope_section[2] * 3, 3),
-                         device=x.device)
-    x_t.index_copy_(-1, idx_h, x[1].index_select(-1, idx_h))
-    x_t.index_copy_(-1, idx_w, x[2].index_select(-1, idx_w))
-    return x_t
 
 
 @RotaryEmbedding.register_oot
@@ -687,6 +670,7 @@ class HPUMRotaryEmbedding(MRotaryEmbedding):
         if positions.ndim == 2:
             assert self.mrope_section
             if getattr(self, "mrope_interleaved", False):
+                from vllm.model_executor.layers.rotary_embedding.mrope import apply_interleaved_rope
                 cos = _apply_interleaved_rope(cos, self.mrope_section)
                 sin = _apply_interleaved_rope(sin, self.mrope_section)
             else:

--- a/vllm_gaudi/ops/hpu_rotary_embedding.py
+++ b/vllm_gaudi/ops/hpu_rotary_embedding.py
@@ -15,7 +15,7 @@ def _apply_interleaved_rope(x: torch.Tensor,
     """Apply interleaved MRoPE to 3D rotary embeddings.
     Reorganizes frequency layout from chunked [TTT...HHH...WWW] to
     interleaved [THTHWHTHW...TT], preserving frequency continuity.
-    Uses index_put_ to avoid clone and arange.
+    Uses index_copy_ / index_select on last dim.
     """
     x_t = torch.empty_like(x[0])
     x_t.copy_(x[0])
@@ -23,8 +23,8 @@ def _apply_interleaved_rope(x: torch.Tensor,
                          device=x.device)
     idx_w = torch.tensor(range(2, mrope_section[2] * 3, 3),
                          device=x.device)
-    x_t.index_put_((..., idx_h), x[1].index_select(-1, idx_h))
-    x_t.index_put_((..., idx_w), x[2].index_select(-1, idx_w))
+    x_t.index_copy_(-1, idx_h, x[1].index_select(-1, idx_h))
+    x_t.index_copy_(-1, idx_w, x[2].index_select(-1, idx_w))
     return x_t
 
 

--- a/vllm_gaudi/ops/hpu_rotary_embedding.py
+++ b/vllm_gaudi/ops/hpu_rotary_embedding.py
@@ -671,6 +671,7 @@ class HPUMRotaryEmbedding(MRotaryEmbedding):
             assert self.mrope_section
             if getattr(self, "mrope_interleaved", False):
                 from vllm.model_executor.layers.rotary_embedding.mrope import apply_interleaved_rope
+
                 cos = _apply_interleaved_rope(cos, self.mrope_section)
                 sin = _apply_interleaved_rope(sin, self.mrope_section)
             else:

--- a/vllm_gaudi/ops/hpu_rotary_embedding.py
+++ b/vllm_gaudi/ops/hpu_rotary_embedding.py
@@ -672,8 +672,8 @@ class HPUMRotaryEmbedding(MRotaryEmbedding):
             if getattr(self, "mrope_interleaved", False):
                 from vllm.model_executor.layers.rotary_embedding.mrope import apply_interleaved_rope
 
-                cos = _apply_interleaved_rope(cos, self.mrope_section)
-                sin = _apply_interleaved_rope(sin, self.mrope_section)
+                cos = apply_interleaved_rope(cos, self.mrope_section)
+                sin = apply_interleaved_rope(sin, self.mrope_section)
             else:
                 cos = torch.cat([m[i] for i, m in enumerate(cos.split(self.mrope_section, dim=-1))], dim=-1)
                 sin = torch.cat([m[i] for i, m in enumerate(sin.split(self.mrope_section, dim=-1))], dim=-1)

--- a/vllm_gaudi/ops/hpu_rotary_embedding.py
+++ b/vllm_gaudi/ops/hpu_rotary_embedding.py
@@ -10,6 +10,24 @@ from vllm.model_executor.layers.rotary_embedding import (RotaryEmbedding, Phi3Lo
 from vllm.model_executor.custom_op import CustomOp
 
 
+def _apply_interleaved_rope(x: torch.Tensor,
+                            mrope_section: list[int]) -> torch.Tensor:
+    """Apply interleaved MRoPE to 3D rotary embeddings.
+    Reorganizes frequency layout from chunked [TTT...HHH...WWW] to
+    interleaved [THTHWHTHW...TT], preserving frequency continuity.
+    Uses index_put_ to avoid clone and arange.
+    """
+    x_t = torch.empty_like(x[0])
+    x_t.copy_(x[0])
+    idx_h = torch.tensor(range(1, mrope_section[1] * 3, 3),
+                         device=x.device)
+    idx_w = torch.tensor(range(2, mrope_section[2] * 3, 3),
+                         device=x.device)
+    x_t.index_put_((..., idx_h), x[1].index_select(-1, idx_h))
+    x_t.index_put_((..., idx_w), x[2].index_select(-1, idx_w))
+    return x_t
+
+
 @RotaryEmbedding.register_oot
 class HPURotaryEmbedding(RotaryEmbedding):
     """Original rotary positional embedding."""
@@ -669,10 +687,8 @@ class HPUMRotaryEmbedding(MRotaryEmbedding):
         if positions.ndim == 2:
             assert self.mrope_section
             if getattr(self, "mrope_interleaved", False):
-                from vllm.model_executor.layers.rotary_embedding.mrope import apply_interleaved_rope
-
-                cos = apply_interleaved_rope(cos, self.mrope_section)
-                sin = apply_interleaved_rope(sin, self.mrope_section)
+                cos = _apply_interleaved_rope(cos, self.mrope_section)
+                sin = _apply_interleaved_rope(sin, self.mrope_section)
             else:
                 cos = torch.cat([m[i] for i, m in enumerate(cos.split(self.mrope_section, dim=-1))], dim=-1)
                 sin = torch.cat([m[i] for i, m in enumerate(sin.split(self.mrope_section, dim=-1))], dim=-1)

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -694,6 +694,7 @@ class HpuModelAdapter(torch.nn.Module, HpuKVConnectorModelRunnerMixin):
         self._rotary_embed_module = self._get_rotary_embedding_module(self.model)
         self._rotary_prepare_cos_sin = self._get_prepare_cos_sin()
         self.flatten_input = get_config().flatten_input
+        self.skip_mark_unbacked = os.environ.get('VLLM_SKIP_MARK_UNBACKED', '0').lower() in ('1', 'true')
         self.is_mm_optimized = is_mm_optimized(self.model)
         self.sliding_window = vllm_config.model_config.get_sliding_window()
         self.interleaved_sliding_window = (is_interleaved(vllm_config.model_config.hf_text_config)
@@ -771,7 +772,7 @@ class HpuModelAdapter(torch.nn.Module, HpuKVConnectorModelRunnerMixin):
                                                                                model_has_chunked_attention)
         # Avoid 0/1 size specialization on block_list dim 0 for MoE models.
         # Must be outside compiled regions — mark_unbacked is a forbidden callable.
-        if self.flatten_input:
+        if self.flatten_input and not self.skip_mark_unbacked:
             attn_md = kwargs.get('attn_metadata')
             if (attn_md is not None and getattr(attn_md, 'is_prompt', False)
                     and getattr(attn_md, 'block_list', None) is not None):


### PR DESCRIPTION
We saw occasionally segfault when the apply_interleave_rope change merged during graph compilation. Replaced upstream apply_interleaved_rope import with a local _apply_interleaved_rope that uses index_copy_ / index_select instead of clone() + slice assignment.


