### PR TITLE
fix: cap fastapi<0.137 to unbreak prometheus instrumentator

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,9 @@ numpy>=1.26.0
 kaldi-native-fbank >= 1.18.7
 tblib==3.1.0
 transformers==5.9.0
+# Cap FastAPI below 0.137: that release made include_router() build a route
+# tree (_IncludedRouter nodes in app.routes) instead of a flat APIRoute list,
+# which prometheus-fastapi-instrumentator (<=8.0.0) chokes on while resolving
+# route.path -> 500 on every request. Upstream bug:
+# trallnag/prometheus-fastapi-instrumentator#370. Remove once it ships a fix.
+fastapi<0.137


### PR DESCRIPTION
## Summary

FastAPI 0.137 changed `include_router()` to build a route tree
(`_IncludedRouter` nodes in `app.routes`) instead of a flat `APIRoute`
list. `prometheus-fastapi-instrumentator` (<=8.0.0) iterates `app.routes`
and reads `route.path` on every element, raising `AttributeError` on the
new `_IncludedRouter` nodes — returning **HTTP 500 on every request**.

Surfaced as NIXL PD `run_accuracy_test.sh` (`test_accuracy`) failing with
500 on `/v1/completions`. The failure looks like a model bug but is purely
a dependency-version regression — unrelated to model code.

Pin `fastapi<0.137` in `requirements.txt` until the instrumentator ships a
fix.

Upstream bug: trallnag/prometheus-fastapi-instrumentator#370

## Notes

Temporary cap — remove once prometheus-fastapi-instrumentator releases a
fix for the FastAPI 0.137 route-tree change.
