### PR TITLE
[FIX_FOR_VLLM_CUSTOM=ab7521d77cf29ccaa6116e644ef0f4c6ff2a9abb] Fix offloading connector prepare_store test

### DIFF
--- a/tests/unit_tests/kv_offload/offloading_connector/utils.py
+++ b/tests/unit_tests/kv_offload/offloading_connector/utils.py
@@ -176,6 +176,7 @@ class RequestRunner:
                 "spec_name": "MockOffloadingSpec",
                 "spec_module_path": "tests.unit_tests.kv_offload.offloading_connector.utils",  # noqa: E501
                 "block_size": offloaded_block_size,
+                "offload_prompt_only": False,
             },
         )
 


### PR DESCRIPTION
## Root cause

Upstream PR vllm-project/vllm#43797 (commit d63108fb18) added a new
`offload_prompt_only` field to `KVConnectorConfig` with a default value
of `True`. This changed the offloading behavior so that only prompt KV
blocks are offloaded, while decode blocks are skipped. The test
`test_scheduler.py` in `kv_offload/offloading_connector/` expected
decode-block offloading via `prepare_store`, which stopped being called.

## Upstream PR

https://github.com/vllm-project/vllm/pull/43797
Added `offload_prompt_only` config field (default `True`) to
`KVConnectorConfig`, changing which blocks are offloaded.

## Fix

Set `"offload_prompt_only": False` in the test helper's
`kv_connector_extra_config` dict in
`tests/unit_tests/kv_offload/offloading_connector/utils.py`.
This restores the pre-existing decode-block offloading behavior that
the tests rely on.

## HPU verification

- Pod: Gaudi 3 pod
- Tests: `pytest tests/unit_tests/kv_offload/offloading_connector/test_scheduler.py -v` (8/8 passed)
- Status: PASS

## Related PRs

None
