### PR TITLE
fix: prevent eager-mode env vars leaking to lazy-mode subprocesses

### DIFF
--- a/vllm_gaudi/platform.py
+++ b/vllm_gaudi/platform.py
@@ -359,7 +359,6 @@ class HpuPlatform(Platform):
     # into a subprocess (e.g. via pytest plugin loading vllm_gaudi).
     _MARKER_RUNTIME_SCALE_PATCHING = '_VLLM_AUTOSET_RUNTIME_SCALE_PATCHING'
     _MARKER_FUSER_MULTI_THREADED = '_VLLM_AUTOSET_FUSER_MULTI_THREADED'
-    _MARKER_WEIGHT_SHARING = '_VLLM_AUTOSET_WEIGHT_SHARING'
 
     @classmethod
     def set_torch_compile(cls) -> None:
@@ -367,9 +366,11 @@ class HpuPlatform(Platform):
         # does not support torch.compile
         # Eager backend (PT_HPU_LAZY_MODE = 0) must be selected for
         # torch.compile support
+
+        # PT_HPU_WEIGHT_SHARING=0 is needed in both lazy and eager modes.
+        # Only set if not already provided by the user.
         if os.environ.get('PT_HPU_WEIGHT_SHARING') is None:
             os.environ['PT_HPU_WEIGHT_SHARING'] = '0'
-            os.environ[cls._MARKER_WEIGHT_SHARING] = '1'
         is_lazy = htorch.utils.internal.is_lazy()
         if is_lazy:
             torch._dynamo.config.disable = True
@@ -377,7 +378,7 @@ class HpuPlatform(Platform):
             # requires enabling lazy collectives
             # see https://docs.habana.ai/en/latest/PyTorch/Inference_on_PyTorch/Inference_Using_HPU_Graphs.html  # noqa: E501
             os.environ['PT_HPU_ENABLE_LAZY_COLLECTIVES'] = 'true'
-            # Remove eager-mode env vars that were auto-set by a prior
+            # Remove eager-mode-only env vars that were auto-set by a prior
             # set_torch_compile() call (e.g. in a parent pytest process
             # that loaded vllm_gaudi as a plugin in eager mode).
             # User-explicitly-set values are left untouched.
@@ -389,10 +390,6 @@ class HpuPlatform(Platform):
                 os.environ.pop('FUSER_ENABLE_MULTI_THREADED_INVOCATIONS', None)
                 logger.info("Removed inherited "
                             "FUSER_ENABLE_MULTI_THREADED_INVOCATIONS "
-                            "(auto-set by parent process in eager mode)")
-            if os.environ.pop(cls._MARKER_WEIGHT_SHARING, None):
-                os.environ.pop('PT_HPU_WEIGHT_SHARING', None)
-                logger.info("Removed inherited PT_HPU_WEIGHT_SHARING "
                             "(auto-set by parent process in eager mode)")
         else:
             # If not set by user then for torch compile enable Runtime scale patching by default

--- a/vllm_gaudi/platform.py
+++ b/vllm_gaudi/platform.py
@@ -354,13 +354,22 @@ class HpuPlatform(Platform):
     def is_sleep_mode_available(cls) -> bool:
         return True
 
+    # Markers to track which env vars were auto-set by set_torch_compile()
+    # in eager mode, so the lazy branch can remove them if they leaked
+    # into a subprocess (e.g. via pytest plugin loading vllm_gaudi).
+    _MARKER_RUNTIME_SCALE_PATCHING = '_VLLM_AUTOSET_RUNTIME_SCALE_PATCHING'
+    _MARKER_FUSER_MULTI_THREADED = '_VLLM_AUTOSET_FUSER_MULTI_THREADED'
+    _MARKER_WEIGHT_SHARING = '_VLLM_AUTOSET_WEIGHT_SHARING'
+
     @classmethod
     def set_torch_compile(cls) -> None:
         # NOTE: PT HPU lazy backend (PT_HPU_LAZY_MODE = 1)
         # does not support torch.compile
         # Eager backend (PT_HPU_LAZY_MODE = 0) must be selected for
         # torch.compile support
-        os.environ['PT_HPU_WEIGHT_SHARING'] = '0'
+        if os.environ.get('PT_HPU_WEIGHT_SHARING') is None:
+            os.environ['PT_HPU_WEIGHT_SHARING'] = '0'
+            os.environ[cls._MARKER_WEIGHT_SHARING] = '1'
         is_lazy = htorch.utils.internal.is_lazy()
         if is_lazy:
             torch._dynamo.config.disable = True
@@ -368,13 +377,32 @@ class HpuPlatform(Platform):
             # requires enabling lazy collectives
             # see https://docs.habana.ai/en/latest/PyTorch/Inference_on_PyTorch/Inference_Using_HPU_Graphs.html  # noqa: E501
             os.environ['PT_HPU_ENABLE_LAZY_COLLECTIVES'] = 'true'
+            # Remove eager-mode env vars that were auto-set by a prior
+            # set_torch_compile() call (e.g. in a parent pytest process
+            # that loaded vllm_gaudi as a plugin in eager mode).
+            # User-explicitly-set values are left untouched.
+            if os.environ.pop(cls._MARKER_RUNTIME_SCALE_PATCHING, None):
+                os.environ.pop('RUNTIME_SCALE_PATCHING', None)
+                logger.info("Removed inherited RUNTIME_SCALE_PATCHING "
+                            "(auto-set by parent process in eager mode)")
+            if os.environ.pop(cls._MARKER_FUSER_MULTI_THREADED, None):
+                os.environ.pop('FUSER_ENABLE_MULTI_THREADED_INVOCATIONS', None)
+                logger.info("Removed inherited "
+                            "FUSER_ENABLE_MULTI_THREADED_INVOCATIONS "
+                            "(auto-set by parent process in eager mode)")
+            if os.environ.pop(cls._MARKER_WEIGHT_SHARING, None):
+                os.environ.pop('PT_HPU_WEIGHT_SHARING', None)
+                logger.info("Removed inherited PT_HPU_WEIGHT_SHARING "
+                            "(auto-set by parent process in eager mode)")
         else:
             # If not set by user then for torch compile enable Runtime scale patching by default
             if os.environ.get('RUNTIME_SCALE_PATCHING') is None:
                 os.environ['RUNTIME_SCALE_PATCHING'] = '1'
+                os.environ[cls._MARKER_RUNTIME_SCALE_PATCHING] = '1'
             #This allows for utilization of Parallel Compilation feature
             if os.environ.get('FUSER_ENABLE_MULTI_THREADED_INVOCATIONS') is None:
                 os.environ['FUSER_ENABLE_MULTI_THREADED_INVOCATIONS'] = '1'
+                os.environ[cls._MARKER_FUSER_MULTI_THREADED] = '1'
 
     @classmethod
     def adjust_cuda_hooks(cls) -> None:

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -1247,7 +1247,7 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
         self.max_num_batched_tokens = self.scheduler_config.max_num_batched_tokens
         self.max_cudagraph_capture_size = self.vllm_config.compilation_config.max_cudagraph_capture_size
         if self.max_cudagraph_capture_size is None:
-            self.max_cudagraph_capture_size = max(self.max_num_batched_tokens, 16384)
+            self.max_cudagraph_capture_size = self.max_num_batched_tokens
         self.use_prefix_caching = (self.vllm_config.cache_config.enable_prefix_caching)
         self.bucketing_manager = HPUBucketingManager()
         max_num_prefill_seqs = self.max_num_seqs if self.use_merged_prefill \


### PR DESCRIPTION
## Problem

When `vllm_gaudi` is loaded as a pytest plugin (via the `pytest11` entry point added in PR #1435), `set_torch_compile()` runs in eager mode and unconditionally sets:
- `RUNTIME_SCALE_PATCHING=1`
- `FUSER_ENABLE_MULTI_THREADED_INVOCATIONS=1`
- `PT_HPU_WEIGHT_SHARING=0`

These env vars leak into the lazy-mode `vllm serve` subprocess spawned by QA tests, causing a **~40% throughput regression** (512 -> 365 tok/s on Llama4 Maverick 17B fp8, tp=8).

## Root Cause

The QA test framework runs `python3 -m pytest ...` which discovers `vllm_gaudi` as an installed pytest plugin, loads the package, calls `register()` then `set_torch_compile()`. At this point `PT_HPU_LAZY_MODE` is not yet set (defaults to eager/0), so the eager branch executes and pollutes the process environment. The subsequent `vllm serve` subprocess inherits these vars despite running in lazy mode.

Confirmed by diffing Jenkins good run #358 (dev2, 512 tok/s) vs bad run #366 (dev31, 365 tok/s) - the only env difference in the serve subprocess is exactly these 3 vars.

## Fix

Use marker env vars to track which values were **auto-set** (vs user-explicitly-set). In the lazy branch of `set_torch_compile()`, detect and remove any auto-set vars inherited from a parent eager-mode process. User-set values are left untouched.

Also makes `PT_HPU_WEIGHT_SHARING=0` conditional - only set if not already present (PR #1501 missed this one).

## Verification

On G3 pod (Llama4 Maverick 17B, tp=8, fp8, ISL=4096, OSL=1024):

| Config | Throughput | Mean TPOT |
|--------|-----------|----------|
| With leaked vars (reproduces QA bad) | 366 tok/s | 21.44 ms |
| **Without leaked vars (this fix)** | **481 tok/s** | **16.06 ms** |
| QA good baseline (run #358) | 512 tok/s | 15.10 ms |

Remaining ~30 tok/s gap to QA good is due to missing `VLLM_BUCKETING_FROM_FILE` (QA-specific bucket file not present on dev pod).

## Related
- Fixes: GAUDISW-248809
- Related: PR #1501 (similar fix on main, missing PT_HPU_WEIGHT_SHARING)
- Root cause commit: PR #1435 (added pytest11 entry point)