### PR TITLE
fix: remove outdated and insecure decord dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,4 @@ pandas>=2.2.3
 numba>=0.58.0
 numpy>=1.26.0
 kaldi-native-fbank >= 1.18.7
-decord >= 0.6.0
 tblib==3.1.0


### PR DESCRIPTION
decord has been removed from vLLM upstream. The package is not imported anywhere in vllm-gaudi code — it was a dead dependency. Video decoding is handled by upstream vLLM's VideoMediaIO using opencv/pyav/torchcodec.

Closes #1517