### PR TITLE
[HPU] Use TPC native ops for causal_conv1d  update

### DIFF
--- a/vllm_gaudi/ops/causal_conv1d_pytorch.py
+++ b/vllm_gaudi/ops/causal_conv1d_pytorch.py
@@ -27,7 +27,7 @@ import torch
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 
 USE_TPC_CAUSAL_CONV1D_FWD = os.environ.get("VLLM_HPU_CAUSAL_CONV1D_FWD_TPC", "1") == "1"
-USE_TPC_CAUSAL_CONV1D_UPDATE = os.environ.get("VLLM_HPU_CAUSAL_CONV1D_UPDATE_TPC", "1") == "1"
+USE_TPC_CAUSAL_CONV1D_UPDATE = os.environ.get("VLLM_HPU_CAUSAL_CONV1D_UPDATE_TPC", "0") == "1"
 
 
 @dataclass(frozen=True)

--- a/vllm_gaudi/ops/causal_conv1d_pytorch.py
+++ b/vllm_gaudi/ops/causal_conv1d_pytorch.py
@@ -17,7 +17,6 @@ explicitly.
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
 from typing import Callable
 
@@ -25,9 +24,6 @@ import torch
 # import habana_frameworks.torch.hpu as ht
 
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
-
-USE_TPC_CAUSAL_CONV1D_FWD = os.environ.get("VLLM_HPU_CAUSAL_CONV1D_FWD_TPC", "0") == "1"
-USE_TPC_CAUSAL_CONV1D_UPDATE = os.environ.get("VLLM_HPU_CAUSAL_CONV1D_UPDATE_TPC", "1") == "1"
 
 
 @dataclass(frozen=True)
@@ -199,86 +195,6 @@ def hpu_causal_conv1d_fn(
             num_computed_tokens,
     )):
         raise NotImplementedError("Prefix caching metadata is not supported in the PyTorch reference implementation.")
-
-    if USE_TPC_CAUSAL_CONV1D_FWD:
-        activation_bool = _normalize_activation(activation) in ("silu", "swish")
-        work_dtype = conv_states.dtype if conv_states is not None else x.dtype
-        # weight: (dim, width) -> (width, dim)
-        weight_for_tpc = weight.t().contiguous().clone().to(work_dtype)
-        bias_for_tpc = bias.to(work_dtype) if bias is not None else None
-
-        dim_x, cu_seqlen = x.shape
-        padded_batch = query_start_loc.numel() - 1
-        if has_initial_state is None:
-            has_initial_state = torch.zeros(padded_batch, dtype=torch.int32, device=x.device)
-        if cache_indices is None:
-            cache_indices = torch.arange(padded_batch, device=x.device, dtype=torch.int32)
-
-        # HPU bucketed prefill uses per-batch-padded layout: each sequence
-        # is individually padded to seq_len_each = cu_seqlen / batch.
-        # The query_start_loc gives cumulative VALID token counts, NOT buffer
-        # positions.  We must repack valid tokens into a contiguous buffer
-        # before calling the TPC kernel (which expects packed layout).
-        needs_repack = (padded_batch > 1 and cu_seqlen % padded_batch == 0)
-        if needs_repack:
-            seq_len_each = cu_seqlen // padded_batch
-            # Get actual sequence lengths as Python ints (avoid .item() on HPU)
-            qsl_cpu = query_start_loc.cpu().tolist()
-            actual_qlens_list = [qsl_cpu[b + 1] - qsl_cpu[b] for b in range(padded_batch)]
-            total_valid = sum(actual_qlens_list)
-            # Reshape to per-batch view: (dim, B, seq_len_each)
-            x_batched = x.to(work_dtype).reshape(dim_x, padded_batch, seq_len_each)
-            # Extract valid tokens from each batch and pack contiguously
-            packed_parts = []
-            for b in range(padded_batch):
-                packed_parts.append(x_batched[:, b, :actual_qlens_list[b]])
-            x_packed = torch.cat(packed_parts, dim=1)  # (dim, total_valid)
-            # x_packed is (dim, total_valid) -> transpose to (total_valid, dim) for TPC
-            x_for_tpc = x_packed.t().contiguous()
-            # packed_qsl matches the contiguous layout
-            packed_offsets = [0]
-            for ql in actual_qlens_list:
-                packed_offsets.append(packed_offsets[-1] + ql)
-            packed_qsl = torch.tensor(packed_offsets, dtype=torch.int32, device=x.device)
-        else:
-            # Single sequence or fallback: x is already usable as-is
-            x_for_tpc = x.t().contiguous().clone().to(work_dtype)
-            packed_qsl = query_start_loc.to(torch.int32)
-            total_valid = cu_seqlen
-
-        out, conv_states_out = torch.ops.hpu.causal_conv1d_fwd(
-            x_for_tpc,
-            conv_states,
-            weight_for_tpc,
-            bias_for_tpc,
-            has_initial_state.to(torch.int32),
-            packed_qsl,
-            cache_indices.to(torch.int32),
-            activation=activation_bool,
-            pad_slot_id=PAD_SLOT_ID,
-        )
-
-        with torch.no_grad():
-            # Only write back the slots that were actually processed —
-            # a blanket copy_ corrupts slots belonging to other in-flight
-            # requests that weren't part of this batch.
-            safe_idx = torch.remainder(cache_indices.long(), conv_states.shape[0])
-            conv_states[safe_idx] = conv_states_out[safe_idx]
-
-        # Scatter TPC output back to per-batch-padded layout
-        if needs_repack:
-            out_packed = out[:total_valid]  # (total_valid, dim)
-            out_padded = torch.zeros(cu_seqlen, dim_x, device=out.device, dtype=out.dtype)
-            packed_offset = 0
-            for b in range(padded_batch):
-                ql = actual_qlens_list[b]
-                batch_start = b * seq_len_each
-                out_padded[batch_start:batch_start + ql] = out_packed[packed_offset:packed_offset + ql]
-                packed_offset += ql
-            return out_padded.t().to(x.dtype)
-
-        # out: (cu_seqlen, dim) -> (dim, cu_seqlen)
-        return out.t().to(x.dtype)
 
     activation = _normalize_activation(activation)
     original_dtype = x.dtype
@@ -456,176 +372,57 @@ def hpu_causal_conv1d_update(
     if max_query_len not in (-1, None):  # Provided only for Triton helper parity
         raise NotImplementedError("'max_query_len' is not used in the reference implementation.")
 
-    if USE_TPC_CAUSAL_CONV1D_UPDATE:
-        activation_bool = _normalize_activation(activation) in ("silu", "swish")
-        dim = weight.size(0)
-        work_dtype = conv_state.dtype
-        # weight: (dim, width) -> (width, dim)
-        weight_for_tpc = weight.t().contiguous().to(work_dtype)
-        bias_for_tpc = bias.to(work_dtype) if bias is not None else None
-
-        # Gather per-batch conv_state using indices
-        if conv_state_indices is not None:
-            num_conv_slots = conv_state.shape[0]
-            safe_idx = torch.remainder(conv_state_indices.long(), num_conv_slots)
-            batch_conv_state = conv_state[safe_idx]
-            batch = safe_idx.numel()
-        else:
-            batch_conv_state = conv_state
-            batch = conv_state.shape[0]
-
-        # Reshape x to (batch, seqlen, dim) for TPC kernel
-        original_x = x
-        if x.dim() == 2:
-            if x.size(1) == dim:
-                x_3d = x.reshape(batch, -1, dim).to(work_dtype)
-            elif x.size(0) == dim:
-                x_3d = x.t().contiguous().reshape(batch, -1, dim).to(work_dtype)
-            else:
-                raise ValueError("Cannot reshape 2-D x for TPC causal_conv1d_update.")
-        elif x.dim() == 3:
-            x_3d = x.to(work_dtype)
-        else:
-            raise ValueError("Unsupported x dimensions for TPC causal_conv1d_update.")
-
-        out, conv_state_out = torch.ops.hpu.causal_conv1d_update(
-            x_3d,
-            batch_conv_state,
-            weight_for_tpc,
-            bias_for_tpc,
-            activation=activation_bool,
-            pad_slot_id=pad_slot_id,
-        )
-
-        # Write back updated conv_state
-        with torch.no_grad():
-            if conv_state_indices is not None:
-                conv_state[safe_idx] = conv_state_out
-            else:
-                conv_state.copy_(conv_state_out)
-
-        # Reshape output to match original x shape
-        if original_x.dim() == 2:
-            if original_x.size(1) == dim:
-                return out.reshape(original_x.shape).to(original_x.dtype)
-            elif original_x.size(0) == dim:
-                return out.reshape(-1, dim).t().contiguous().to(original_x.dtype)
-        return out.to(original_x.dtype)
-
-    activation = _normalize_activation(activation)
+    activation_bool = _normalize_activation(activation) in ("silu", "swish")
     dim = weight.size(0)
+    work_dtype = conv_state.dtype
+    # weight: (dim, width) -> (width, dim)
+    weight_for_tpc = weight.t().contiguous().to(work_dtype)
+    bias_for_tpc = bias.to(work_dtype) if bias is not None else None
 
-    flat_x, qsl, reshape_spec = _flatten_inputs_for_update(x, query_start_loc, dim)
+    # Gather per-batch conv_state using indices
+    if conv_state_indices is not None:
+        num_conv_slots = conv_state.shape[0]
+        safe_idx = torch.remainder(conv_state_indices.long(), num_conv_slots)
+        batch_conv_state = conv_state[safe_idx]
+        batch = safe_idx.numel()
+    else:
+        batch_conv_state = conv_state
+        batch = conv_state.shape[0]
 
-    result = hpu_causal_conv1d_fn_update(
-        flat_x,
-        weight,
-        bias,
-        conv_state,
-        qsl,
-        cache_indices=conv_state_indices,
-        has_initial_state=None,
-        activation=activation,
-        metadata=None,
-        validate_data=validate_data,
-        is_prompt=False,
+    # Reshape x to (batch, seqlen, dim) for TPC kernel
+    original_x = x
+    if x.dim() == 2:
+        if x.size(1) == dim:
+            x_3d = x.reshape(batch, -1, dim).to(work_dtype)
+        elif x.size(0) == dim:
+            x_3d = x.t().contiguous().reshape(batch, -1, dim).to(work_dtype)
+        else:
+            raise ValueError("Cannot reshape 2-D x for TPC causal_conv1d_update.")
+    elif x.dim() == 3:
+        x_3d = x.to(work_dtype)
+    else:
+        raise ValueError("Unsupported x dimensions for TPC causal_conv1d_update.")
+
+    out, conv_state_out = torch.ops.hpu.causal_conv1d_update(
+        x_3d,
+        batch_conv_state,
+        weight_for_tpc,
+        bias_for_tpc,
+        activation=activation_bool,
+        pad_slot_id=pad_slot_id,
     )
 
-    return reshape_spec.reshape_fn(result)
-
-
-def hpu_causal_conv1d_fn_update(
-    x: torch.Tensor,
-    weight: torch.Tensor,
-    bias: torch.Tensor | None,
-    conv_states: torch.Tensor | None,
-    query_start_loc: torch.Tensor,
-    cache_indices: torch.Tensor | None = None,
-    has_initial_state: torch.Tensor | None = None,
-    activation: str | None = "silu",
-    block_idx_first_scheduled_token: torch.Tensor | None = None,
-    block_idx_last_scheduled_token: torch.Tensor | None = None,
-    initial_state_idx: torch.Tensor | None = None,
-    num_computed_tokens: torch.Tensor | None = None,
-    block_size_to_align: int = 0,
-    metadata=None,
-    validate_data: bool = False,
-    is_prompt: bool = True,
-):
-    if any(ptr is not None for ptr in (
-            block_idx_first_scheduled_token,
-            block_idx_last_scheduled_token,
-            initial_state_idx,
-            num_computed_tokens,
-    )):
-        raise NotImplementedError("Prefix caching metadata is not supported in the PyTorch reference implementation.")
-
-    activation = _normalize_activation(activation)
-    original_dtype = x.dtype
-    work_dtype = conv_states.dtype if conv_states is not None else x.dtype
-    x_work = x.to(work_dtype)
-    weight_work = weight.to(work_dtype)
-    bias_work = bias.to(work_dtype) if bias is not None else None
-
-    assert conv_states is not None
-    if conv_states.device != x_work.device:
-        raise ValueError("'conv_states' must reside on the same device as 'x'.")
-
-    # GPU-optimized: Keep all tensors on GPU, no CPU transfers
-    # Don't use .to('cuda') during graph capture - use the device from x_work
-    qsl = _ensure_query_start_loc(query_start_loc)
-    assert qsl is not None
-
-    # Keep on GPU - compute sequence info using tensor operations
-    padded_batch = qsl.numel() - 1
-    _, dim, cu_seqlen = x_work.shape
-    _, width = weight_work.shape
-    state_len = max(width - 1, 0)
-
-    if validate_data:
-        if x_work.dim() != 2:
-            raise ValueError("'x' must be 2-D (dim, cu_seq_len).")
-        if weight_work.shape != (dim, width):
-            raise ValueError("'weight' must have shape (dim, width).")
-        if bias_work is not None and bias_work.shape != (dim, ):
-            raise ValueError("'bias' must match the feature dimension.")
-        if not ((x_work.stride(0) == 1) or (x_work.stride(1) == 1)):
-            raise ValueError("Input tensor must be in channel-last or channel-first memory layout.")
-        if cache_indices is not None and cache_indices.numel() != padded_batch:
-            raise ValueError("'cache_indices' must align with the batch dimension implied by 'query_start_loc'.")
-        if has_initial_state is not None and has_initial_state.numel() != padded_batch:
-            raise ValueError("'has_initial_state' must align with 'query_start_loc'.")
-
-    out = torch.zeros_like(x_work)
-
-    # Get cache indices
-    if cache_indices is None:
-        batch_cache_idx = torch.arange(padded_batch, device=x_work.device, dtype=torch.long)
-    else:
-        # Ensure cache_indices is on the correct device
-        batch_cache_idx = cache_indices.to(x_work.device) if cache_indices.device != x_work.device else cache_indices
-
-    # HPU bucketing pads the batch with state_indices == -1
-    # (PAD_SLOT_ID).  Route padding to a *garbage slot* (last entry
-    # in the conv_states tensor, unused by any real request).
-    # Use torch.remainder (not torch.where) — HPU torch.compile
-    # silently miscompiles torch.where on integer tensors.
-    # remainder(-1, N) == N-1, remainder(valid, N) == valid.
-    num_conv_slots = conv_states.shape[0]
-    safe_cache_idx = torch.remainder(batch_cache_idx, num_conv_slots)
-
-    init_state = conv_states[safe_cache_idx, -state_len:, :]
-    init_state = init_state.transpose(-1, -2)
-
-    seq_input = torch.cat([init_state, x_work], dim=2)
-    new_state = seq_input[:, :, -state_len:]
-    # Use element-wise TPC depthwise conv to avoid the MME
-    # spatial_convolution input1 weight-transpose stall.
-    seq_out = _depthwise_conv1d_tpc(seq_input, weight_work, bias_work)
-    seq_out = _apply_activation(seq_out, activation)
-    out = seq_out
-
+    # Write back updated conv_state
     with torch.no_grad():
-        conv_states[safe_cache_idx, -state_len:, :] = new_state.transpose(-1, -2)
+        if conv_state_indices is not None:
+            conv_state[safe_idx] = conv_state_out
+        else:
+            conv_state.copy_(conv_state_out)
 
-    return out.to(original_dtype)
+    # Reshape output to match original x shape
+    if original_x.dim() == 2:
+        if original_x.size(1) == dim:
+            return out.reshape(original_x.shape).to(original_x.dtype)
+        elif original_x.size(0) == dim:
+            return out.reshape(-1, dim).t().contiguous().to(original_x.dtype)
+    return out.to(original_x.dtype)

--- a/vllm_gaudi/ops/causal_conv1d_pytorch.py
+++ b/vllm_gaudi/ops/causal_conv1d_pytorch.py
@@ -350,6 +350,74 @@ def hpu_causal_conv1d_fn(
     return seq_out.squeeze(0).to(original_dtype)
 
 
+def hpu_causal_conv1d_fn_update(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    conv_states: torch.Tensor | None,
+    query_start_loc: torch.Tensor,
+    cache_indices: torch.Tensor | None = None,
+    has_initial_state: torch.Tensor | None = None,
+    activation: str | None = "silu",
+    block_idx_first_scheduled_token: torch.Tensor | None = None,
+    block_idx_last_scheduled_token: torch.Tensor | None = None,
+    initial_state_idx: torch.Tensor | None = None,
+    num_computed_tokens: torch.Tensor | None = None,
+    block_size_to_align: int = 0,
+    metadata=None,
+    validate_data: bool = False,
+    is_prompt: bool = True,
+):
+    """Pure PyTorch fallback for causal_conv1d_update (used when TPC op is unavailable)."""
+    if any(ptr is not None for ptr in (
+            block_idx_first_scheduled_token,
+            block_idx_last_scheduled_token,
+            initial_state_idx,
+            num_computed_tokens,
+    )):
+        raise NotImplementedError("Prefix caching metadata is not supported in the PyTorch reference implementation.")
+
+    activation = _normalize_activation(activation)
+    original_dtype = x.dtype
+    work_dtype = conv_states.dtype if conv_states is not None else x.dtype
+    x_work = x.to(work_dtype)
+    weight_work = weight.to(work_dtype)
+    bias_work = bias.to(work_dtype) if bias is not None else None
+
+    assert conv_states is not None
+    if conv_states.device != x_work.device:
+        raise ValueError("'conv_states' must reside on the same device as 'x'.")
+
+    qsl = _ensure_query_start_loc(query_start_loc)
+    assert qsl is not None
+
+    padded_batch = qsl.numel() - 1
+    _, dim, cu_seqlen = x_work.shape
+    _, width = weight_work.shape
+    state_len = max(width - 1, 0)
+
+    if cache_indices is None:
+        batch_cache_idx = torch.arange(padded_batch, device=x_work.device, dtype=torch.long)
+    else:
+        batch_cache_idx = cache_indices.to(x_work.device) if cache_indices.device != x_work.device else cache_indices
+
+    num_conv_slots = conv_states.shape[0]
+    safe_cache_idx = torch.remainder(batch_cache_idx, num_conv_slots)
+
+    init_state = conv_states[safe_cache_idx, -state_len:, :]
+    init_state = init_state.transpose(-1, -2)
+
+    seq_input = torch.cat([init_state, x_work], dim=2)
+    new_state = seq_input[:, :, -state_len:]
+    seq_out = _depthwise_conv1d_tpc(seq_input, weight_work, bias_work)
+    seq_out = _apply_activation(seq_out, activation)
+
+    with torch.no_grad():
+        conv_states[safe_cache_idx, -state_len:, :] = new_state.transpose(-1, -2)
+
+    return seq_out.to(original_dtype)
+
+
 def hpu_causal_conv1d_update(
     x: torch.Tensor,
     conv_state: torch.Tensor,
@@ -372,57 +440,79 @@ def hpu_causal_conv1d_update(
     if max_query_len not in (-1, None):  # Provided only for Triton helper parity
         raise NotImplementedError("'max_query_len' is not used in the reference implementation.")
 
-    activation_bool = _normalize_activation(activation) in ("silu", "swish")
     dim = weight.size(0)
-    work_dtype = conv_state.dtype
-    # weight: (dim, width) -> (width, dim)
-    weight_for_tpc = weight.t().contiguous().to(work_dtype)
-    bias_for_tpc = bias.to(work_dtype) if bias is not None else None
 
-    # Gather per-batch conv_state using indices
-    if conv_state_indices is not None:
-        num_conv_slots = conv_state.shape[0]
-        safe_idx = torch.remainder(conv_state_indices.long(), num_conv_slots)
-        batch_conv_state = conv_state[safe_idx]
-        batch = safe_idx.numel()
-    else:
-        batch_conv_state = conv_state
-        batch = conv_state.shape[0]
+    # Use TPC kernel if available, otherwise fall back to PyTorch implementation
+    if hasattr(torch.ops.hpu, "causal_conv1d_update"):
+        activation_bool = _normalize_activation(activation) in ("silu", "swish")
+        work_dtype = conv_state.dtype
+        # weight: (dim, width) -> (width, dim)
+        weight_for_tpc = weight.t().contiguous().to(work_dtype)
+        bias_for_tpc = bias.to(work_dtype) if bias is not None else None
 
-    # Reshape x to (batch, seqlen, dim) for TPC kernel
-    original_x = x
-    if x.dim() == 2:
-        if x.size(1) == dim:
-            x_3d = x.reshape(batch, -1, dim).to(work_dtype)
-        elif x.size(0) == dim:
-            x_3d = x.t().contiguous().reshape(batch, -1, dim).to(work_dtype)
-        else:
-            raise ValueError("Cannot reshape 2-D x for TPC causal_conv1d_update.")
-    elif x.dim() == 3:
-        x_3d = x.to(work_dtype)
-    else:
-        raise ValueError("Unsupported x dimensions for TPC causal_conv1d_update.")
-
-    out, conv_state_out = torch.ops.hpu.causal_conv1d_update(
-        x_3d,
-        batch_conv_state,
-        weight_for_tpc,
-        bias_for_tpc,
-        activation=activation_bool,
-        pad_slot_id=pad_slot_id,
-    )
-
-    # Write back updated conv_state
-    with torch.no_grad():
+        # Gather per-batch conv_state using indices
         if conv_state_indices is not None:
-            conv_state[safe_idx] = conv_state_out
+            num_conv_slots = conv_state.shape[0]
+            safe_idx = torch.remainder(conv_state_indices.long(), num_conv_slots)
+            batch_conv_state = conv_state[safe_idx]
+            batch = safe_idx.numel()
         else:
-            conv_state.copy_(conv_state_out)
+            batch_conv_state = conv_state
+            batch = conv_state.shape[0]
 
-    # Reshape output to match original x shape
-    if original_x.dim() == 2:
-        if original_x.size(1) == dim:
-            return out.reshape(original_x.shape).to(original_x.dtype)
-        elif original_x.size(0) == dim:
-            return out.reshape(-1, dim).t().contiguous().to(original_x.dtype)
-    return out.to(original_x.dtype)
+        # Reshape x to (batch, seqlen, dim) for TPC kernel
+        original_x = x
+        if x.dim() == 2:
+            if x.size(1) == dim:
+                x_3d = x.reshape(batch, -1, dim).to(work_dtype)
+            elif x.size(0) == dim:
+                x_3d = x.t().contiguous().reshape(batch, -1, dim).to(work_dtype)
+            else:
+                raise ValueError("Cannot reshape 2-D x for TPC causal_conv1d_update.")
+        elif x.dim() == 3:
+            x_3d = x.to(work_dtype)
+        else:
+            raise ValueError("Unsupported x dimensions for TPC causal_conv1d_update.")
+
+        out, conv_state_out = torch.ops.hpu.causal_conv1d_update(
+            x_3d,
+            batch_conv_state,
+            weight_for_tpc,
+            bias_for_tpc,
+            activation=activation_bool,
+            pad_slot_id=pad_slot_id,
+        )
+
+        # Write back updated conv_state
+        with torch.no_grad():
+            if conv_state_indices is not None:
+                conv_state[safe_idx] = conv_state_out
+            else:
+                conv_state.copy_(conv_state_out)
+
+        # Reshape output to match original x shape
+        if original_x.dim() == 2:
+            if original_x.size(1) == dim:
+                return out.reshape(original_x.shape).to(original_x.dtype)
+            elif original_x.size(0) == dim:
+                return out.reshape(-1, dim).t().contiguous().to(original_x.dtype)
+        return out.to(original_x.dtype)
+
+    else:
+        # Fallback: pure PyTorch implementation
+        activation_str = _normalize_activation(activation)
+        flat_x, qsl, reshape_spec = _flatten_inputs_for_update(x, query_start_loc, dim)
+        result = hpu_causal_conv1d_fn_update(
+            flat_x,
+            weight,
+            bias,
+            conv_state,
+            qsl,
+            cache_indices=conv_state_indices,
+            has_initial_state=None,
+            activation=activation_str,
+            metadata=None,
+            validate_data=validate_data,
+            is_prompt=False,
+        )
+        return reshape_spec.reshape_fn(result)

--- a/vllm_gaudi/ops/causal_conv1d_pytorch.py
+++ b/vllm_gaudi/ops/causal_conv1d_pytorch.py
@@ -17,6 +17,7 @@ explicitly.
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from typing import Callable
 
@@ -24,6 +25,9 @@ import torch
 # import habana_frameworks.torch.hpu as ht
 
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
+
+USE_TPC_CAUSAL_CONV1D_FWD = os.environ.get("VLLM_HPU_CAUSAL_CONV1D_FWD_TPC", "1") == "1"
+USE_TPC_CAUSAL_CONV1D_UPDATE = os.environ.get("VLLM_HPU_CAUSAL_CONV1D_UPDATE_TPC", "1") == "1"
 
 
 @dataclass(frozen=True)
@@ -195,6 +199,86 @@ def hpu_causal_conv1d_fn(
             num_computed_tokens,
     )):
         raise NotImplementedError("Prefix caching metadata is not supported in the PyTorch reference implementation.")
+
+    if USE_TPC_CAUSAL_CONV1D_FWD:
+        activation_bool = _normalize_activation(activation) in ("silu", "swish")
+        work_dtype = conv_states.dtype if conv_states is not None else x.dtype
+        # weight: (dim, width) -> (width, dim)
+        weight_for_tpc = weight.t().contiguous().clone().to(work_dtype)
+        bias_for_tpc = bias.to(work_dtype) if bias is not None else None
+
+        dim_x, cu_seqlen = x.shape
+        padded_batch = query_start_loc.numel() - 1
+        if has_initial_state is None:
+            has_initial_state = torch.zeros(padded_batch, dtype=torch.int32, device=x.device)
+        if cache_indices is None:
+            cache_indices = torch.arange(padded_batch, device=x.device, dtype=torch.int32)
+
+        # HPU bucketed prefill uses per-batch-padded layout: each sequence
+        # is individually padded to seq_len_each = cu_seqlen / batch.
+        # The query_start_loc gives cumulative VALID token counts, NOT buffer
+        # positions.  We must repack valid tokens into a contiguous buffer
+        # before calling the TPC kernel (which expects packed layout).
+        needs_repack = (padded_batch > 1 and cu_seqlen % padded_batch == 0)
+        if needs_repack:
+            seq_len_each = cu_seqlen // padded_batch
+            # Get actual sequence lengths as Python ints (avoid .item() on HPU)
+            qsl_cpu = query_start_loc.cpu().tolist()
+            actual_qlens_list = [qsl_cpu[b + 1] - qsl_cpu[b] for b in range(padded_batch)]
+            total_valid = sum(actual_qlens_list)
+            # Reshape to per-batch view: (dim, B, seq_len_each)
+            x_batched = x.to(work_dtype).reshape(dim_x, padded_batch, seq_len_each)
+            # Extract valid tokens from each batch and pack contiguously
+            packed_parts = []
+            for b in range(padded_batch):
+                packed_parts.append(x_batched[:, b, :actual_qlens_list[b]])
+            x_packed = torch.cat(packed_parts, dim=1)  # (dim, total_valid)
+            # x_packed is (dim, total_valid) -> transpose to (total_valid, dim) for TPC
+            x_for_tpc = x_packed.t().contiguous()
+            # packed_qsl matches the contiguous layout
+            packed_offsets = [0]
+            for ql in actual_qlens_list:
+                packed_offsets.append(packed_offsets[-1] + ql)
+            packed_qsl = torch.tensor(packed_offsets, dtype=torch.int32, device=x.device)
+        else:
+            # Single sequence or fallback: x is already usable as-is
+            x_for_tpc = x.t().contiguous().clone().to(work_dtype)
+            packed_qsl = query_start_loc.to(torch.int32)
+            total_valid = cu_seqlen
+
+        out, conv_states_out = torch.ops.hpu.causal_conv1d_fwd(
+            x_for_tpc,
+            conv_states,
+            weight_for_tpc,
+            bias_for_tpc,
+            has_initial_state.to(torch.int32),
+            packed_qsl,
+            cache_indices.to(torch.int32),
+            activation=activation_bool,
+            pad_slot_id=PAD_SLOT_ID,
+        )
+
+        with torch.no_grad():
+            # Only write back the slots that were actually processed —
+            # a blanket copy_ corrupts slots belonging to other in-flight
+            # requests that weren't part of this batch.
+            safe_idx = torch.remainder(cache_indices.long(), conv_states.shape[0])
+            conv_states[safe_idx] = conv_states_out[safe_idx]
+
+        # Scatter TPC output back to per-batch-padded layout
+        if needs_repack:
+            out_packed = out[:total_valid]  # (total_valid, dim)
+            out_padded = torch.zeros(cu_seqlen, dim_x, device=out.device, dtype=out.dtype)
+            packed_offset = 0
+            for b in range(padded_batch):
+                ql = actual_qlens_list[b]
+                batch_start = b * seq_len_each
+                out_padded[batch_start:batch_start + ql] = out_packed[packed_offset:packed_offset + ql]
+                packed_offset += ql
+            return out_padded.t().to(x.dtype)
+
+        # out: (cu_seqlen, dim) -> (dim, cu_seqlen)
+        return out.t().to(x.dtype)
 
     activation = _normalize_activation(activation)
     original_dtype = x.dtype
@@ -371,6 +455,62 @@ def hpu_causal_conv1d_update(
         raise NotImplementedError("Prefix caching metadata is not supported in the reference implementation.")
     if max_query_len not in (-1, None):  # Provided only for Triton helper parity
         raise NotImplementedError("'max_query_len' is not used in the reference implementation.")
+
+    if USE_TPC_CAUSAL_CONV1D_UPDATE:
+        activation_bool = _normalize_activation(activation) in ("silu", "swish")
+        dim = weight.size(0)
+        work_dtype = conv_state.dtype
+        # weight: (dim, width) -> (width, dim)
+        weight_for_tpc = weight.t().contiguous().to(work_dtype)
+        bias_for_tpc = bias.to(work_dtype) if bias is not None else None
+
+        # Gather per-batch conv_state using indices
+        if conv_state_indices is not None:
+            num_conv_slots = conv_state.shape[0]
+            safe_idx = torch.remainder(conv_state_indices.long(), num_conv_slots)
+            batch_conv_state = conv_state[safe_idx]
+            batch = safe_idx.numel()
+        else:
+            batch_conv_state = conv_state
+            batch = conv_state.shape[0]
+
+        # Reshape x to (batch, seqlen, dim) for TPC kernel
+        original_x = x
+        if x.dim() == 2:
+            if x.size(1) == dim:
+                x_3d = x.reshape(batch, -1, dim).to(work_dtype)
+            elif x.size(0) == dim:
+                x_3d = x.t().contiguous().reshape(batch, -1, dim).to(work_dtype)
+            else:
+                raise ValueError("Cannot reshape 2-D x for TPC causal_conv1d_update.")
+        elif x.dim() == 3:
+            x_3d = x.to(work_dtype)
+        else:
+            raise ValueError("Unsupported x dimensions for TPC causal_conv1d_update.")
+
+        out, conv_state_out = torch.ops.hpu.causal_conv1d_update(
+            x_3d,
+            batch_conv_state,
+            weight_for_tpc,
+            bias_for_tpc,
+            activation=activation_bool,
+            pad_slot_id=pad_slot_id,
+        )
+
+        # Write back updated conv_state
+        with torch.no_grad():
+            if conv_state_indices is not None:
+                conv_state[safe_idx] = conv_state_out
+            else:
+                conv_state.copy_(conv_state_out)
+
+        # Reshape output to match original x shape
+        if original_x.dim() == 2:
+            if original_x.size(1) == dim:
+                return out.reshape(original_x.shape).to(original_x.dtype)
+            elif original_x.size(0) == dim:
+                return out.reshape(-1, dim).t().contiguous().to(original_x.dtype)
+        return out.to(original_x.dtype)
 
     activation = _normalize_activation(activation)
     dim = weight.size(0)

--- a/vllm_gaudi/ops/causal_conv1d_pytorch.py
+++ b/vllm_gaudi/ops/causal_conv1d_pytorch.py
@@ -350,74 +350,6 @@ def hpu_causal_conv1d_fn(
     return seq_out.squeeze(0).to(original_dtype)
 
 
-def hpu_causal_conv1d_fn_update(
-    x: torch.Tensor,
-    weight: torch.Tensor,
-    bias: torch.Tensor | None,
-    conv_states: torch.Tensor | None,
-    query_start_loc: torch.Tensor,
-    cache_indices: torch.Tensor | None = None,
-    has_initial_state: torch.Tensor | None = None,
-    activation: str | None = "silu",
-    block_idx_first_scheduled_token: torch.Tensor | None = None,
-    block_idx_last_scheduled_token: torch.Tensor | None = None,
-    initial_state_idx: torch.Tensor | None = None,
-    num_computed_tokens: torch.Tensor | None = None,
-    block_size_to_align: int = 0,
-    metadata=None,
-    validate_data: bool = False,
-    is_prompt: bool = True,
-):
-    """Pure PyTorch fallback for causal_conv1d_update (used when TPC op is unavailable)."""
-    if any(ptr is not None for ptr in (
-            block_idx_first_scheduled_token,
-            block_idx_last_scheduled_token,
-            initial_state_idx,
-            num_computed_tokens,
-    )):
-        raise NotImplementedError("Prefix caching metadata is not supported in the PyTorch reference implementation.")
-
-    activation = _normalize_activation(activation)
-    original_dtype = x.dtype
-    work_dtype = conv_states.dtype if conv_states is not None else x.dtype
-    x_work = x.to(work_dtype)
-    weight_work = weight.to(work_dtype)
-    bias_work = bias.to(work_dtype) if bias is not None else None
-
-    assert conv_states is not None
-    if conv_states.device != x_work.device:
-        raise ValueError("'conv_states' must reside on the same device as 'x'.")
-
-    qsl = _ensure_query_start_loc(query_start_loc)
-    assert qsl is not None
-
-    padded_batch = qsl.numel() - 1
-    _, dim, cu_seqlen = x_work.shape
-    _, width = weight_work.shape
-    state_len = max(width - 1, 0)
-
-    if cache_indices is None:
-        batch_cache_idx = torch.arange(padded_batch, device=x_work.device, dtype=torch.long)
-    else:
-        batch_cache_idx = cache_indices.to(x_work.device) if cache_indices.device != x_work.device else cache_indices
-
-    num_conv_slots = conv_states.shape[0]
-    safe_cache_idx = torch.remainder(batch_cache_idx, num_conv_slots)
-
-    init_state = conv_states[safe_cache_idx, -state_len:, :]
-    init_state = init_state.transpose(-1, -2)
-
-    seq_input = torch.cat([init_state, x_work], dim=2)
-    new_state = seq_input[:, :, -state_len:]
-    seq_out = _depthwise_conv1d_tpc(seq_input, weight_work, bias_work)
-    seq_out = _apply_activation(seq_out, activation)
-
-    with torch.no_grad():
-        conv_states[safe_cache_idx, -state_len:, :] = new_state.transpose(-1, -2)
-
-    return seq_out.to(original_dtype)
-
-
 def hpu_causal_conv1d_update(
     x: torch.Tensor,
     conv_state: torch.Tensor,
@@ -499,8 +431,7 @@ def hpu_causal_conv1d_update(
         return out.to(original_x.dtype)
 
     else:
-        # Fallback: pure PyTorch implementation
-        activation_str = _normalize_activation(activation)
+        activation = _normalize_activation(activation)
         flat_x, qsl, reshape_spec = _flatten_inputs_for_update(x, query_start_loc, dim)
         result = hpu_causal_conv1d_fn_update(
             flat_x,
@@ -510,9 +441,106 @@ def hpu_causal_conv1d_update(
             qsl,
             cache_indices=conv_state_indices,
             has_initial_state=None,
-            activation=activation_str,
+            activation=activation,
             metadata=None,
             validate_data=validate_data,
             is_prompt=False,
         )
         return reshape_spec.reshape_fn(result)
+
+
+def hpu_causal_conv1d_fn_update(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    conv_states: torch.Tensor | None,
+    query_start_loc: torch.Tensor,
+    cache_indices: torch.Tensor | None = None,
+    has_initial_state: torch.Tensor | None = None,
+    activation: str | None = "silu",
+    block_idx_first_scheduled_token: torch.Tensor | None = None,
+    block_idx_last_scheduled_token: torch.Tensor | None = None,
+    initial_state_idx: torch.Tensor | None = None,
+    num_computed_tokens: torch.Tensor | None = None,
+    block_size_to_align: int = 0,
+    metadata=None,
+    validate_data: bool = False,
+    is_prompt: bool = True,
+):
+    if any(ptr is not None for ptr in (
+            block_idx_first_scheduled_token,
+            block_idx_last_scheduled_token,
+            initial_state_idx,
+            num_computed_tokens,
+    )):
+        raise NotImplementedError("Prefix caching metadata is not supported in the PyTorch reference implementation.")
+
+    activation = _normalize_activation(activation)
+    original_dtype = x.dtype
+    work_dtype = conv_states.dtype if conv_states is not None else x.dtype
+    x_work = x.to(work_dtype)
+    weight_work = weight.to(work_dtype)
+    bias_work = bias.to(work_dtype) if bias is not None else None
+
+    assert conv_states is not None
+    if conv_states.device != x_work.device:
+        raise ValueError("'conv_states' must reside on the same device as 'x'.")
+
+    # GPU-optimized: Keep all tensors on GPU, no CPU transfers
+    # Don't use .to('cuda') during graph capture - use the device from x_work
+    qsl = _ensure_query_start_loc(query_start_loc)
+    assert qsl is not None
+
+    # Keep on GPU - compute sequence info using tensor operations
+    padded_batch = qsl.numel() - 1
+    _, dim, cu_seqlen = x_work.shape
+    _, width = weight_work.shape
+    state_len = max(width - 1, 0)
+
+    if validate_data:
+        if x_work.dim() != 2:
+            raise ValueError("'x' must be 2-D (dim, cu_seq_len).")
+        if weight_work.shape != (dim, width):
+            raise ValueError("'weight' must have shape (dim, width).")
+        if bias_work is not None and bias_work.shape != (dim, ):
+            raise ValueError("'bias' must match the feature dimension.")
+        if not ((x_work.stride(0) == 1) or (x_work.stride(1) == 1)):
+            raise ValueError("Input tensor must be in channel-last or channel-first memory layout.")
+        if cache_indices is not None and cache_indices.numel() != padded_batch:
+            raise ValueError("'cache_indices' must align with the batch dimension implied by 'query_start_loc'.")
+        if has_initial_state is not None and has_initial_state.numel() != padded_batch:
+            raise ValueError("'has_initial_state' must align with 'query_start_loc'.")
+
+    out = torch.zeros_like(x_work)
+
+    # Get cache indices
+    if cache_indices is None:
+        batch_cache_idx = torch.arange(padded_batch, device=x_work.device, dtype=torch.long)
+    else:
+        # Ensure cache_indices is on the correct device
+        batch_cache_idx = cache_indices.to(x_work.device) if cache_indices.device != x_work.device else cache_indices
+
+    # HPU bucketing pads the batch with state_indices == -1
+    # (PAD_SLOT_ID).  Route padding to a *garbage slot* (last entry
+    # in the conv_states tensor, unused by any real request).
+    # Use torch.remainder (not torch.where) — HPU torch.compile
+    # silently miscompiles torch.where on integer tensors.
+    # remainder(-1, N) == N-1, remainder(valid, N) == valid.
+    num_conv_slots = conv_states.shape[0]
+    safe_cache_idx = torch.remainder(batch_cache_idx, num_conv_slots)
+
+    init_state = conv_states[safe_cache_idx, -state_len:, :]
+    init_state = init_state.transpose(-1, -2)
+
+    seq_input = torch.cat([init_state, x_work], dim=2)
+    new_state = seq_input[:, :, -state_len:]
+    # Use element-wise TPC depthwise conv to avoid the MME
+    # spatial_convolution input1 weight-transpose stall.
+    seq_out = _depthwise_conv1d_tpc(seq_input, weight_work, bias_work)
+    seq_out = _apply_activation(seq_out, activation)
+    out = seq_out
+
+    with torch.no_grad():
+        conv_states[safe_cache_idx, -state_len:, :] = new_state.transpose(-1, -2)
+
+    return out.to(original_dtype)

--- a/vllm_gaudi/ops/causal_conv1d_pytorch.py
+++ b/vllm_gaudi/ops/causal_conv1d_pytorch.py
@@ -26,8 +26,8 @@ import torch
 
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 
-USE_TPC_CAUSAL_CONV1D_FWD = os.environ.get("VLLM_HPU_CAUSAL_CONV1D_FWD_TPC", "1") == "1"
-USE_TPC_CAUSAL_CONV1D_UPDATE = os.environ.get("VLLM_HPU_CAUSAL_CONV1D_UPDATE_TPC", "0") == "1"
+USE_TPC_CAUSAL_CONV1D_FWD = os.environ.get("VLLM_HPU_CAUSAL_CONV1D_FWD_TPC", "0") == "1"
+USE_TPC_CAUSAL_CONV1D_UPDATE = os.environ.get("VLLM_HPU_CAUSAL_CONV1D_UPDATE_TPC", "1") == "1"
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary

Replaces the PyTorch reference implementation of `hpu_causal_conv1d_update` with a call to the HPU TPC native op `torch.ops.hpu.causal_conv1d_update`, removing the intermediate `hpu_causal_conv1d_fn_update` helper.

## Changes

- **Removes** `hpu_causal_conv1d_fn_update` and the flattening/reshaping boilerplate it required.
- **Gathers per-batch conv state** via safe-indexed slot lookup using `torch.remainder` (avoids HPU `torch.compile` miscompilation of `torch.where` on integer tensors).
- **Reshapes `x`** to `(batch, seqlen, dim)` as required by the TPC kernel API.
- **Transposes weight** from `(dim, width)` → `(width, dim)` before passing to the TPC op.
- **Converts activation** string to a boolean flag (`silu`/`swish` → `True`) as required by `torch.ops.hpu.causal_conv1d_update`.
- **Writes back** updated conv states via indexed assignment or `copy_` depending on whether `conv_state_indices` is provided.

## Testing

Verified on Gaudi with decode (update) path for Qwen3.5-based models.