### PR TITLE
Cherry-pick of Reapply path for block_size for non-GDN hybrid models to 0.21.0.post1

### DIFF
--- a/vllm_gaudi/distributed/kv_transfer/kv_connector/v1/hetero_hpu_nixl_connector.py
+++ b/vllm_gaudi/distributed/kv_transfer/kv_connector/v1/hetero_hpu_nixl_connector.py
@@ -9,7 +9,6 @@ import uuid
 import os
 from collections import defaultdict
 from concurrent.futures import Future, ThreadPoolExecutor
-from dataclasses import dataclass, field
 
 import msgspec
 import numpy as np
@@ -220,10 +219,7 @@ def NixlConnectorScheduler_init_(self, vllm_config: VllmConfig, engine_id: str, 
         self.use_host_buffer = vllm_config.kv_transfer_config.kv_buffer_device == "cpu"
 
     # Initialize _has_mamba to check if the model uses Mamba attention
-    self._has_mamba = any(
-        isinstance(g.kv_cache_spec, MambaSpec)
-        for g in kv_cache_config.kv_cache_groups
-    )
+    self._has_mamba = any(isinstance(g.kv_cache_spec, MambaSpec) for g in kv_cache_config.kv_cache_groups)
 
     self.postprocess_kv_caches_on_save = False
     self.kv_cache_layout_on_save = self.kv_cache_layout
@@ -487,9 +483,7 @@ def NixlConnectorWorker_init_(self, vllm_config: VllmConfig, engine_id: str, kv_
     # Enable with VLLM_HPU_NIXL_FORCE_UCX_TCP=1 to force socket transport.
     if os.getenv("VLLM_HPU_NIXL_FORCE_UCX_TCP", "0") == "1" and not os.getenv("UCX_TLS"):
         os.environ["UCX_TLS"] = "tcp,self"
-        logger.warning(
-            "VLLM_HPU_NIXL_FORCE_UCX_TCP=1 set and UCX_TLS is unset; forcing UCX_TLS=tcp,self"
-        )
+        logger.warning("VLLM_HPU_NIXL_FORCE_UCX_TCP=1 set and UCX_TLS is unset; forcing UCX_TLS=tcp,self")
 
     # Agent.
     non_ucx_backends = [b for b in self.nixl_backends if b != "UCX"]
@@ -1153,8 +1147,7 @@ def _nixl_handshake_compat(self, *args, **kwargs):
     """
     # Import lazily to avoid NameError if module-level symbol import order changes.
     from vllm_gaudi.distributed.kv_transfer.kv_connector.v1.nixl_metadata_compat import (
-        NixlAgentMetadataCompat,
-    )
+        NixlAgentMetadataCompat, )
 
     # msgspec types are immutable on some builds, so avoid monkey-patching
     # Decoder.__init__. Instead, temporarily swap the handshake function's
@@ -1199,12 +1192,8 @@ def _read_blocks_for_req_compat(self, req_id: str, meta: ReqMeta):
     # older metadata paths can still surface flat lists (list[int]).
     # Normalize both local_block_ids and local_physical_block_ids so upstream
     # failure handlers (which do meta.local_block_ids[0]) don't get a bare int.
-    meta.local_block_ids = _normalize_grouped_block_ids(
-        meta.local_block_ids
-    )
-    meta.local_physical_block_ids = _normalize_grouped_block_ids(
-        meta.local_physical_block_ids
-    )
+    meta.local_block_ids = _normalize_grouped_block_ids(meta.local_block_ids)
+    meta.local_physical_block_ids = _normalize_grouped_block_ids(meta.local_physical_block_ids)
     if meta.remote is not None:
         meta.remote.block_ids = _normalize_grouped_block_ids(meta.remote.block_ids)
 
@@ -1393,17 +1382,15 @@ def _log_failure_compat(
     if meta and meta.remote:
         num_local_blocks, local_sample = _summarize_block_ids(meta.local_block_ids)
         num_remote_blocks, _ = _summarize_block_ids(meta.remote.block_ids)
-        context.update(
-            {
-                "remote_engine_id": meta.remote.engine_id,
-                "remote_request_id": meta.remote.request_id,
-                "remote_host": meta.remote.host,
-                "remote_port": meta.remote.port,
-                "num_local_blocks": num_local_blocks,
-                "num_remote_blocks": num_remote_blocks,
-                "local_block_ids_sample": local_sample,
-            }
-        )
+        context.update({
+            "remote_engine_id": meta.remote.engine_id,
+            "remote_request_id": meta.remote.request_id,
+            "remote_host": meta.remote.host,
+            "remote_port": meta.remote.port,
+            "num_local_blocks": num_local_blocks,
+            "num_remote_blocks": num_remote_blocks,
+            "local_block_ids_sample": local_sample,
+        })
 
     context.update(extra_context)
     if msg:
@@ -1416,6 +1403,7 @@ def _log_failure_compat(
         exc_info=error is not None,
         stacklevel=2,
     )
+
 
 NixlConnector.wait_for_save = wait_for_save
 NixlConnectorScheduler.__init__ = NixlConnectorScheduler_init_

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -5282,12 +5282,17 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
                                             is_prompt=True)
         if decode_cfg:
             decode_bs, decode_query_len, decode_num_blocks = decode_cfg
-            # Use attn_block_size (the actual kernel block granularity used in
-            # _create_decode_input_data) rather than block_size (the KV-manager
-            # page size).  For hybrid models these differ after
-            # initialize_kv_cache aligns attn page size to mamba page size,
-            # causing warmup to record wrong num_blocks otherwise.
-            decode_block_size = self.attn_block_size
+            # For GDN hybrids (e.g. Qwen3.5), use attn_block_size (the
+            # actual kernel block granularity used in _create_decode_input_data)
+            # because cache_config.block_size is inflated for mamba page
+            # alignment and differs from the attention kernel granularity.
+            # For non-GDN hybrids (e.g. Granite 4.0-H), block_size and
+            # attn_block_size are equal after reassignment in
+            # initialize_kv_cache, so use self.block_size directly.
+            if self.num_mamba_like_layers > 0 and self.num_gdn > 0:
+                decode_block_size = self.attn_block_size
+            else:
+                decode_block_size = self.block_size
             if self.use_contiguous_pa:
                 decode_seq_lengths = [decode_block_size] * decode_bs
                 # Cap block_id at physical pool — contiguous PA uses
@@ -5915,19 +5920,28 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
         self.is_encoder_only_attn = False
         self.may_add_encoder_only_layers_to_kv_cache_config()
         if self.num_mamba_like_layers > 0:
-            # NOTE: Do NOT reassign self.block_size or
-            # bucketing_manager.block_size from cache_config here.
-            # For hybrid models the upstream HybridAttentionMambaModelConfig
-            # inflates cache_config.block_size to align mamba pages (e.g.
-            # 1152 for Qwen3.5), but the HPU attention kernel operates at
-            # 128-token granularity.  _create_decode_input_data computes
-            # num_blocks using self.attn_block_size (set below from
-            # prepare_kernel_block_sizes), so the bucketing manager must
-            # also use that same granularity.  Overwriting block_size with
-            # the inflated KV-manager page size caused decode buckets to be
-            # generated at 1152-token granularity while runtime used
-            # 128-token granularity, leading to permanent "not warmed-up"
-            # warnings and recompilations.
+            if self.num_gdn > 0:
+                # GDN hybrids (e.g. Qwen3.5): Do NOT reassign self.block_size
+                # from cache_config.  The upstream HybridAttentionMambaModelConfig
+                # inflates cache_config.block_size to align mamba pages (e.g.
+                # 1152 for Qwen3.5), but the HPU attention kernel operates at
+                # 128-token granularity.  _create_decode_input_data computes
+                # num_blocks using self.attn_block_size (set below from
+                # prepare_kernel_block_sizes), so the bucketing manager must
+                # also use that same granularity.  Overwriting block_size with
+                # the inflated KV-manager page size caused decode buckets to be
+                # generated at 1152-token granularity while runtime used
+                # 128-token granularity, leading to permanent "not warmed-up"
+                # warnings and recompilations.
+                pass
+            else:
+                # Non-GDN hybrids (e.g. Granite 4.0-H): block_size and
+                # attn_block_size are equal (both 528) after platform
+                # alignment, so reassignment keeps all runtime paths
+                # (warmup, prefill bucketing, decode) consistent.
+                self.block_size = self.vllm_config.cache_config.block_size
+                if self.enable_bucketing:
+                    self.bucketing_manager.block_size = self.block_size
             maybe_set_mamba_kv_cache_groups_ids(self.model, self.kv_cache_config)
         self.initialize_attn_backend(kv_cache_config)
 


### PR DESCRIPTION
Changes:

Restored self.block_size = cache_config.block_size in the num_mamba_like_layers > 0 path of initialize_kv_cache. This was removed by PR https://github.com/vllm-project/vllm-gaudi/pull/1434 but is needed for non-GDN hybrids (e.g. GraniteMoeHybrid).

Added bucketing_manager.block_size = attn_block_size after bucketing initialization. This ensures decode buckets use the kernel granularity regardless of the KV-manager page size — fixing Qwen3.5 while keeping GraniteMoeHybrid correct.