### PR TITLE
Update vLLM Gaudi Plugin to version 0.21.0

### DIFF
--- a/.cd/Dockerfile.rhel.ubi.vllm
+++ b/.cd/Dockerfile.rhel.ubi.vllm
@@ -16,8 +16,8 @@ ARG PT_MODULES_REPO_NAME=gaudi-pt-modules
 ARG PT_PACKAGE_NAME_NON_DEFAULT_PYTHON_SUBSTRING=
 ARG PYPI_INDEX_URL="https://pypi.org/simple/"
 ARG HABANA_RPM_REPO_PATH="rhel/9/${OS_VERSION}"
-ARG VLLM_GAUDI_COMMIT=main
-ARG VLLM_PROJECT_COMMIT=
+ARG VLLM_GAUDI_COMMIT=v0.21.0
+ARG VLLM_PROJECT_COMMIT=v0.21.0
 ARG VLLM_REPO="https://github.com/vllm-project/vllm.git"
 ARG VLLM_GAUDI_REPO="https://github.com/vllm-project/vllm-gaudi.git"
 

--- a/.cd/Dockerfile.rhel.ubi.vllm.no-torchaudio
+++ b/.cd/Dockerfile.rhel.ubi.vllm.no-torchaudio
@@ -20,8 +20,8 @@ ARG PT_MODULES_REPO_NAME=gaudi-pt-modules
 ARG PT_PACKAGE_NAME_NON_DEFAULT_PYTHON_SUBSTRING=
 ARG PYPI_INDEX_URL="https://pypi.org/simple/"
 ARG HABANA_RPM_REPO_PATH="rhel/9/${OS_VERSION}"
-ARG VLLM_GAUDI_COMMIT=main
-ARG VLLM_PROJECT_COMMIT=
+ARG VLLM_GAUDI_COMMIT=v0.21.0
+ARG VLLM_PROJECT_COMMIT=v0.21.0
 ARG VLLM_REPO="https://github.com/vllm-project/vllm.git"
 ARG VLLM_GAUDI_REPO="https://github.com/vllm-project/vllm-gaudi.git"
 

--- a/.cd/Dockerfile.ubuntu.pytorch.vllm
+++ b/.cd/Dockerfile.ubuntu.pytorch.vllm
@@ -16,9 +16,9 @@ FROM ${DOCKER_URL}/${VERSION}/${BASE_NAME}/${REPO_TYPE}/pytorch-${TORCH_TYPE_SUF
 ARG PT_VERSION
 
 # Parameterize commit/branch for vllm-project & vllm-gaudi checkout
-ARG VLLM_GAUDI_COMMIT=main
+ARG VLLM_GAUDI_COMMIT=v0.21.0
 # leave empty to use last-good-commit-for-vllm-gaudi
-ARG VLLM_PROJECT_COMMIT=
+ARG VLLM_PROJECT_COMMIT=v0.21.0
 ENV OMPI_MCA_btl_vader_single_copy_mechanism=none
 
 RUN apt update && \

--- a/.cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest
+++ b/.cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest
@@ -15,8 +15,8 @@ FROM ${DOCKER_URL}/${VERSION}/${BASE_NAME}/${REPO_TYPE}/pytorch-${TORCH_TYPE_SUF
 # Parameterize commit/branch for vllm-project & vllm-gaudi checkout
 # leave empty to use last-good-commit-for-vllm-gaudi
 ARG PT_VERSION
-ARG VLLM_PROJECT_COMMIT=
-ARG VLLM_GAUDI_COMMIT=main
+ARG VLLM_PROJECT_COMMIT=v0.21.0
+ARG VLLM_GAUDI_COMMIT=v0.21.0
 
 ENV OMPI_MCA_btl_vader_single_copy_mechanism=none
 

--- a/.cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest.no-torchaudio
+++ b/.cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest.no-torchaudio
@@ -19,8 +19,8 @@ FROM ${DOCKER_URL}/${VERSION}/${BASE_NAME}/${REPO_TYPE}/pytorch-${TORCH_TYPE_SUF
 # Parameterize commit/branch for vllm-project & vllm-gaudi checkout
 # leave empty to use last-good-commit-for-vllm-gaudi
 ARG PT_VERSION
-ARG VLLM_PROJECT_COMMIT=
-ARG VLLM_GAUDI_COMMIT=main
+ARG VLLM_PROJECT_COMMIT=v0.21.0
+ARG VLLM_GAUDI_COMMIT=v0.21.0
 
 ENV OMPI_MCA_btl_vader_single_copy_mechanism=none
 

--- a/.cd/Dockerfile.ubuntu.pytorch.vllm.no-torchaudio
+++ b/.cd/Dockerfile.ubuntu.pytorch.vllm.no-torchaudio
@@ -20,9 +20,9 @@ FROM ${DOCKER_URL}/${VERSION}/${BASE_NAME}/${REPO_TYPE}/pytorch-${TORCH_TYPE_SUF
 ARG PT_VERSION
 
 # Parameterize commit/branch for vllm-project & vllm-gaudi checkout
-ARG VLLM_GAUDI_COMMIT=main
+ARG VLLM_GAUDI_COMMIT=v0.21.0
 # leave empty to use last-good-commit-for-vllm-gaudi
-ARG VLLM_PROJECT_COMMIT=
+ARG VLLM_PROJECT_COMMIT=v0.21.0
 ENV OMPI_MCA_btl_vader_single_copy_mechanism=none
 
 RUN apt update && \

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ vLLM Hardware Plugin for Intel® Gaudi®
 
 ---
 *Latest News* 🔥
+- [2026/06] Version 0.21.0 is now available, built on [vLLM 0.21.0](https://github.com/vllm-project/vllm/releases/tag/v0.21.0) and fully compatible with [Intel® Gaudi® v1.24.0](https://docs.habana.ai/en/v1.24.0/Release_Notes/GAUDI_Release_Notes.html) with PyTorch 2.10.
+
+  This release removes lazy execution mode from CI (eager-only in CI, lazy still supported at runtime), introduces a new padding-aware bucketing strategy, W8A8 INT8 quantization with BF16 fallback, FusedSDPA slicing, prefix caching for HPUMambaMixer2, OpenAI /v1/models/switch integration, and NIXL heterogeneous/homogeneous deployment fixes. See the [detailed release notes](docs/release_notes_v0.21.0.md) for the full list of changes.
+
 - [2026/04] Version 0.19.0 is now available, built on [vLLM 0.19.0](https://github.com/vllm-project/vllm/releases/tag/v0.19.0) and fully compatible with [Intel® Gaudi® v1.24.0](https://docs.habana.ai/en/v1.24.0/Release_Notes/GAUDI_Release_Notes.html) with PyTorch 2.10.
 
   This release upgrades the platform to Intel® Gaudi® Software v1.24.0 with PyTorch 2.10. It introduces Qwen 3.5 model support, Mamba prefix caching for hybrid models, MxFP4 weight dequantization, LMCache integration, and a custom depthwise conv1d TPC kernel for MambaMixer2. Performance improvements include torch.compile-compatible online defragmentation, improved warmup time, and optimized hybrid KV cache visibility.

--- a/docs/getting_started/compatibility_matrix.md
+++ b/docs/getting_started/compatibility_matrix.md
@@ -44,6 +44,12 @@ The following table details the supported vLLM versions for Intel® Gaudi® 2 an
     <tr>
       <td>0.19.0</td><td>❌</td><td>❌</td><td>❌</td><td>✅</td>
     </tr>
+    <tr>
+      <td>0.19.1</td><td>❌</td><td>❌</td><td>❌</td><td>✅</td>
+    </tr>
+    <tr>
+      <td>0.21.0</td><td>❌</td><td>❌</td><td>❌</td><td>✅</td>
+    </tr>
   </tbody>
 </table>
 </div>

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -2,6 +2,22 @@
 
 This document provides an overview of the features, changes, and fixes introduced in each release of the vLLM Hardware Plugin for Intel® Gaudi®.
 
+## 0.21.0
+
+This version is based on [vLLM 0.21.0](https://github.com/vllm-project/vllm/releases/tag/v0.21.0) and supports [Intel® Gaudi® Software v1.24.0](https://docs.habana.ai/en/v1.24.0/Release_Notes/GAUDI_Release_Notes.html) with PyTorch 2.10.
+
+This release removes lazy execution mode from CI — eager is now the default in CI pipelines while lazy mode remains supported at runtime. It introduces a new padding-aware bucketing strategy, W8A8 INT8 quantization with BF16 fallback, FusedSDPA slicing, prefix caching for HPUMambaMixer2, and OpenAI /v1/models/switch integration. Performance improvements include raised max cudagraph capture size, bucketing edge case tuning, and MoE compilation optimizations. Multiple stability fixes address NIXL heterogeneous deployments, hybrid model block sizes, Llama4 torch.compile recompilations, MRoPE accuracy, and FP8 quantization issues.
+
+For a full list of changes, see the [Detailed Release Notes](release_notes_v0.21.0.md).
+
+## 0.19.1
+
+This is a minor patch release on top of 0.19.0 and continues to support [Intel® Gaudi® Software v1.24.0](https://docs.habana.ai/en/v1.24.0/Release_Notes/GAUDI_Release_Notes.html) with PyTorch 2.10.
+
+The release lifts the `transformers < 5` upper-bound constraint, allowing Hugging Face Transformers v5 to be installed alongside the plugin.
+
+For a full list of changes, see the [Detailed Release Notes](release_notes_v0.19.1.md).
+
 ## 0.19.0
 
 This version is based on [vLLM 0.19.0](https://github.com/vllm-project/vllm/releases/tag/v0.19.0) and supports the latest [Intel® Gaudi® Software v1.24.0](https://docs.habana.ai/en/v1.24.0/Release_Notes/GAUDI_Release_Notes.html) with PyTorch 2.10.

--- a/docs/release_notes_v0.19.1.md
+++ b/docs/release_notes_v0.19.1.md
@@ -1,0 +1,30 @@
+# vLLM Gaudi Plugin v0.19.1 Release Notes
+
+## Overview
+
+This is a minor patch release on top of [v0.19.0](release_notes_v0.19.0.md) and continues to support [Intel® Gaudi® Software v1.24.0](https://docs.habana.ai/en/v1.24.0/Release_Notes/GAUDI_Release_Notes.html) with PyTorch 2.10.
+
+The release lifts the **`transformers < 5` upper-bound constraint**, allowing users to install Hugging Face Transformers v5 alongside the plugin.
+
+For the full set of features delivered in the v0.19.x line, see the [v0.19.0 release notes](release_notes_v0.19.0.md).
+
+---
+
+## Highlights
+
+- Removed the **`transformers >= 4.56.0, <5`** dependency constraint from `requirements.txt`, enabling installation of Hugging Face Transformers v5.
+- Refreshed the pinned **upstream vLLM stable commit** used by build scripts and CI.
+
+---
+
+## Plugin Core
+
+- Removed the `transformers >= 4.56.0, <5` dependency entry entirely from `requirements.txt` (the plugin no longer pins a `transformers` version), and dropped the now-redundant `add_bos_token=True` test setting in `tests/models/language/generation/test_common.py`. ([#1420](https://github.com/vllm-project/vllm-gaudi/pull/1420))
+
+---
+
+## Full Changelog
+
+| PR | Title | Author |
+| --- | --- | --- |
+| [#1420](https://github.com/vllm-project/vllm-gaudi/pull/1420) | Transformers v5 upgrade | @iboiko-habana |

--- a/docs/release_notes_v0.21.0.md
+++ b/docs/release_notes_v0.21.0.md
@@ -116,7 +116,7 @@ This release is based on [vLLM v0.21.0](https://github.com/vllm-project/vllm/rel
 
 | PR | Title | Author |
 | --- | --- | --- |
-| [#1511](https://github.com/vllm-project/vllm-gaudi/pull/1511) | Heterogenous and Homogenous fixes for v0.21.0 | @hsubramony |
+| [#1511](https://github.com/vllm-project/vllm-gaudi/pull/1511) | Heterogeneous and Homogeneous fixes for v0.21.0 | @hsubramony |
 | [#1510](https://github.com/vllm-project/vllm-gaudi/pull/1510) | fix: prevent eager-mode env vars leaking to lazy-mode subprocesses | @adobrzyn |
 | [#1507](https://github.com/vllm-project/vllm-gaudi/pull/1507) | fix: raise default max_cudagraph_capture_size floor to 16384 | @adobrzyn |
 | [#1503](https://github.com/vllm-project/vllm-gaudi/pull/1503) | Fix NIXL connector V1 API signature mismatches for hetero HPU | @hsubramony |

--- a/docs/release_notes_v0.21.0.md
+++ b/docs/release_notes_v0.21.0.md
@@ -1,0 +1,218 @@
+# vLLM Gaudi Plugin v0.21.0 Release Notes
+
+## Overview
+
+This release is based on [vLLM v0.21.0](https://github.com/vllm-project/vllm/releases/tag/v0.21.0) and supports [Intel® Gaudi® Software v1.24.0](https://docs.habana.ai/en/v1.24.0/Release_Notes/GAUDI_Release_Notes.html) with PyTorch 2.10.
+
+---
+
+## Highlights
+
+- **Removed lazy execution mode from CI** — eager mode is now the default in CI pipelines; lazy mode is still supported at runtime. ([#996](https://github.com/vllm-project/vllm-gaudi/pull/996))
+- Introduced **new padding-aware bucketing strategy** for improved memory utilization and reduced padding overhead. ([#762](https://github.com/vllm-project/vllm-gaudi/pull/762))
+- Added **W8A8 INT8 quantization with BF16 fallback** via `HPUCompressedTensorsW8A8Int8_BF16Fallback`. ([#1168](https://github.com/vllm-project/vllm-gaudi/pull/1168))
+- Enabled **FusedSDPA slicing** for better attention performance. ([#1155](https://github.com/vllm-project/vllm-gaudi/pull/1155))
+- Added **OpenAI-compatible `/v1/models/switch` entrypoint** and per-model tool-calling and FP8 configs for online model swap. ([#1258](https://github.com/vllm-project/vllm-gaudi/pull/1258))
+- Introduced **HPU-specific KV-offload and async speculative decoding** fixes. ([#1264](https://github.com/vllm-project/vllm-gaudi/pull/1264))
+- Fixed **NIXL connector heterogeneous and homogeneous** deployment scenarios. ([#1511](https://github.com/vllm-project/vllm-gaudi/pull/1511), [#1503](https://github.com/vllm-project/vllm-gaudi/pull/1503))
+
+---
+
+## Performance
+
+- Introduced a new padding-aware bucketing strategy. ([#762](https://github.com/vllm-project/vllm-gaudi/pull/762))
+- Enabled slicing for the FusedSDPA attention path. ([#1155](https://github.com/vllm-project/vllm-gaudi/pull/1155))
+- Skipped HPU graphs for long (query + context) prefills. ([#1346](https://github.com/vllm-project/vllm-gaudi/pull/1346))
+- Fixed guard breaks and improved warmup time for Qwen3 MoE. ([#1329](https://github.com/vllm-project/vllm-gaudi/pull/1329))
+- Improved `selective_state_update` performance. ([#1291](https://github.com/vllm-project/vllm-gaudi/pull/1291))
+- Removed splitting MoE decode layer compilation function. ([#1313](https://github.com/vllm-project/vllm-gaudi/pull/1313))
+- Optimized visible block number for hybrid KV cache. ([#1317](https://github.com/vllm-project/vllm-gaudi/pull/1317))
+- Fine-tuned bucketing edge cases for longer contexts. ([#1362](https://github.com/vllm-project/vllm-gaudi/pull/1362))
+- Raised the default `max_cudagraph_capture_size` floor to 16384. ([#1507](https://github.com/vllm-project/vllm-gaudi/pull/1507))
+
+---
+
+## Attention & KV Cache
+
+- Added prefix caching support for HPUMambaMixer2. ([#1366](https://github.com/vllm-project/vllm-gaudi/pull/1366))
+- Fixed condition for materialised causal `attn_bias`. ([#1433](https://github.com/vllm-project/vllm-gaudi/pull/1433))
+- Fixed proper KV cache slot addressing for hybrid models. ([#1327](https://github.com/vllm-project/vllm-gaudi/pull/1327))
+- Fixed `mamba_type` comparison for GDN hybrid cache allocation. ([#1449](https://github.com/vllm-project/vllm-gaudi/pull/1449))
+- Fixed extra masking for batched prefill in GDN layers. ([#1440](https://github.com/vllm-project/vllm-gaudi/pull/1440))
+- Fixed HPU-specific bugs for KV-offload and async speculative decoding. ([#1264](https://github.com/vllm-project/vllm-gaudi/pull/1264))
+
+---
+
+## Quantization
+
+- Implemented `HPUCompressedTensorsW8A8Int8_BF16Fallback` for W8A8 INT8 quantization with BF16 fallback. ([#1168](https://github.com/vllm-project/vllm-gaudi/pull/1168))
+- Fixed Synapse GC compile failure for FP8-quantized models. ([#1324](https://github.com/vllm-project/vllm-gaudi/pull/1324))
+- Enabled Llama4 Maverick FP8 torch.compile without breaking DeepSeek. ([#1396](https://github.com/vllm-project/vllm-gaudi/pull/1396))
+- Fixed GPT-OSS MxFP4 TP partitioning and `quant_method` matching. ([#1498](https://github.com/vllm-project/vllm-gaudi/pull/1498))
+- Added Granite-4.0-h calibration config. ([#1270](https://github.com/vllm-project/vllm-gaudi/pull/1270))
+- Fixed load failure of MxFP4 GPT-OSS-120B with expert parallel. ([#1411](https://github.com/vllm-project/vllm-gaudi/pull/1411))
+- Added `hf_config` parameter to HPU quantization config overrides. ([#1349](https://github.com/vllm-project/vllm-gaudi/pull/1349))
+
+---
+
+## Plugin Core
+
+- Removed lazy execution mode from CI — eager is now the default in CI pipelines. ([#996](https://github.com/vllm-project/vllm-gaudi/pull/996))
+- Accepted PEP 440 versions in build detection. ([#1351](https://github.com/vllm-project/vllm-gaudi/pull/1351))
+- Patched `torch.accelerator.empty_cache` for HPU to fix import-order dependent cleanup failures. ([#1430](https://github.com/vllm-project/vllm-gaudi/pull/1430))
+- Removed `matmul_qk` output-tensor compatibility gate after 1.24.0. ([#1409](https://github.com/vllm-project/vllm-gaudi/pull/1409))
+- Removed `transformers` installation from vllm-gaudi. ([#1494](https://github.com/vllm-project/vllm-gaudi/pull/1494))
+- Prevented eager-mode env vars from leaking to lazy-mode subprocesses. ([#1510](https://github.com/vllm-project/vllm-gaudi/pull/1510))
+- Fixed multiple upstream regressions across MoE, MLA, NIXL, attention, FP8, offloading, and platform modules. ([#1279](https://github.com/vllm-project/vllm-gaudi/pull/1279), [#1311](https://github.com/vllm-project/vllm-gaudi/pull/1311), [#1338](https://github.com/vllm-project/vllm-gaudi/pull/1338), [#1342](https://github.com/vllm-project/vllm-gaudi/pull/1342), [#1354](https://github.com/vllm-project/vllm-gaudi/pull/1354), [#1375](https://github.com/vllm-project/vllm-gaudi/pull/1375), [#1377](https://github.com/vllm-project/vllm-gaudi/pull/1377), [#1403](https://github.com/vllm-project/vllm-gaudi/pull/1403), [#1421](https://github.com/vllm-project/vllm-gaudi/pull/1421), [#1428](https://github.com/vllm-project/vllm-gaudi/pull/1428), [#1442](https://github.com/vllm-project/vllm-gaudi/pull/1442))
+- Ported fixes for MoE fast path, dynamic shape, kernel block size, and batched count operations. ([#1453](https://github.com/vllm-project/vllm-gaudi/pull/1453), [#1458](https://github.com/vllm-project/vllm-gaudi/pull/1458), [#1459](https://github.com/vllm-project/vllm-gaudi/pull/1459), [#1460](https://github.com/vllm-project/vllm-gaudi/pull/1460), [#1469](https://github.com/vllm-project/vllm-gaudi/pull/1469))
+
+---
+
+## Serving & Infrastructure
+
+- Added torchaudio-free copies of CD Dockerfiles. ([#1446](https://github.com/vllm-project/vllm-gaudi/pull/1446))
+- Set Docker `PT_HPU_LAZY_MODE=0` as the default auto-calculated value. ([#1378](https://github.com/vllm-project/vllm-gaudi/pull/1378))
+- Added OpenAI-compatible `/v1/models/switch` entrypoint integration. ([#1258](https://github.com/vllm-project/vllm-gaudi/pull/1258))
+- Added per-model tool-calling and FP8 configs. ([#1258](https://github.com/vllm-project/vllm-gaudi/pull/1258))
+- Enhanced process management for online model swap example. ([#1414](https://github.com/vllm-project/vllm-gaudi/pull/1414))
+- Fixed NIXL connector V1 API signature mismatches for heterogeneous HPU. ([#1503](https://github.com/vllm-project/vllm-gaudi/pull/1503))
+- Fixed heterogeneous and homogeneous NIXL deployment issues for v0.21.0. ([#1511](https://github.com/vllm-project/vllm-gaudi/pull/1511))
+- Enabled defragmentation when contiguous PA is enabled. ([#1400](https://github.com/vllm-project/vllm-gaudi/pull/1400))
+- Clarified `VLLM_PROMPT_BS_BUCKET_MAX` runtime behavior in docs. ([#1410](https://github.com/vllm-project/vllm-gaudi/pull/1410))
+
+---
+
+## Fixes
+
+- Fixed occasional Qwen3.5 segfault. ([#1500](https://github.com/vllm-project/vllm-gaudi/pull/1500))
+- Fixed decode bucket generation for hybrid models with mismatched block sizes. ([#1486](https://github.com/vllm-project/vllm-gaudi/pull/1486))
+- Fixed HPU `prompt_token_ids` device placement for penalty sampling. ([#1466](https://github.com/vllm-project/vllm-gaudi/pull/1466))
+- Fixed decode bucket filter issues. ([#1447](https://github.com/vllm-project/vllm-gaudi/pull/1447))
+- Fixed decode bucketing in non-contiguous PA scenario. ([#1122](https://github.com/vllm-project/vllm-gaudi/pull/1122))
+- Fixed MRoPE accuracy for Qwen models. ([#1437](https://github.com/vllm-project/vllm-gaudi/pull/1437))
+- Fixed warmup failure and multimodal graph warmup in PT compile-only mode. ([#1392](https://github.com/vllm-project/vllm-gaudi/pull/1392))
+- Flattened 3D `inputs_embeds` in `HpuModelAdapter.forward`. ([#1381](https://github.com/vllm-project/vllm-gaudi/pull/1381))
+- Fixed prompt logprobs gathering on Gaudi HPU. ([#1405](https://github.com/vllm-project/vllm-gaudi/pull/1405))
+- Fixed regression in Mistral-Large-3-675B. ([#1304](https://github.com/vllm-project/vllm-gaudi/pull/1304))
+- Fixed Granite 4h block size calculations. ([#1332](https://github.com/vllm-project/vllm-gaudi/pull/1332))
+- Separated conv1d for Granite 4.0. ([#1322](https://github.com/vllm-project/vllm-gaudi/pull/1322))
+- Corrected `get_supported_kernel_block_sizes`. ([#1384](https://github.com/vllm-project/vllm-gaudi/pull/1384))
+- Fixed MoE graph breaks from ForwardContext lookups. ([#1357](https://github.com/vllm-project/vllm-gaudi/pull/1357))
+- Reset hybrid `block_size` to 128 for tool calling. ([#1303](https://github.com/vllm-project/vllm-gaudi/pull/1303))
+- Fixed hybrid model warmup `block_size` mismatch (Qwen3.5-35B-A3B). ([#1462](https://github.com/vllm-project/vllm-gaudi/pull/1462))
+- Fixed stale gate ref overriding caller `router_logits` in dp_size==1 MoE fast path. ([#1469](https://github.com/vllm-project/vllm-gaudi/pull/1469))
+- Fixed Ernie4.5-VL test. ([#1105](https://github.com/vllm-project/vllm-gaudi/pull/1105))
+- Eliminated Llama4 torch.compile recompilations on HPU. ([#1360](https://github.com/vllm-project/vllm-gaudi/pull/1360))
+
+---
+
+## Deprecation & Breaking Changes
+
+- Removed `transformers` installation from vllm-gaudi — it is now expected to be provided by the base environment. ([#1494](https://github.com/vllm-project/vllm-gaudi/pull/1494))
+
+---
+
+## Full Changelog
+
+| PR | Title | Author |
+| --- | --- | --- |
+| [#1511](https://github.com/vllm-project/vllm-gaudi/pull/1511) | Heterogenous and Homogenous fixes for v0.21.0 | @hsubramony |
+| [#1510](https://github.com/vllm-project/vllm-gaudi/pull/1510) | fix: prevent eager-mode env vars leaking to lazy-mode subprocesses | @adobrzyn |
+| [#1507](https://github.com/vllm-project/vllm-gaudi/pull/1507) | fix: raise default max_cudagraph_capture_size floor to 16384 | @adobrzyn |
+| [#1503](https://github.com/vllm-project/vllm-gaudi/pull/1503) | Fix NIXL connector V1 API signature mismatches for hetero HPU | @hsubramony |
+| [#1500](https://github.com/vllm-project/vllm-gaudi/pull/1500) | QWN35: fix occasional segfault | @libinta |
+| [#1498](https://github.com/vllm-project/vllm-gaudi/pull/1498) | Fix gpt-oss mxfp4 TP partitioning and quant_method matching | @mkrze |
+| [#1494](https://github.com/vllm-project/vllm-gaudi/pull/1494) | Remove transformers installation from vllm-gaudi | @iboiko-habana |
+| [#1491](https://github.com/vllm-project/vllm-gaudi/pull/1491) | ci: route HF_TOKEN-using jobs through approved-workflow environment | @adobrzyn |
+| [#1489](https://github.com/vllm-project/vllm-gaudi/pull/1489) | Port of: Update lora tests | @iboiko-habana |
+| [#1486](https://github.com/vllm-project/vllm-gaudi/pull/1486) | Fix decode bucket generation for hybrid models with mismatched block sizes | @yangulei |
+| [#1471](https://github.com/vllm-project/vllm-gaudi/pull/1471) | Add pre-merge-approval for execute_pre_merge | @bmyrcha |
+| [#1469](https://github.com/vllm-project/vllm-gaudi/pull/1469) | Port of: Fix stale gate ref overriding caller router_logits in dp_size==1 MoE fast path | @iboiko-habana |
+| [#1466](https://github.com/vllm-project/vllm-gaudi/pull/1466) | Fix HPU prompt_token_ids device placement for penalty sampling | @yeonsily |
+| [#1462](https://github.com/vllm-project/vllm-gaudi/pull/1462) | Port of: fix: hybrid model warmup block_size mismatch (Qwen3.5-35B-A3B) | @iboiko-habana |
+| [#1460](https://github.com/vllm-project/vllm-gaudi/pull/1460) | Port of: Remove num_ctx_tokens_less_or_equal_batched_max_model_len filter | @iboiko-habana |
+| [#1459](https://github.com/vllm-project/vllm-gaudi/pull/1459) | Port of: fix: bypass _forward_impl for dp_size==1 to fix DeepSeek R1 FP8 crash | @iboiko-habana |
+| [#1458](https://github.com/vllm-project/vllm-gaudi/pull/1458) | Port of: fix: replace batched_count_greater_than to avoid dynamic shape TypeError on HPU | @iboiko-habana |
+| [#1453](https://github.com/vllm-project/vllm-gaudi/pull/1453) | Port of: fix kernel block size | @iboiko-habana |
+| [#1449](https://github.com/vllm-project/vllm-gaudi/pull/1449) | Fix mamba_type comparison for GDN hybrid cache allocation | @shepark |
+| [#1447](https://github.com/vllm-project/vllm-gaudi/pull/1447) | Fix decode bucket filter issues | @yangulei |
+| [#1446](https://github.com/vllm-project/vllm-gaudi/pull/1446) | Add torchaudio-free copies of CD Dockerfiles | @PatrykWo |
+| [#1444](https://github.com/vllm-project/vllm-gaudi/pull/1444) | [MiniMax-M2] Remove reduce_results kwarg from FusedMoE init | @mounikamandava |
+| [#1443](https://github.com/vllm-project/vllm-gaudi/pull/1443) | Harden Qwen3.5 CI test to detect regressions | @shepark |
+| [#1442](https://github.com/vllm-project/vllm-gaudi/pull/1442) | Fix for MoE refactor | @iboiko-habana |
+| [#1440](https://github.com/vllm-project/vllm-gaudi/pull/1440) | fix extra masking for batched prefill in GDN layers | @osavchenkox |
+| [#1437](https://github.com/vllm-project/vllm-gaudi/pull/1437) | MRoPE accuracy fix for Qwen | @hsubramony |
+| [#1435](https://github.com/vllm-project/vllm-gaudi/pull/1435) | fix: guard CUDA sync in hf3fs mock client for HPU compatibility | @kamil-kaczor |
+| [#1433](https://github.com/vllm-project/vllm-gaudi/pull/1433) | Fixing condition for materialised causal attn_bias | @ksmusz |
+| [#1430](https://github.com/vllm-project/vllm-gaudi/pull/1430) | fix: patch torch.accelerator.empty_cache for HPU to fix import-order dependent cleanup failures | @kamil-kaczor |
+| [#1428](https://github.com/vllm-project/vllm-gaudi/pull/1428) | Fix moe_forward hidden_dim_unpadded parameter | @pawel-olejniczak |
+| [#1425](https://github.com/vllm-project/vllm-gaudi/pull/1425) | [DOC] Fix torchaudio version | @yangulei |
+| [#1424](https://github.com/vllm-project/vllm-gaudi/pull/1424) | fix: lower eagle3 spec_decode accuracy threshold to 0.60 | @kamil-kaczor |
+| [#1422](https://github.com/vllm-project/vllm-gaudi/pull/1422) | CI cleanup v0.20.0 | @iboiko-habana |
+| [#1421](https://github.com/vllm-project/vllm-gaudi/pull/1421) | Fix upstream regressions: MoE PluggableLayer recursion, MLA attention init crashes, KV offload module consolidation | @pawel-olejniczak |
+| [#1414](https://github.com/vllm-project/vllm-gaudi/pull/1414) | Enhance process management for online model swap example | @12010486 |
+| [#1411](https://github.com/vllm-project/vllm-gaudi/pull/1411) | Fix load failure of mxfp4 gpt-oss-120b with expert parallel | @malsbat |
+| [#1410](https://github.com/vllm-project/vllm-gaudi/pull/1410) | Clarify VLLM_PROMPT_BS_BUCKET_MAX runtime behavior in docs | @iboiko-habana |
+| [#1409](https://github.com/vllm-project/vllm-gaudi/pull/1409) | Remove matmul_qk output-tensor compatibility gate after 1.24.0 | @iboiko-habana |
+| [#1405](https://github.com/vllm-project/vllm-gaudi/pull/1405) | Fix prompt logprobs gathering on Gaudi HPU | @iboiko-habana |
+| [#1403](https://github.com/vllm-project/vllm-gaudi/pull/1403) | Fix upstream regressions: MoE refactor, DeepSeek V4 router, KV offload HMA | @pawel-olejniczak |
+| [#1400](https://github.com/vllm-project/vllm-gaudi/pull/1400) | Enable defrag when contig_pa is enabled | @iboiko-habana |
+| [#1399](https://github.com/vllm-project/vllm-gaudi/pull/1399) | QA test fixes for ValueError: No common block size for 16 | @hsubramony |
+| [#1396](https://github.com/vllm-project/vllm-gaudi/pull/1396) | fix: enable Llama4 Maverick FP8 torch.compile without breaking DeepSeek | @adobrzyn |
+| [#1392](https://github.com/vllm-project/vllm-gaudi/pull/1392) | Fix warmup failure and run mm graph warmup pt compile only mode | @shepark |
+| [#1385](https://github.com/vllm-project/vllm-gaudi/pull/1385) | Update CODEOWNERS | @jbyczkow |
+| [#1384](https://github.com/vllm-project/vllm-gaudi/pull/1384) | Correct get_supported_kernel_block_sizes | @jbyczkow |
+| [#1383](https://github.com/vllm-project/vllm-gaudi/pull/1383) | fix: monkey-patch cleanup_dist_env_and_memory for HPU allocator | @kamil-kaczor |
+| [#1381](https://github.com/vllm-project/vllm-gaudi/pull/1381) | flatten 3D inputs_embeds in HpuModelAdapter.forward | @shepark |
+| [#1378](https://github.com/vllm-project/vllm-gaudi/pull/1378) | Set Docker auto calc PT_HPU_LAZY_MODE=0 as default | @nngokhale |
+| [#1377](https://github.com/vllm-project/vllm-gaudi/pull/1377) | Fix upstream breakages: NIXL connector, TpKVTopology rename, MoE refactor, transformers v5 | @pawel-olejniczak |
+| [#1375](https://github.com/vllm-project/vllm-gaudi/pull/1375) | Fix offloading test lambdas for upstream req_context parameter | @pawel-olejniczak |
+| [#1366](https://github.com/vllm-project/vllm-gaudi/pull/1366) | Prefix caching support for HPUMambaMixer2 | @jbyczkow |
+| [#1364](https://github.com/vllm-project/vllm-gaudi/pull/1364) | Logging omitted buckets when bucketing from file is enabled | @ksmusz |
+| [#1363](https://github.com/vllm-project/vllm-gaudi/pull/1363) | Set GaudiSW version in CI to 1.24.0 | @afierka-intel |
+| [#1362](https://github.com/vllm-project/vllm-gaudi/pull/1362) | Bucketing edge cases finetune for longer ctx | @ksmusz |
+| [#1360](https://github.com/vllm-project/vllm-gaudi/pull/1360) | Eliminate Llama4 torch.compile recompilations on HPU | @adobrzyn |
+| [#1357](https://github.com/vllm-project/vllm-gaudi/pull/1357) | Fix MoE graph breaks from ForwardContext lookups | @jbyczkow |
+| [#1354](https://github.com/vllm-project/vllm-gaudi/pull/1354) | Fix upstream regressions in HPU worker, MoE router, and offloading tests | @pawel-olejniczak |
+| [#1352](https://github.com/vllm-project/vllm-gaudi/pull/1352) | Add pre-merge-trigger.yaml | @bmyrcha |
+| [#1351](https://github.com/vllm-project/vllm-gaudi/pull/1351) | Accept PEP 440 versions in build detection | @wjhrdy |
+| [#1349](https://github.com/vllm-project/vllm-gaudi/pull/1349) | Add hf_config parameter to HPU quantization config overrides | @pawel-olejniczak |
+| [#1342](https://github.com/vllm-project/vllm-gaudi/pull/1342) | Fix requirements paths and nixl_connector imports after upstream restructuring | @pawel-olejniczak |
+| [#1339](https://github.com/vllm-project/vllm-gaudi/pull/1339) | Qwen3.5 changes cherry-picked from release 0.19.0 | @yeonsily |
+| [#1338](https://github.com/vllm-project/vllm-gaudi/pull/1338) | Fix upstream regressions in attention, FP8, offloading and platform | @pawel-olejniczak |
+| [#1332](https://github.com/vllm-project/vllm-gaudi/pull/1332) | Fix granite 4h block size calculations | @jkaniecki |
+| [#1329](https://github.com/vllm-project/vllm-gaudi/pull/1329) | feat: fix guard breaks and improve warmup time for Qwen3 MoE | @kamil-kaczor |
+| [#1327](https://github.com/vllm-project/vllm-gaudi/pull/1327) | Fix for proper KV cache slot addressing for Hybrid models | @ksmusz |
+| [#1324](https://github.com/vllm-project/vllm-gaudi/pull/1324) | Fix Synapse GC compile failure for FP8-quantized models | @slokesha |
+| [#1322](https://github.com/vllm-project/vllm-gaudi/pull/1322) | Separate conv1d for Granite 4.0 | @jbyczkow |
+| [#1317](https://github.com/vllm-project/vllm-gaudi/pull/1317) | Optimizing visible block number for Hybrid kv_cache | @ksmusz |
+| [#1313](https://github.com/vllm-project/vllm-gaudi/pull/1313) | Remove splitting moe decode layer compilation func | @shepark |
+| [#1311](https://github.com/vllm-project/vllm-gaudi/pull/1311) | Fix Pixtral, MoE and Granite regressions | @pawel-olejniczak |
+| [#1304](https://github.com/vllm-project/vllm-gaudi/pull/1304) | Fix regression in Mistral-Large-3-675B | @skavulya |
+| [#1303](https://github.com/vllm-project/vllm-gaudi/pull/1303) | reset hybrid block_size to 128 for tool calling | @shepark |
+| [#1291](https://github.com/vllm-project/vllm-gaudi/pull/1291) | improve selective_state_update | @osavchenkox |
+| [#1279](https://github.com/vllm-project/vllm-gaudi/pull/1279) | Upstream vLLM compatibility fix | @iboiko-habana |
+| [#1270](https://github.com/vllm-project/vllm-gaudi/pull/1270) | Granite-4.0-h Calibration config | @mfylcek |
+| [#1264](https://github.com/vllm-project/vllm-gaudi/pull/1264) | fix: HPU-specific bug fixes for KV-offload + async spec-decode | @hsubramony |
+| [#1258](https://github.com/vllm-project/vllm-gaudi/pull/1258) | Add per-model toolcalling and fp8 configs; OpenAI /v1/models/switch entrypoint | @12010486 |
+| [#1242](https://github.com/vllm-project/vllm-gaudi/pull/1242) | avoid using pip show to get habana-torch-plugin version | @dtrifiro |
+| [#1168](https://github.com/vllm-project/vllm-gaudi/pull/1168) | HPUCompressedTensorsW8A8Int8_BF16Fallback impl | @rsmyrek |
+| [#1160](https://github.com/vllm-project/vllm-gaudi/pull/1160) | Revert "Cap decode block bucket limit to reduce warmup time" | @adobrzyn |
+| [#1155](https://github.com/vllm-project/vllm-gaudi/pull/1155) | Enable slicing for the FusedSDPA | @yangulei |
+| [#1122](https://github.com/vllm-project/vllm-gaudi/pull/1122) | Fixes for the decode bucketing in non-contiguous pa scenario | @yangulei |
+| [#1105](https://github.com/vllm-project/vllm-gaudi/pull/1105) | fix ernie45-vl test | @jinyouzhi |
+| [#996](https://github.com/vllm-project/vllm-gaudi/pull/996) | Remove all lazy execution mode from the codebase | @afierka-intel |
+| [#762](https://github.com/vllm-project/vllm-gaudi/pull/762) | Add the padding-aware bucketing strategy | @yangulei |
+
+---
+
+## New Contributors
+
+Welcome to the following first-time contributors to vLLM Gaudi Plugin!
+
+- **@dtrifiro** — avoid using pip show to get habana-torch-plugin version ([#1242](https://github.com/vllm-project/vllm-gaudi/pull/1242))
+- **@malsbat** — Fix load failure of mxfp4 gpt-oss-120b with expert parallel ([#1411](https://github.com/vllm-project/vllm-gaudi/pull/1411))
+- **@mkrze** — Fix gpt-oss mxfp4 TP partitioning and quant_method matching ([#1498](https://github.com/vllm-project/vllm-gaudi/pull/1498))
+- **@mounikamandava** — [MiniMax-M2] Remove reduce_results kwarg from FusedMoE init ([#1444](https://github.com/vllm-project/vllm-gaudi/pull/1444))
+- **@osavchenkox** — fix extra masking for batched prefill in GDN layers ([#1440](https://github.com/vllm-project/vllm-gaudi/pull/1440))
+- **@wjhrdy** — Accept PEP 440 versions in build detection ([#1351](https://github.com/vllm-project/vllm-gaudi/pull/1351))


### PR DESCRIPTION
- Changed VLLM_GAUDI_COMMIT and VLLM_PROJECT_COMMIT to v0.21.0 in Dockerfiles for RHEL and Ubuntu.
- Added release notes for version 0.21.0, highlighting new features and improvements.
- Updated compatibility matrix to include support for vLLM 0.21.0.

Highlights
- Introduced new features such as padding-aware bucketing strategy and W8A8 INT8 quantization with BF16 fallback.
- Removed lazy execution mode from CI, making eager mode the default.
- Fixed various bugs and improved performance across multiple components.