### PR TITLE
[FIX_FOR_VLLM_CUSTOM=8b8546da1c3ba65097357523bc24199e36eddf65] Skip WNA16 MoE backend oracle on Gaudi

### DIFF
--- a/vllm_gaudi/ops/hpu_compressed_tensors.py
+++ b/vllm_gaudi/ops/hpu_compressed_tensors.py
@@ -748,11 +748,26 @@ class HPUCompressedTensorsWNA16MoEMethod(CompressedTensorsWNA16MarlinMoEMethod):
         moe: FusedMoEConfig,
         layer_name: str | None = None,
     ):
-        super().__init__(weight_quant, input_quant, moe)
+        # NOTE: Intentionally bypass CompressedTensorsWNA16MarlinMoEMethod.__init__.
+        # Upstream made that constructor select a WNA16 MoE backend via an oracle
+        # (select_wna16_moe_backend), which raises
+        # NotImplementedError("No WNA16 MoE backend supports the deployment
+        # configuration") on Gaudi because no CUDA Marlin/Flashinfer backend is
+        # available. The HPU path supplies its own MoE op
+        # (VllmMixtureOfExpertsOpWNA16) and does not need a CUDA backend, so we
+        # initialize the grandparent (CompressedTensorsMoEMethod ->
+        # FusedMoEMethodBase) directly and replicate the weight-derived
+        # attributes that the HPU create_weights/process_weights path consumes.
+        CompressedTensorsMoEMethod.__init__(self, moe)
 
         self.weight_quant = weight_quant
         self.input_quant = input_quant
         assert weight_quant.symmetric, ("Only symmetric quantization is supported for MoE")
+        self.num_bits = weight_quant.num_bits
+        self.packed_factor = 32 // weight_quant.num_bits
+        self.strategy = weight_quant.strategy
+        self.group_size = weight_quant.group_size
+        self.actorder = weight_quant.actorder
         self.quant_type = WNA16_SUPPORTED_TYPES_MAP[self.num_bits]
         self.layer_name = layer_name
 


### PR DESCRIPTION
## Summary

Skip the WNA16 MoE backend oracle on Gaudi so compressed-tensors W4A16 MoE models load again.

## Root cause

Upstream vLLM PR https://github.com/vllm-project/vllm/pull/42553 changed `CompressedTensorsWNA16MarlinMoEMethod.__init__` to select a WNA16 MoE backend via `select_wna16_moe_backend`. On Gaudi this raises `NotImplementedError("No WNA16 MoE backend supports the deployment configuration")` because no CUDA Marlin/Flashinfer backend is available.

## Fix

`HPUCompressedTensorsWNA16MoEMethod.__init__` now bypasses the Marlin parent `__init__` and initializes the grandparent (`CompressedTensorsMoEMethod` -> `FusedMoEMethodBase`) directly. It replicates the weight-derived attributes the HPU `create_weights` / `process_weights` path consumes (`num_bits`, `packed_factor`, `strategy`, `group_size`, `actorder`, `quant_type`, `layer_name`). The HPU path supplies its own MoE op and does not need a CUDA backend.

## Verification

Built against the pinned upstream vLLM commit and ran on Gaudi:

- The previously-failing unit test `tests/unit_tests/ops/test_hpu_compressed_tensors.py::test_compressed_tensors_wna16_moe_method` now passes (reproduce-then-pass confirmed).
- The compressed W4A16 MoE end-to-end generate test passes.
