### PR TITLE
Forward schedule() args to base in HPUAsyncScheduler

### DIFF
--- a/vllm_gaudi/v1/core/sched/hpu_async_scheduler.py
+++ b/vllm_gaudi/v1/core/sched/hpu_async_scheduler.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from collections.abc import Iterable
+from typing import Any
 
 from vllm.v1.core.sched.async_scheduler import AsyncScheduler
 from vllm.v1.request import Request, RequestStatus
@@ -7,7 +8,7 @@ from vllm.v1.request import Request, RequestStatus
 
 class HPUAsyncScheduler(AsyncScheduler):
 
-    def schedule(self):
+    def schedule(self, *args: Any, **kwargs: Any):
         """HPU override: fix stale cached-token accounting after preemption.
 
         After preemption a request is requeued with num_computed_tokens reset.
@@ -24,8 +25,13 @@ class HPUAsyncScheduler(AsyncScheduler):
         re-scheduled stays in self.waiting and the inconsistency persists
         until it is picked up. The Prometheus clamp in vllm_gaudi/utils.py
         guards the metrics path during that window.
+
+        Accepts *args/**kwargs and forwards them verbatim to the base
+        schedule() so this override stays compatible as upstream evolves the
+        signature (e.g. the throttle_prefills flag passed by
+        step_with_batch_queue under --async-scheduling).
         """
-        output = super().schedule()
+        output = super().schedule(*args, **kwargs)
         for request in self.running:
             # vLLM Request no longer exposes num_cached_tokens on newer
             # branches. Keep the old fix only when the field exists.


### PR DESCRIPTION
## Problem

Upstream vLLM changed the scheduler entrypoint from `Scheduler.schedule(self)` to `schedule(self, throttle_prefills: bool = False)`, and the engine core now calls it with that argument in both step paths:

```python
# vllm/v1/engine/core.py (sync path and step_with_batch_queue)
scheduler_output = self.scheduler.schedule(self._should_throttle_prefills())
```

`AsyncScheduler` does not override `schedule()`, so it inherits the new signature. But `HPUAsyncScheduler` overrode it with no parameter (`def schedule(self)`). Under `--async-scheduling`, the batch-queue path passes the throttle flag positionally, crashing the engine at call dispatch:

```
TypeError: HPUAsyncScheduler.schedule() takes 1 positional argument but 2 were given
```

This kills the engine core (`EngineDeadError`) on the first request, returning HTTP 500 and leaving `/health` at 503. It reproduces with any model served with `--async-scheduling`.

## Fix

Change the override to accept `*args, **kwargs` and forward them verbatim to `super().schedule()`. This keeps the override compatible regardless of how upstream evolves the base signature, while the HPU-specific post-processing (the `num_cached_tokens` resync after preemption) is unchanged.

## Verification

Reproduced and verified on a Gaudi3 pod against vLLM `main` + vLLM-Gaudi `main`, serving with `--async-scheduling --enable-auto-tool-choice`:

- **Before:** `TypeError` at the batch-queue schedule call → `EngineDeadError` → 500 / 503.
- **After:** the request completes cleanly, the engine stays alive, and a follow-up `/health` succeeds.

`ruff` (v0.11.7, the repo's pinned pre-commit linter) passes on the changed file.