### PR TITLE
Restore recursive dict-tag guards for torch.compile

### DIFF
--- a/vllm_gaudi/platform.py
+++ b/vllm_gaudi/platform.py
@@ -406,6 +406,13 @@ class HpuPlatform(Platform):
         # Allow utilization of the Parallel Compilation feature.
         if os.environ.get('FUSER_ENABLE_MULTI_THREADED_INVOCATIONS') is None:
             os.environ['FUSER_ENABLE_MULTI_THREADED_INVOCATIONS'] = '1'
+        # Use recursive dict-tag guards for torch.compile. A recent upstream
+        # torch release flipped this dynamo default off, which regresses
+        # throughput of the torch.compile serving path; force it back on so
+        # guard evaluation stays cheap. hasattr-guarded so torch builds without
+        # the knob are a no-op.
+        if hasattr(torch._dynamo.config, 'use_recursive_dict_tags_for_guards'):
+            torch._dynamo.config.use_recursive_dict_tags_for_guards = True
 
     @classmethod
     def adjust_cuda_hooks(cls) -> None:


### PR DESCRIPTION
## Summary

A recent upstream torch release flipped the TorchDynamo
`use_recursive_dict_tags_for_guards` config default from `True` to `False`.
With recursive dict-tag guards disabled, guard evaluation on the
`torch.compile` serving path falls back to full guard execution, which is
more expensive and regresses decode throughput on HPU (observed on the
8-card FP8 `torch_compile` serving benchmark — a single-digit-percent drop
that tracks exactly to this flag).

This restores the previous behavior by setting the flag back to `True` at
engine-construction time, inside the eager-only `set_compile_env_defaults()`
hook. Doing it here (rather than relying on the torch build default) makes
the plugin robust to the upstream default flipping again.

## Details

- Eager-only: `set_compile_env_defaults()` already returns early in lazy
  mode, so the lazy serving path is untouched.
- `hasattr`-guarded: torch builds that don't have the knob are a no-op, and
  builds where it is already `True` are unaffected.
- It is a `torch._dynamo.config` assignment, not an environment variable, so
  it cannot propagate into a differently-moded subprocess.
- Consistent with the existing dynamo config the plugin already manages
  (`disable`, `cache_size_limit`, `force_parameter_static_shapes`).

## Test Plan

- Rerun the FP8 `torch_compile` serving benchmark and confirm throughput
  returns to the pre-regression baseline.
- `set_compile_env_defaults()` remains a no-op in lazy mode (covered by the
  existing platform env-default unit tests).