### PR TITLE
Fix eager-only env var leak into lazy subprocesses; respect user input

### DIFF
--- a/tests/unit_tests/test_platform_env_defaults.py
+++ b/tests/unit_tests/test_platform_env_defaults.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for HPU compile-related env var defaults.
+
+These guard two regressions:
+
+* GAUDISW-248809: eager-mode defaults (e.g. ``RUNTIME_SCALE_PATCHING=1``) must
+  not be set at plugin-registration / import time, otherwise they leak into a
+  lazy-mode ``vllm serve`` subprocess spawned by a parent that merely imported
+  ``vllm_gaudi`` (e.g. a pytest collection process) and regress throughput.
+* GAUDISW-249135: an env var the user set explicitly must never be overwritten
+  or removed.
+
+The eager-only defaults now live in ``set_compile_env_defaults()`` which is
+called from ``check_and_update_config()`` (engine construction time), while
+``set_torch_compile()`` (import time) only sets mode-agnostic / lazy-only vars.
+"""
+import os
+from unittest import mock
+
+import pytest
+
+from vllm_gaudi.platform import HpuPlatform
+
+_EAGER_ONLY_VARS = (
+    "RUNTIME_SCALE_PATCHING",
+    "FUSER_ENABLE_MULTI_THREADED_INVOCATIONS",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env():
+    """Isolate the env vars this test touches."""
+    touched = (
+        "PT_HPU_WEIGHT_SHARING",
+        "PT_HPU_ENABLE_LAZY_COLLECTIVES",
+        *_EAGER_ONLY_VARS,
+    )
+    with mock.patch.dict(os.environ, clear=False):
+        for var in touched:
+            os.environ.pop(var, None)
+        yield
+
+
+def _set_lazy(is_lazy: bool):
+    return mock.patch("vllm_gaudi.platform.htorch.utils.internal.is_lazy", return_value=is_lazy)
+
+
+@pytest.mark.parametrize("is_lazy", [True, False])
+def test_set_torch_compile_never_sets_eager_only_vars(is_lazy):
+    """Import-time hook must not set eager-only vars in ANY mode (no leak)."""
+    with _set_lazy(is_lazy):
+        HpuPlatform.set_torch_compile()
+    for var in _EAGER_ONLY_VARS:
+        assert var not in os.environ, f"{var} leaked from set_torch_compile (is_lazy={is_lazy})"
+
+
+def test_set_compile_env_defaults_eager_sets_defaults():
+    with _set_lazy(False):
+        HpuPlatform.set_compile_env_defaults()
+    assert os.environ.get("RUNTIME_SCALE_PATCHING") == "1"
+    assert os.environ.get("FUSER_ENABLE_MULTI_THREADED_INVOCATIONS") == "1"
+
+
+def test_set_compile_env_defaults_lazy_is_noop():
+    with _set_lazy(True):
+        HpuPlatform.set_compile_env_defaults()
+    for var in _EAGER_ONLY_VARS:
+        assert var not in os.environ
+
+
+def test_set_compile_env_defaults_respects_user_values():
+    """User-set values must not be overwritten (GAUDISW-249135)."""
+    os.environ["RUNTIME_SCALE_PATCHING"] = "0"
+    os.environ["FUSER_ENABLE_MULTI_THREADED_INVOCATIONS"] = "0"
+    with _set_lazy(False):
+        HpuPlatform.set_compile_env_defaults()
+    assert os.environ["RUNTIME_SCALE_PATCHING"] == "0"
+    assert os.environ["FUSER_ENABLE_MULTI_THREADED_INVOCATIONS"] == "0"
+
+
+def test_no_leak_from_eager_parent_into_lazy_child():
+    """End-to-end of the GAUDISW-248809 scenario.
+
+    An eager parent process (e.g. pytest collection) imports vllm_gaudi and runs
+    set_torch_compile(). A lazy child then builds an engine. The eager-only var
+    must not be present for the lazy engine.
+    """
+    # Eager parent merely imports / registers the plugin.
+    with _set_lazy(False):
+        HpuPlatform.set_torch_compile()
+    assert "RUNTIME_SCALE_PATCHING" not in os.environ
+
+    # Lazy child builds an engine.
+    with _set_lazy(True):
+        HpuPlatform.set_torch_compile()
+        HpuPlatform.set_compile_env_defaults()
+    assert "RUNTIME_SCALE_PATCHING" not in os.environ
+
+
+def test_user_value_survives_lazy_engine_build():
+    """A user-set eager-only var is preserved even in a lazy engine build."""
+    os.environ["RUNTIME_SCALE_PATCHING"] = "1"
+    with _set_lazy(True):
+        HpuPlatform.set_torch_compile()
+        HpuPlatform.set_compile_env_defaults()
+    assert os.environ["RUNTIME_SCALE_PATCHING"] == "1"
+
+
+def test_pt_hpu_weight_sharing_default_and_respect():
+    # Default-set when absent.
+    with _set_lazy(True):
+        HpuPlatform.set_torch_compile()
+    assert os.environ["PT_HPU_WEIGHT_SHARING"] == "0"
+
+    # User value respected.
+    os.environ["PT_HPU_WEIGHT_SHARING"] = "1"
+    with _set_lazy(False):
+        HpuPlatform.set_torch_compile()
+    assert os.environ["PT_HPU_WEIGHT_SHARING"] == "1"

--- a/tests/unit_tests/test_platform_env_defaults.py
+++ b/tests/unit_tests/test_platform_env_defaults.py
@@ -18,6 +18,7 @@ import os
 from unittest import mock
 
 import pytest
+import torch
 
 from vllm_gaudi.platform import HpuPlatform
 
@@ -29,16 +30,22 @@ _EAGER_ONLY_VARS = (
 
 @pytest.fixture(autouse=True)
 def _clean_env():
-    """Isolate the env vars this test touches."""
+    """Isolate the env vars and global torch state this test touches."""
     touched = (
         "PT_HPU_WEIGHT_SHARING",
         "PT_HPU_ENABLE_LAZY_COLLECTIVES",
         *_EAGER_ONLY_VARS,
     )
+    # set_torch_compile() flips torch._dynamo.config.disable in lazy mode;
+    # snapshot it so the change does not leak into other tests.
+    saved_dynamo_disable = torch._dynamo.config.disable
     with mock.patch.dict(os.environ, clear=False):
         for var in touched:
             os.environ.pop(var, None)
-        yield
+        try:
+            yield
+        finally:
+            torch._dynamo.config.disable = saved_dynamo_disable
 
 
 def _set_lazy(is_lazy: bool):
@@ -117,3 +124,16 @@ def test_pt_hpu_weight_sharing_default_and_respect():
     with _set_lazy(False):
         HpuPlatform.set_torch_compile()
     assert os.environ["PT_HPU_WEIGHT_SHARING"] == "1"
+
+
+def test_pt_hpu_enable_lazy_collectives_default_and_respect():
+    # Default-set in lazy mode when absent.
+    with _set_lazy(True):
+        HpuPlatform.set_torch_compile()
+    assert os.environ["PT_HPU_ENABLE_LAZY_COLLECTIVES"] == "true"
+
+    # User value respected in lazy mode (GAUDISW-249135).
+    os.environ["PT_HPU_ENABLE_LAZY_COLLECTIVES"] = "false"
+    with _set_lazy(True):
+        HpuPlatform.set_torch_compile()
+    assert os.environ["PT_HPU_ENABLE_LAZY_COLLECTIVES"] == "false"

--- a/vllm_gaudi/platform.py
+++ b/vllm_gaudi/platform.py
@@ -384,7 +384,8 @@ class HpuPlatform(Platform):
             # NOTE multi-HPU inference with HPUGraphs (lazy-only)
             # requires enabling lazy collectives
             # see https://docs.habana.ai/en/latest/PyTorch/Inference_on_PyTorch/Inference_Using_HPU_Graphs.html  # noqa: E501
-            os.environ['PT_HPU_ENABLE_LAZY_COLLECTIVES'] = 'true'
+            if os.environ.get('PT_HPU_ENABLE_LAZY_COLLECTIVES') is None:
+                os.environ['PT_HPU_ENABLE_LAZY_COLLECTIVES'] = 'true'
 
     @classmethod
     def set_compile_env_defaults(cls) -> None:

--- a/vllm_gaudi/platform.py
+++ b/vllm_gaudi/platform.py
@@ -123,6 +123,11 @@ class HpuPlatform(Platform):
 
     @classmethod
     def check_and_update_config(cls, vllm_config: VllmConfig) -> None:
+        # Apply torch.compile/eager-only env defaults here (engine construction
+        # time) instead of at plugin registration time, so they cannot leak into
+        # a lazy-mode subprocess (GAUDISW-248809) and always respect values the
+        # user set explicitly (GAUDISW-249135).
+        cls.set_compile_env_defaults()
         parallel_config = vllm_config.parallel_config
 
         if parallel_config.worker_cls == "auto":
@@ -360,7 +365,19 @@ class HpuPlatform(Platform):
         # does not support torch.compile
         # Eager backend (PT_HPU_LAZY_MODE = 0) must be selected for
         # torch.compile support
-        os.environ['PT_HPU_WEIGHT_SHARING'] = '0'
+        #
+        # This runs at plugin-registration / import time (e.g. when vllm_gaudi
+        # is loaded as a pytest plugin), which may be a different process and a
+        # different execution mode than the engine that ultimately runs. Only
+        # set env vars here that are safe to inherit in ANY mode, so they never
+        # leak harmful values into a child process running a different mode
+        # (see GAUDISW-248809). Compile/eager-only defaults are applied later in
+        # check_and_update_config(), which only runs when a real engine is built.
+        #
+        # Never overwrite a value the user set explicitly (respect user input,
+        # see GAUDISW-249135).
+        if os.environ.get('PT_HPU_WEIGHT_SHARING') is None:
+            os.environ['PT_HPU_WEIGHT_SHARING'] = '0'
         is_lazy = htorch.utils.internal.is_lazy()
         if is_lazy:
             torch._dynamo.config.disable = True
@@ -368,13 +385,26 @@ class HpuPlatform(Platform):
             # requires enabling lazy collectives
             # see https://docs.habana.ai/en/latest/PyTorch/Inference_on_PyTorch/Inference_Using_HPU_Graphs.html  # noqa: E501
             os.environ['PT_HPU_ENABLE_LAZY_COLLECTIVES'] = 'true'
-        else:
-            # If not set by user then for torch compile enable Runtime scale patching by default
-            if os.environ.get('RUNTIME_SCALE_PATCHING') is None:
-                os.environ['RUNTIME_SCALE_PATCHING'] = '1'
-            #This allows for utilization of Parallel Compilation feature
-            if os.environ.get('FUSER_ENABLE_MULTI_THREADED_INVOCATIONS') is None:
-                os.environ['FUSER_ENABLE_MULTI_THREADED_INVOCATIONS'] = '1'
+
+    @classmethod
+    def set_compile_env_defaults(cls) -> None:
+        # Apply torch.compile / eager-only env defaults. Called from
+        # check_and_update_config() (engine construction time) rather than from
+        # set_torch_compile() (import/registration time) so these eager-only
+        # values can never leak into a lazy-mode subprocess spawned by a parent
+        # that merely imported vllm_gaudi (e.g. a pytest collection process).
+        # See GAUDISW-248809.
+        #
+        # No-op in lazy mode, and never overwrites a user-provided value
+        # (respect user input, see GAUDISW-249135).
+        if htorch.utils.internal.is_lazy():
+            return
+        # Enable Runtime Scale Patching by default for torch.compile/FP8.
+        if os.environ.get('RUNTIME_SCALE_PATCHING') is None:
+            os.environ['RUNTIME_SCALE_PATCHING'] = '1'
+        # Allow utilization of the Parallel Compilation feature.
+        if os.environ.get('FUSER_ENABLE_MULTI_THREADED_INVOCATIONS') is None:
+            os.environ['FUSER_ENABLE_MULTI_THREADED_INVOCATIONS'] = '1'
 
     @classmethod
     def adjust_cuda_hooks(cls) -> None:


### PR DESCRIPTION
## Summary

Fixes a regression chain where compile/eager-only env vars leaked into lazy-mode
subprocesses, and a follow-up regression where stripping those vars broke lazy
warmup. This change removes the leak **at the source** and always respects
values the user set explicitly.

## Background

`set_torch_compile()` runs at **plugin-registration / import time**. After a
`pytest11` entry point was added, any `import vllm` during pytest collection runs
`register()` → `set_torch_compile()`. In eager mode this wrote
`RUNTIME_SCALE_PATCHING=1` and `FUSER_ENABLE_MULTI_THREADED_INVOCATIONS=1` into
process-global `os.environ`.

- **GAUDISW-248809**: those eager-only values leaked into a lazy-mode
  `vllm serve` subprocess and regressed throughput (512 → 365 tok/s).
- **GAUDISW-249135**: a later fix that *removed* the leaked vars in the lazy
  branch stripped `FUSER_ENABLE_MULTI_THREADED_INVOCATIONS` (which is beneficial
  in lazy), causing a warmup timeout (rc 124, Llama3.3-70B 4xcard fp8).

## Change

- `set_torch_compile()` (import time) now only sets **mode-agnostic / lazy-only**
  vars, guarded with `is None`. It no longer sets any eager-only var, so nothing
  harmful can leak into a child process running a different mode.
- New `set_compile_env_defaults()` applies the eager-only defaults
  (`RUNTIME_SCALE_PATCHING`, `FUSER_ENABLE_MULTI_THREADED_INVOCATIONS`). It is
  called from `check_and_update_config()` (engine construction time), which only
  runs when a real engine is built — never during a bare pytest collection.
  It is a no-op in lazy mode.
- Every default is guarded with `is None`, so a value the user set explicitly is
  always respected and never overwritten or removed.

Because `check_and_update_config()` runs in the main engine process **before**
workers are spawned, the eager defaults it sets are inherited by spawned workers
via `os.environ`. A pure pytest-collection process that imports `vllm_gaudi`
without building an engine never runs it, so no leak occurs.

## Tests

Adds `tests/unit_tests/test_platform_env_defaults.py` covering:
- `set_torch_compile()` never sets eager-only vars in either mode (no leak).
- `set_compile_env_defaults()` sets defaults in eager, no-op in lazy.
- User-provided values are preserved in both modes.
- End-to-end: no leak from an eager parent into a lazy child; a user-set value
  survives a lazy engine build.

The logic was also validated against the real `platform.py` source on an HPU
pod (11/11 checks passed).

## QA

Please verify both originally-failing scenarios:
1. GAUDISW-248809 — lazy `vllm serve` throughput is restored (no leaked
   eager-only vars).
2. GAUDISW-249135 — Llama3.3-70B 4xcard fp8 lazy warmup completes (no timeout).
