### PR TITLE
[FIX_FOR_VLLM_CUSTOM=f8e9c56d1587b2eb5599800aa907e091ec9a8182] Fix online_model_swap generate import after upstream resettlement

### DIFF
--- a/vllm_gaudi/entrypoints/openai/multi_model_api_server.py
+++ b/vllm_gaudi/entrypoints/openai/multi_model_api_server.py
@@ -525,7 +525,7 @@ async def _init_multi_model_state(
     )
 
     if "generate" in supported_tasks:
-        from vllm.entrypoints.openai.generate.api_router import init_generate_state
+        from vllm.entrypoints.generate.api_router import init_generate_state
 
         state_args = Namespace(**vars(args))
         state_args.enable_auto_tool_choice = frontend_settings.enable_auto_tool_choice


### PR DESCRIPTION
## Root cause
Upstream vLLM relocated the `generate` entrypoint module from `vllm.entrypoints.openai.generate` to `vllm.entrypoints.generate` (vllm-project/vllm#44153). The plugin's multi-model API server still imported the old path, so importing it raised `ModuleNotFoundError: No module named 'vllm.entrypoints.openai.generate'`.

## Upstream PR
https://github.com/vllm-project/vllm/pull/44153
Moved the `generate` API router/module out of the `openai` package into `vllm.entrypoints.generate`.

## Fix
Single-line import-path correction in `vllm_gaudi/entrypoints/openai/multi_model_api_server.py` to import from `vllm.entrypoints.generate.api_router` instead of the removed `vllm.entrypoints.openai.generate`.

## HPU verification
- Hardware: Intel Gaudi (g3) accelerator
- Tests:
  - run_online_model_swap_test (online_model_swap.py)
- Status: PASS

## Related PRs
None
