### PR TITLE
Fix decode bucket sparsity for longprompt

### DIFF
--- a/tests/unit_tests/test_bucketing.py
+++ b/tests/unit_tests/test_bucketing.py
@@ -352,8 +352,9 @@ _REAL_BUGGY_MAX_DECODE_BLOCKS = 183808  # min(91964//128*256, 3593*256//4)
 @patch('vllm_gaudi.extension.bucketing.exponential.get_config')
 def test_real_scenario_decode_cfg_matches_fixed_log(mock_get_config):
     """Verify decode bucket config matches expected values for real scenario.
-    With non-contiguous PA: block config should be
-    [1, 256, ceil(91964/128)*256, ceil(log2(that))+1]
+    With non-contiguous PA: block config limit includes extra buckets
+    when max_decode_blocks > max_blocks*3 to maintain bucket density
+    at high block counts (longprompt density fix).
     """
     mock_get_config.return_value = _MockConfig(use_contiguous_pa=False)
     strategy = ExponentialBucketingStrategy()
@@ -366,6 +367,11 @@ def test_real_scenario_decode_cfg_matches_fixed_log(mock_get_config):
 
     expected_max = math.ceil(_REAL_MAX_MODEL_LEN / _REAL_BLOCK_SIZE) * _REAL_MAX_NUM_SEQS
     expected_limit = math.ceil(math.log2(expected_max)) + 1
+    # Account for extra buckets added when max_decode_blocks exceeds
+    # bounded_max (longprompt density compensation)
+    bounded_max = _REAL_MAX_BLOCKS * 3
+    if expected_max > bounded_max:
+        expected_limit += math.ceil(math.log2(expected_max / bounded_max)) + 1
     assert block_cfg[0] == 1, f"block min: expected 1, got {block_cfg[0]}"
     assert block_cfg[1] == _REAL_MAX_NUM_SEQS, (f"block step: expected {_REAL_MAX_NUM_SEQS}, got {block_cfg[1]}")
     assert block_cfg[2] == expected_max, (f"block max: expected {expected_max}, got {block_cfg[2]}")

--- a/vllm_gaudi/extension/bucketing/exponential.py
+++ b/vllm_gaudi/extension/bucketing/exponential.py
@@ -92,6 +92,11 @@ class ExponentialBucketingStrategy():
         max_decode_blocks = math.ceil(max_model_len / block_size) * max_num_seqs
         max_decode_blocks = min(max_blocks, max_decode_blocks) if use_contiguous_pa else max_decode_blocks
         decode_blocks_limit = math.ceil(math.log2(max_decode_blocks)) + 1
+        # Compensate for wider range: add extra buckets to maintain density at high end
+        if not use_contiguous_pa and max_blocks > 0:
+            bounded_max = max_blocks * 3
+            if max_decode_blocks > bounded_max:
+                decode_blocks_limit += math.ceil(math.log2(max_decode_blocks / bounded_max)) + 1
         decode_block_bucket_cfg = [1, max_num_seqs, max_decode_blocks, decode_blocks_limit]
 
         msg = ("Decode bucket config (min, step, max_warmup, limit) "


### PR DESCRIPTION
Add extra exponential buckets when max_decode_blocks exceeds max_blocks*3 to maintain bucket density at high block counts, avoiding excessive
padding that degrades throughput for large context workloads.

In case qwen3.5 122b-a10b model, there're perf regression with longprompt (ex: 200k) due to [f24f3f9d ](https://github.com/vllm-project/vllm-gaudi/commit/f24f3f9d) which causing overly wide max_decode_blocks, resulting excessive padding, but gives good low-end density and perf.

This is the test result with 122b-a10b model.

|Workload | v0.19.1 | v0.21.0 (before) | v0.21.0 (with fix) | Fix vs v0.19.1|
-- | -- | -- | -- | --
51200/2560 | 250.68 | 255.16 | 253.53 | +1.1%
102400/5120 | 212.36 | 223.25 | 218.57 | +2.9%
204800/10240 | 129.87 | 125.15 | 134.06 | +3.2%

With 35b-a3b model, 200k

|Workload | v0.19.1 | v0.21.0 (before) | v0.21.0 (with fix) | Fix vs v0.19.1| Fix vs v0.21.0|
-- | -- | -- | -- | -- | --
204800/10240 | 124.55 | 123.19 | 160.81 | +29.1% | +30.5%

And, corresponding changes in bucket test.