### PR TITLE
fix: prevent eager-mode env vars leaking to lazy-mode subprocesses

### DIFF
--- a/vllm_gaudi/platform.py
+++ b/vllm_gaudi/platform.py
@@ -354,7 +354,8 @@ class HpuPlatform(Platform):
     def is_sleep_mode_available(cls) -> bool:
         return True
 
-    _TORCH_COMPILE_ENV_MARKER = '_VLLM_SET_TORCH_COMPILE_FLAGS'
+    _MARKER_RUNTIME_SCALE_PATCHING = '_VLLM_AUTOSET_RUNTIME_SCALE_PATCHING'
+    _MARKER_FUSER_MULTI_THREADED = '_VLLM_AUTOSET_FUSER_MULTI_THREADED'
 
     @classmethod
     def set_torch_compile(cls) -> None:
@@ -373,24 +374,19 @@ class HpuPlatform(Platform):
             # Remove eager-mode flags ONLY if they were auto-set by a prior
             # set_torch_compile() call (e.g. in a parent pytest process that
             # ran in eager mode). User-set values are left untouched.
-            if os.environ.get(cls._TORCH_COMPILE_ENV_MARKER):
+            if os.environ.pop(cls._MARKER_RUNTIME_SCALE_PATCHING, None):
                 os.environ.pop('RUNTIME_SCALE_PATCHING', None)
+            if os.environ.pop(cls._MARKER_FUSER_MULTI_THREADED, None):
                 os.environ.pop('FUSER_ENABLE_MULTI_THREADED_INVOCATIONS', None)
-                os.environ.pop(cls._TORCH_COMPILE_ENV_MARKER, None)
         else:
-            auto_set = False
             # If not set by user then for torch compile enable Runtime scale patching by default
             if os.environ.get('RUNTIME_SCALE_PATCHING') is None:
                 os.environ['RUNTIME_SCALE_PATCHING'] = '1'
-                auto_set = True
+                os.environ[cls._MARKER_RUNTIME_SCALE_PATCHING] = '1'
             #This allows for utilization of Parallel Compilation feature
             if os.environ.get('FUSER_ENABLE_MULTI_THREADED_INVOCATIONS') is None:
                 os.environ['FUSER_ENABLE_MULTI_THREADED_INVOCATIONS'] = '1'
-                auto_set = True
-            # Mark only when this call actually set the flags, not when
-            # user-provided values were already present.
-            if auto_set:
-                os.environ[cls._TORCH_COMPILE_ENV_MARKER] = '1'
+                os.environ[cls._MARKER_FUSER_MULTI_THREADED] = '1'
 
     @classmethod
     def adjust_cuda_hooks(cls) -> None:

--- a/vllm_gaudi/platform.py
+++ b/vllm_gaudi/platform.py
@@ -354,6 +354,8 @@ class HpuPlatform(Platform):
     def is_sleep_mode_available(cls) -> bool:
         return True
 
+    _TORCH_COMPILE_ENV_MARKER = '_VLLM_SET_TORCH_COMPILE_FLAGS'
+
     @classmethod
     def set_torch_compile(cls) -> None:
         # NOTE: PT HPU lazy backend (PT_HPU_LAZY_MODE = 1)
@@ -368,6 +370,13 @@ class HpuPlatform(Platform):
             # requires enabling lazy collectives
             # see https://docs.habana.ai/en/latest/PyTorch/Inference_on_PyTorch/Inference_Using_HPU_Graphs.html  # noqa: E501
             os.environ['PT_HPU_ENABLE_LAZY_COLLECTIVES'] = 'true'
+            # Remove eager-mode flags ONLY if they were auto-set by a prior
+            # set_torch_compile() call (e.g. in a parent pytest process that
+            # ran in eager mode). User-set values are left untouched.
+            if os.environ.get(cls._TORCH_COMPILE_ENV_MARKER):
+                os.environ.pop('RUNTIME_SCALE_PATCHING', None)
+                os.environ.pop('FUSER_ENABLE_MULTI_THREADED_INVOCATIONS', None)
+                os.environ.pop(cls._TORCH_COMPILE_ENV_MARKER, None)
         else:
             # If not set by user then for torch compile enable Runtime scale patching by default
             if os.environ.get('RUNTIME_SCALE_PATCHING') is None:
@@ -375,6 +384,8 @@ class HpuPlatform(Platform):
             #This allows for utilization of Parallel Compilation feature
             if os.environ.get('FUSER_ENABLE_MULTI_THREADED_INVOCATIONS') is None:
                 os.environ['FUSER_ENABLE_MULTI_THREADED_INVOCATIONS'] = '1'
+            # Mark that these flags were set by set_torch_compile(), not user.
+            os.environ[cls._TORCH_COMPILE_ENV_MARKER] = '1'
 
     @classmethod
     def adjust_cuda_hooks(cls) -> None:

--- a/vllm_gaudi/platform.py
+++ b/vllm_gaudi/platform.py
@@ -378,14 +378,19 @@ class HpuPlatform(Platform):
                 os.environ.pop('FUSER_ENABLE_MULTI_THREADED_INVOCATIONS', None)
                 os.environ.pop(cls._TORCH_COMPILE_ENV_MARKER, None)
         else:
+            auto_set = False
             # If not set by user then for torch compile enable Runtime scale patching by default
             if os.environ.get('RUNTIME_SCALE_PATCHING') is None:
                 os.environ['RUNTIME_SCALE_PATCHING'] = '1'
+                auto_set = True
             #This allows for utilization of Parallel Compilation feature
             if os.environ.get('FUSER_ENABLE_MULTI_THREADED_INVOCATIONS') is None:
                 os.environ['FUSER_ENABLE_MULTI_THREADED_INVOCATIONS'] = '1'
-            # Mark that these flags were set by set_torch_compile(), not user.
-            os.environ[cls._TORCH_COMPILE_ENV_MARKER] = '1'
+                auto_set = True
+            # Mark only when this call actually set the flags, not when
+            # user-provided values were already present.
+            if auto_set:
+                os.environ[cls._TORCH_COMPILE_ENV_MARKER] = '1'
 
     @classmethod
     def adjust_cuda_hooks(cls) -> None:

--- a/vllm_gaudi/platform.py
+++ b/vllm_gaudi/platform.py
@@ -376,8 +376,10 @@ class HpuPlatform(Platform):
             # ran in eager mode). User-set values are left untouched.
             if os.environ.pop(cls._MARKER_RUNTIME_SCALE_PATCHING, None):
                 os.environ.pop('RUNTIME_SCALE_PATCHING', None)
+                logger.info("Removed inherited RUNTIME_SCALE_PATCHING (auto-set by parent process)")
             if os.environ.pop(cls._MARKER_FUSER_MULTI_THREADED, None):
                 os.environ.pop('FUSER_ENABLE_MULTI_THREADED_INVOCATIONS', None)
+                logger.info("Removed inherited FUSER_ENABLE_MULTI_THREADED_INVOCATIONS (auto-set by parent process)")
         else:
             # If not set by user then for torch compile enable Runtime scale patching by default
             if os.environ.get('RUNTIME_SCALE_PATCHING') is None:


### PR DESCRIPTION
## Summary
- The `pytest11` entry point (PR #1435) causes `register()` → `set_torch_compile()` to execute during pytest plugin loading in eager mode, setting `RUNTIME_SCALE_PATCHING=1` and `FUSER_ENABLE_MULTI_THREADED_INVOCATIONS=1`
- When a benchmark test spawns a server subprocess with `PT_HPU_LAZY_MODE=1`, those flags leak via `os.environ` inheritance, causing ~29% throughput regression on Llama-4-Maverick (512 → 365 tok/s)
- Fix uses a marker env var (`_VLLM_SET_TORCH_COMPILE_FLAGS`) to distinguish auto-set flags from user-set ones. In the lazy branch, only flags carrying the marker are removed — user-intentional values are preserved

## Root Cause
```
pytest loads vllm_gaudi plugin (pytest11 entry)
  → register() → set_torch_compile()
  → is_lazy() returns False (PT_HPU_LAZY_MODE unset = eager default)
  → sets RUNTIME_SCALE_PATCHING=1 in os.environ
  → test spawns server subprocess with env=os.environ + PT_HPU_LAZY_MODE=1
  → server's register() sees is_lazy()=True but RUNTIME_SCALE_PATCHING=1 already present
  → lazy-mode inference runs with incompatible eager-mode flag → perf regression
```

## Test plan
- [x] Verified on pod (8-card Gaudi3) with 4 scenarios:
  1. Leaked flags (marker present) → correctly removed
  2. User-set flags (no marker) → correctly preserved
  3. Eager mode (no prior flags) → correctly sets + marks
  4. User override in eager → correctly preserves user value
- [x] hf3fs compatibility tests (16/16) pass with fix
- [ ] Full throughput benchmark via CI (Maverick lazy-mode, expect ~512 tok/s restored)
- [x] yapf + ruff pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)