### PR TITLE
fix: raise default max_cudagraph_capture_size floor to 16384

### DIFF
--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -1247,7 +1247,7 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
         self.max_num_batched_tokens = self.scheduler_config.max_num_batched_tokens
         self.max_cudagraph_capture_size = self.vllm_config.compilation_config.max_cudagraph_capture_size
         if self.max_cudagraph_capture_size is None:
-            self.max_cudagraph_capture_size = self.max_num_batched_tokens
+            self.max_cudagraph_capture_size = max(self.max_num_batched_tokens, 16384)
         self.use_prefix_caching = (self.vllm_config.cache_config.enable_prefix_caching)
         self.bucketing_manager = HPUBucketingManager()
         max_num_prefill_seqs = self.max_num_seqs if self.use_merged_prefill \
@@ -4643,9 +4643,9 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
             num_blocks = attn_metadata.num_blocks()
             total_tokens = (batch_size * seq_len + num_blocks * attn_metadata.block_size)
             if total_tokens > self.max_cudagraph_capture_size:
-                logger.debug_once(f"Skipping HPU graph capture for prompt with [bs, query, num_blocks] = "
-                                  f"[{batch_size}, {seq_len}, {num_blocks}] due to total token count "
-                                  f"{total_tokens} exceeding the threshold of {self.max_cudagraph_capture_size}.")
+                logger.info_once(f"Skipping HPU graph capture for prompt with [bs, query, num_blocks] = "
+                                 f"[{batch_size}, {seq_len}, {num_blocks}] due to total token count "
+                                 f"{total_tokens} exceeding the threshold of {self.max_cudagraph_capture_size}.")
                 return False
         return True
 


### PR DESCRIPTION
max_cudagraph_capture_size defaults to max_num_batched_tokens which is 2048 for serving context. With ISL>=2048 workloads, all prefills exceed the threshold and skip HPU graph compilation, falling back to eager mode and causing ~29% throughput regression.

Use max(max_num_batched_tokens, 16384) so typical serving workloads (ISL<=8192) always use HPU graphs while still protecting against OOM from very long prefills (>16K total tokens).

Also promote the graph-skip log from debug_once to info_once for visibility in production logs.