### PR TITLE
[FIX_FOR_VLLM_CUSTOM=4efd6ffde09477800294a8ed9cc752017812c3b1] Fix minimax_m2 import after mamba LINEAR refactor (+1 more)

### DIFF
--- a/vllm_gaudi/entrypoints/openai/multi_model_api_server.py
+++ b/vllm_gaudi/entrypoints/openai/multi_model_api_server.py
@@ -22,15 +22,15 @@ from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.chat_utils import load_chat_template
 from vllm.entrypoints.launcher import serve_http
-from vllm.entrypoints.logger import RequestLogger
+from vllm.entrypoints.serve.utils.request_logger import RequestLogger
 from vllm.entrypoints.openai.api_server import build_app, setup_server
 from vllm.entrypoints.openai.cli_args import make_arg_parser, validate_parsed_serve_args
 from vllm.entrypoints.openai.models.protocol import BaseModelPath
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
-from vllm.entrypoints.openai.server_utils import get_uvicorn_log_config
+from vllm.entrypoints.serve.utils.server_utils import get_uvicorn_log_config
 from vllm.entrypoints.serve.render.serving import OpenAIServingRender
 from vllm.entrypoints.serve.tokenize.serving import OpenAIServingTokenization
-from vllm.entrypoints.utils import cli_env_setup, process_lora_modules
+from vllm.entrypoints.serve.utils.api_utils import cli_env_setup, process_lora_modules
 from vllm.logger import init_logger
 from vllm.reasoning import ReasoningParserManager
 from vllm.tasks import POOLING_TASKS, SupportedTask

--- a/vllm_gaudi/models/minimax_m2.py
+++ b/vllm_gaudi/models/minimax_m2.py
@@ -35,7 +35,7 @@ from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, ModelConfig, VllmConfig
 from vllm.distributed import (get_pp_group, get_tensor_model_parallel_world_size)
 from vllm.model_executor.layers.fused_moe import FusedMoE
-from vllm.model_executor.layers.mamba.linear_attn import MiniMaxText01RMSNormTP
+from vllm.model_executor.layers.minimax_rms_norm import MiniMaxText01RMSNormTP
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (QKVParallelLinear, ReplicatedLinear, RowParallelLinear)
 from vllm.model_executor.layers.logits_processor import LogitsProcessor


### PR DESCRIPTION
This PR consolidates 2 hourly-CI fixes against vllm@`4efd6ffde09477800294a8ed9cc752017812c3b1` per the single-rolling-PR rule (invariant I9).

## Bug 1: Fix minimax_m2 import after mamba LINEAR refactor

- **State machine id**: mamba_linear_attn_import_missing
- **Commit**: a9923506bd1d492ddb6807062cf3f1e6ce9423d1

### Root cause
Upstream vLLM moved `MiniMaxText01RMSNormTP` out of `vllm.model_executor.layers.mamba.linear_attn` into a dedicated module `vllm.model_executor.layers.minimax_rms_norm`. The HPU `minimax_m2` model is eagerly imported by `register_model()`, so the stale import broke every CI test at import time.

### Upstream PR
https://github.com/vllm-project/vllm/pull/43556

### Fix
Update the import of `MiniMaxText01RMSNormTP` to `vllm.model_executor.layers.minimax_rms_norm`.

## Bug 2: Fix multi_model_api_server imports after serving-utils consolidation

- **State machine id**: multi_model_entrypoints_logger_missing
- **Commit**: 2c4e39f6085ce8cc668245ec3b6470513974ad73

### Root cause
Upstream vLLM consolidated the online serving utilities, removing `entrypoints/logger.py`, `entrypoints/openai/server_utils.py` and `entrypoints/utils.py`. The HPU multi-model API server imported three symbols from those removed modules, breaking the unit-test import path.

### Upstream PR
https://github.com/vllm-project/vllm/pull/44479

### Fix
Repoint three imports in `multi_model_api_server.py` to the consolidated locations: `serve.utils.request_logger` (RequestLogger), `serve.utils.server_utils` (get_uvicorn_log_config) and `serve.utils.api_utils` (cli_env_setup, process_lora_modules).

## HPU verification
- Pod: Gaudi g3
- Full commit stack (`origin/main..HEAD`) re-verified against vllm@`4efd6ffde09477800294a8ed9cc752017812c3b1`: PASS

## Related PRs
None