### PR TITLE
Fix contiguous PA KV fetch reading wrong physical rows at long context

### DIFF
--- a/vllm_gaudi/extension/utils.py
+++ b/vllm_gaudi/extension/utils.py
@@ -77,7 +77,14 @@ class VLLMKVCache(torch.nn.Module):
 
     def fetch_from_cache(self, cache, blocks, scales=None, **kwargs):
         if self.use_contiguous_pa:
-            return cache[:blocks.size(0)]
+            # `blocks` holds physical block ids; with contiguous PA they are not
+            # necessarily packed into [0, len(blocks)). Slicing `cache[:n]` only
+            # returns the first n physical rows, which at long context (where the
+            # ids range far above n) reads the wrong KV and corrupts attention.
+            # Fetch the actual rows by id instead. clamp() keeps padding ids
+            # (e.g. -1 / num_blocks) in-bounds; their contribution is masked out
+            # downstream via block_usage/block_bias.
+            return cache.index_select(0, blocks.clamp(0, cache.size(0) - 1))
         else:
             return cache.index_select(0, blocks)
 


### PR DESCRIPTION
> **Draft — correctness verified, performance trade-off documented. Seeking maintainer input on the proper long-term fix (see "Open question").**

## Problem

On Gaudi with `VLLM_CONTIGUOUS_PA=true`, `Llama-3.3-70B` (FP8/INC, TP2, `max-model-len 131072`) returns fluent-but-wrong / garbled answers on **long-context** prompts. Short-context tasks are unaffected. No HTTP errors — failures are purely behavioral. (Internal ref: GAUDISW-248985, IBM watsonx.)

## Root cause (verified by instrumentation)

`VLLMKVCache.fetch_from_cache` (`vllm_gaudi/extension/utils.py`) fetches decode KV via:

```python
if self.use_contiguous_pa:
    return cache[:blocks.size(0)]      # first N physical rows
```

This assumes the `block_list` reaching the fetch is the *contiguous identity layout* (physical row `i` holds block `i`), so a cheap contiguous slice equals a gather. **Instrumentation shows that assumption does not hold at decode**: the `block_list` passed to the fetch contains the raw, scattered physical block ids — for every decode step measured, **100% of entries had `block_list[i] != i`** (and zero padding/gap entries). So `cache[:N]` returns physical rows `0..N-1`, which are **not** the rows this sequence owns, and attention reads the wrong KV. Short context works only because there the block ids happen to coincide with `0..N-1`.

This is a wrong-rows bug, not numerical — fetched keys are finite and in range (no NaN/Inf).

## Fix

Fetch the actual rows by block id (same as the non-contiguous branch):

```python
if self.use_contiguous_pa:
    return cache.index_select(0, blocks.clamp(0, cache.size(0) - 1))
```

`clamp()` keeps any padding ids in-bounds.

## Validation (Gaudi3, Llama-3.3-70B FP8/INC, TP2, max-model-len 131072, warmup on)

**Accuracy — LongBench `narrativeqa` (lm-eval, chat template):**

| Config | qa_f1 |
|---|---|
| `CONTIGUOUS_PA=true` (before) | 0.03 |
| `CONTIGUOUS_PA=true` + this fix | **0.35–0.38** |
| `CONTIGUOUS_PA=false` (reference) | 0.37 |

Short-context (GSM8K CoT) is ~94% and unaffected (no block scatter there).

**Performance — `vllm bench serve`, random, out=128, both PA=true @ util 0.9** (TPOT = ms/output-token, A=this fix vs B=unpatched PA=true):

| input len | fix TPOT | unpatched TPOT | regression |
|---|---|---|---|
| 2,048 | 234.9 | 221.9 | ~6% |
| 8,192 | 302.6 | 278.4 | ~9% |
| 32,768 | 533.3 | (baseline not captured) | >9% (growing) |

`index_select` copies the fetched KV blocks every layer/step, whereas the slice was a free view, so the cost grows with block count / context length. **This is a real regression** and I'm not claiming otherwise.

**Trade-off vs. the existing workaround:** the current mitigation is `VLLM_CONTIGUOUS_PA=false`, which on the same system costs ~24% throughput **and** forces lower `--gpu-memory-utilization` (0.9→0.7 to fit `bs=192`). This fix restores correctness at ~6–9% (growing) while keeping util 0.9 — a strict improvement over both the bug and the workaround.

## Open question for maintainers (the proper fix)

The deeper issue is that the contiguous identity `block_list` built in `get_habana_paged_attn_buffers` does not appear to reach the decode fetch as identity — the fetch sees raw scattered ids. If the intended-contiguous layout were actually preserved end-to-end, `cache[:n]` would be both correct **and** free. I couldn't pin down where the identity layout is lost. **Is this fetch-side `index_select` an acceptable correctness fix while that's investigated, or should the layout be fixed upstream so the cheap slice stays valid?** Happy to take direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
