### PR TITLE
[HPU] Fix contiguous PA wrong-rows on prefill context (perf-preserving)

### DIFF
--- a/vllm_gaudi/attention/backends/hpu_attn.py
+++ b/vllm_gaudi/attention/backends/hpu_attn.py
@@ -30,6 +30,23 @@ from vllm._aiter_ops import rocm_aiter_ops
 logger = init_logger()
 
 
+def _set_fetch_by_id(kv_cache, value: bool) -> None:
+    """Toggle id-based KV fetch (vs. the contiguous-PA zero-copy slice) on a KV cache.
+
+    GAUDISW-248985: the prefill-context block_list holds raw scattered ids and must be
+    gathered by id, whereas the decode block_list is the contiguous-identity layout and
+    can use the zero-copy slice. We flag the module instead of passing a kwarg because
+    INC's PatchedVLLMKVCache wraps fetch_from_cache with a fixed signature and delegates
+    to orig_mod; set the flag there too so the original method (which INC calls) sees it.
+    """
+    if kv_cache is None:
+        return
+    kv_cache._fetch_by_id = value
+    orig = getattr(kv_cache, "orig_mod", None)
+    if orig is not None:
+        orig._fetch_by_id = value
+
+
 class HPUAttentionBackend(AttentionBackend):
 
     @staticmethod
@@ -594,6 +611,11 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
             block_list = attn_metadata.block_list if attn_metadata \
                 and attn_metadata.block_list is not None else None
 
+            # GAUDISW-248985: prefill context blocks are raw scattered ids, so the
+            # contiguous-PA fetch must gather by id (cache[:n] would read wrong rows).
+            _set_fetch_by_id(self.k_cache, True)
+            _set_fetch_by_id(self.v_cache, True)
+
             common_args = self.common_attention_args(block_list, key_cache, value_cache, attn_metadata.block_size,
                                                      k_scales, v_scales)
 
@@ -621,6 +643,10 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
             output = out.reshape(batch_size, seq_len, hidden_size)
         else:
             # Decoding run.
+            # GAUDISW-248985: decode block_list is the contiguous-identity layout, so
+            # keep the zero-copy slice fetch (cache[:n]); only prefill needs gather.
+            _set_fetch_by_id(self.k_cache, False)
+            _set_fetch_by_id(self.v_cache, False)
             if self.sliding_window and \
                 attn_metadata.window_block_list is not None:
                 block_list = attn_metadata.window_block_list

--- a/vllm_gaudi/extension/utils.py
+++ b/vllm_gaudi/extension/utils.py
@@ -76,7 +76,14 @@ class VLLMKVCache(torch.nn.Module):
         return cache
 
     def fetch_from_cache(self, cache, blocks, scales=None, **kwargs):
-        if self.use_contiguous_pa:
+        # Contiguous PA's fast path (cache[:n]) is only valid when `blocks` is the
+        # contiguous-identity layout the decode path builds (blocks[i] == i). The
+        # prefill-context path passes raw, scattered physical block ids, for which
+        # cache[:n] would return the wrong rows (GAUDISW-248985). The prefill path
+        # sets `_fetch_by_id` on this module so we gather by id there, while decode
+        # keeps the zero-copy slice. We use an instance flag rather than a kwarg
+        # because INC's PatchedVLLMKVCache wraps this method with a fixed signature.
+        if self.use_contiguous_pa and not getattr(self, "_fetch_by_id", False):
             return cache[:blocks.size(0)]
         else:
             return cache.index_select(0, blocks)


### PR DESCRIPTION
> **Draft.** Perf-preserving alternative to #1540 for GAUDISW-248985. Validated on Gaudi3 / Llama-3.3-70B FP8.

## Problem

With `VLLM_CONTIGUOUS_PA=true`, Llama-3.3-70B (FP8/INC, TP2, `--async-scheduling`) returns garbled / wrong answers on **long-context** prompts; short context is fine. No HTTP errors — behavioral only. (Internal ref: GAUDISW-248985, IBM watsonx.)

## Root cause

`VLLMKVCache.fetch_from_cache` takes the contiguous-PA fast path `cache[:n]`, which is only correct when `blocks` is the **contiguous-identity layout** (`blocks[i] == i`, gaps padded out of range). Instrumentation showed:

- The **decode** block_list *is* built that way → `cache[:n]` is correct.
- The **prefill-context** block_list (`context_blocks`, built in `hpu_model_runner`) holds **raw, scattered physical block ids**. `cache[:n]` then returns physical rows `0..n-1` — not the rows the sequence owns — so attention over the cached context reads the wrong KV → garbled generation.

Only manifests with `--async-scheduling` (how the block tables / scheduling are produced); short context works because there are few/no context blocks.

## Fix

Gather by id (`index_select`) on the **prefill-context** fetch, while keeping the zero-copy `cache[:n]` slice on the **decode** hot path. The path is selected by a per-forward `_fetch_by_id` instance flag (prompt → gather, decode → slice), set on the KV-cache module. A kwarg can't be used here: INC's `PatchedVLLMKVCache` wraps `fetch_from_cache` with a fixed signature and delegates to `orig_mod`, so the helper sets the flag on `orig_mod` too.

## Why not just always `index_select` (#1540)?

#1540 makes the fetch gather on **every** path. That fixes correctness but turns the per-token decode fetch from a zero-copy view into a gather, regressing throughput (~24% in our runs). This PR keeps decode on the slice, so **throughput is unchanged**.

## Validation

Gaudi3, Llama-3.3-70B FP8/INC, TP2, `--max-model-len 131072`, `--block-size 128`, `--async-scheduling`, warmup on (canonical benchmark config).

**Accuracy** — LongBench `narrativeqa` (lm-eval, chat template, limit 20):

| Config | qa_f1 | garbled |
|---|---|---|
| `CONTIGUOUS_PA=true` (before) | 0.05 | 3/20 |
| + this fix | **0.31** | 0/20 |
| `CONTIGUOUS_PA=false` (reference) | ~0.34 | 0/20 |

**Throughput** — `vllm bench serve`, random 4096-in / 1024-out, 384 prompts, max-concurrency 192, `--ignore-eos`:

| Config | Output tok/s | Mean TPOT |
|---|---|---|
| unpatched `CONTIGUOUS_PA=true` | 1076.6 | 142.9 ms |
| + this fix | **1074.1** | 143.6 ms |

→ within noise, **no regression** (contrast #1540 ≈ −24%).

**Short context (e.g. GSM8K):** unaffected by construction — prefill has no/few context blocks, so the decode slice path is taken exactly as before. (Not separately re-measured on this build.)

## Notes for reviewers

- Validated on a single LongBench subtask (narrativeqa). Generalization to other long-context tasks not yet swept.
- Open to preference between this instance-flag approach and threading the choice through the metadata more explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Throughput vs. the `CONTIGUOUS_PA=false` workaround (the key comparison)

The current mitigation is `VLLM_CONTIGUOUS_PA=false`, which also forces `--gpu-memory-utilization 0.70` (it can't fit `bs=192` at 0.90). All three on the same Gaudi3 pod, canonical bench (random 4096-in/1024-out, 384 prompts, max-concurrency 192, `--ignore-eos`):

| Config | Output tok/s | Mean TPOT | narrativeqa f1 |
|---|---|---|---|
| **this fix** (PA=true, util 0.90) | **1074** | 143.6 ms | 0.31 |
| `CONTIGUOUS_PA=false` workaround (util 0.70) | 726 | 182.2 ms | ~0.34 |
| unpatched `PA=true` (broken) | 1077 | 142.9 ms | 0.05 |

→ **~+48% throughput over the workaround**, with equivalent accuracy. The fix restores correctness while keeping contiguous-PA's full performance and `--gpu-memory-utilization 0.90`.