### PR TITLE
[FIX_FOR_VLLM_CUSTOM=ecf9d83520eb217401b47d8a5451a27c5231b8c2] Fix 3 hourly-CI breakages: tokenization import, stale take_events test, HPU plugin re-entrancy

### DIFF
--- a/tests/unit_tests/kv_offload/offloading_connector/test_scheduler.py
+++ b/tests/unit_tests/kv_offload/offloading_connector/test_scheduler.py
@@ -1,14 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from collections.abc import Iterable
-
 import pytest
 
 from tests.unit_tests.kv_offload.offloading_connector.utils import (
     generate_store_output, )
 from tests.unit_tests.kv_offload.utils import EOS_TOKEN_ID
-from vllm.distributed.kv_events import BlockRemoved, BlockStored
-from vllm.v1.kv_offload.base import OffloadingEvent, OffloadKey, make_offload_key
 from vllm.v1.request import RequestStatus
 
 
@@ -105,31 +101,6 @@ def test_offloading_connector(request_runner, async_scheduling: bool):
     runner.manager.prepare_store.side_effect = (lambda block_hashes, req_context: generate_store_output([]))
     runner.connector_scheduler._maximal_prefix_lookup = lambda key, req_context: 1
     runner.run(decoded_tokens=[EOS_TOKEN_ID], expected_loaded_gpu_block_indexes=(3, 4, 5))
-
-    # test take_events
-    def to_keys(int_ids: list[int]) -> list[OffloadKey]:
-        return [make_offload_key(str(i).encode(), 0) for i in int_ids]
-
-    def take_events() -> Iterable[OffloadingEvent]:
-        yield OffloadingEvent(keys=to_keys([1, 2, 3]), medium="A", removed=False)
-        yield OffloadingEvent(keys=to_keys([4, 5, 6]), medium="B", removed=True)
-
-    runner.manager.take_events.side_effect = take_events
-    events = list(runner.scheduler_connector.take_events())
-    assert len(events) == 2
-    event = events[0]
-    assert isinstance(event, BlockStored)
-    assert event.block_hashes == [str(i).encode() for i in [1, 2, 3]]
-    assert event.block_size == 0
-    assert event.medium == "A"
-    assert event.token_ids == []
-    assert event.parent_block_hash is None
-    assert event.lora_id is None
-    assert event.lora_name is None
-    event = events[1]
-    assert isinstance(event, BlockRemoved)
-    assert event.block_hashes == [str(i).encode() for i in [4, 5, 6]]
-    assert event.medium == "B"
 
 
 @pytest.mark.parametrize("async_scheduling", [True, False])

--- a/vllm_gaudi/entrypoints/openai/multi_model_api_server.py
+++ b/vllm_gaudi/entrypoints/openai/multi_model_api_server.py
@@ -29,7 +29,7 @@ from vllm.entrypoints.openai.models.protocol import BaseModelPath
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
 from vllm.entrypoints.serve.utils.server_utils import get_uvicorn_log_config
 from vllm.entrypoints.serve.render.serving import OpenAIServingRender
-from vllm.entrypoints.serve.tokenize.serving import OpenAIServingTokenization
+from vllm.entrypoints.serve.tokenize.serving import ServingTokenization
 from vllm.entrypoints.serve.utils.api_utils import cli_env_setup, process_lora_modules
 from vllm.logger import init_logger
 from vllm.reasoning import ReasoningParserManager
@@ -513,8 +513,7 @@ async def _init_multi_model_state(
         log_error_stack=args.log_error_stack,
     )
 
-    state.openai_serving_tokenization = OpenAIServingTokenization(
-        engine_client,
+    state.openai_serving_tokenization = ServingTokenization(
         state.openai_serving_models,
         state.openai_serving_render,
         request_logger=request_logger,

--- a/vllm_gaudi/entrypoints/openai/multi_model_api_server.py
+++ b/vllm_gaudi/entrypoints/openai/multi_model_api_server.py
@@ -29,7 +29,7 @@ from vllm.entrypoints.openai.models.protocol import BaseModelPath
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
 from vllm.entrypoints.serve.utils.server_utils import get_uvicorn_log_config
 from vllm.entrypoints.serve.render.serving import OpenAIServingRender
-from vllm.entrypoints.serve.tokenize.serving import ServingTokenization
+from vllm.entrypoints.serve.tokenize.serving import OpenAIServingTokenization
 from vllm.entrypoints.serve.utils.api_utils import cli_env_setup, process_lora_modules
 from vllm.logger import init_logger
 from vllm.reasoning import ReasoningParserManager
@@ -513,7 +513,8 @@ async def _init_multi_model_state(
         log_error_stack=args.log_error_stack,
     )
 
-    state.openai_serving_tokenization = ServingTokenization(
+    state.openai_serving_tokenization = OpenAIServingTokenization(
+        engine_client,
         state.openai_serving_models,
         state.openai_serving_render,
         request_logger=request_logger,

--- a/vllm_gaudi/patches.py
+++ b/vllm_gaudi/patches.py
@@ -44,8 +44,27 @@ import gc
 import torch
 
 from vllm import envs
-from vllm.distributed import parallel_state
-from vllm.platforms import current_platform
+
+# NOTE: neither ``vllm.platforms.current_platform`` nor
+# ``vllm.distributed.parallel_state`` is imported at module top level — both
+# force re-entrant platform resolution *while this module is being imported by
+# ``vllm_gaudi.register()``*, leaving ``vllm_gaudi`` partially initialized so
+# the HPU platform plugin is silently dropped and vLLM falls back to
+# ``UnspecifiedPlatform`` ("RuntimeError: Failed to infer device type / Device
+# string must not be empty"). Concretely:
+#
+# * ``current_platform`` is a lazily-resolved attribute (see
+#   ``vllm/platforms/__init__.py.__getattr__``): importing it eagerly runs
+#   ``resolve_current_platform_cls_qualname()`` directly.
+# * ``parallel_state`` transitively imports ``vllm.utils.torch_utils``, whose
+#   module-level ``PIN_MEMORY = is_pin_memory_available()`` (vllm PR #45424)
+#   resolves ``current_platform`` at import time — the same re-entry, one hop
+#   removed.
+#
+# Both are therefore imported lazily inside the functions that use them, and
+# the ``cleanup_dist_env_and_memory`` patch (which needs ``parallel_state``)
+# is deferred to ``load_general_plugins`` time rather than ``apply()``
+# (platform-registration time). See GAUDISW-249622.
 
 
 def _hpu_accelerator_empty_cache() -> None:
@@ -56,6 +75,8 @@ def _hpu_accelerator_empty_cache() -> None:
     ``RuntimeError``.  Route through ``current_platform.empty_cache``
     instead (which is ``None`` on HPU, making this a no-op).
     """
+    from vllm.platforms import current_platform
+
     empty_cache = current_platform.empty_cache
     if empty_cache is not None:
         empty_cache()
@@ -132,6 +153,9 @@ def _hpu_cleanup_dist_env_and_memory(shutdown_ray: bool = False) -> None:
     ``torch.accelerator.empty_cache()`` (which is incompatible with the
     HPU allocator).
     """
+    from vllm.distributed import parallel_state
+    from vllm.platforms import current_platform
+
     # Re-apply lazy runtime patches that may depend on import timing.
     _patch_hf3fs_mock_client_for_cpu_only()
 
@@ -235,6 +259,22 @@ def _patch_batched_count_greater_than() -> None:
     _sampler_mod.batched_count_greater_than = _hpu_batched_count_greater_than
 
 
+def _patch_cleanup_dist_env_and_memory() -> None:
+    """Install the HPU-safe ``cleanup_dist_env_and_memory`` replacement.
+
+    Deferred to ``load_general_plugins`` time (rather than ``apply()`` at
+    platform-registration time) so the ``vllm.distributed.parallel_state``
+    import chain runs *after* the platform is initialised and *after*
+    ``vllm.utils.torch_utils`` has finished importing (see ``apply()`` and
+    the module-level NOTE — GAUDISW-249622).
+    """
+    from vllm.distributed import parallel_state
+    import vllm.distributed as _vllm_distributed
+
+    parallel_state.cleanup_dist_env_and_memory = _hpu_cleanup_dist_env_and_memory
+    _vllm_distributed.cleanup_dist_env_and_memory = _hpu_cleanup_dist_env_and_memory
+
+
 def apply() -> None:
     """Install all HPU runtime monkey-patches."""
     # --- torch.accelerator.empty_cache ---
@@ -244,25 +284,25 @@ def apply() -> None:
     if not hasattr(torch._C, "_host_emptyCache"):
         torch._C._host_emptyCache = lambda: None
 
-    # --- cleanup_dist_env_and_memory ---
-    parallel_state.cleanup_dist_env_and_memory = _hpu_cleanup_dist_env_and_memory
-    import vllm.distributed as _vllm_distributed
-
-    _vllm_distributed.cleanup_dist_env_and_memory = _hpu_cleanup_dist_env_and_memory
     _patch_hf3fs_mock_client_for_cpu_only()
 
-    # --- batched_count_greater_than (deferred) ---
-    # We cannot import the sampler modules here because the import chain
-    # triggers platform re-initialisation ("Device string must not be
-    # empty").  Instead we hook into ``load_general_plugins`` which runs
-    # in every process (parent + EngineCore subprocess) after the platform
-    # is ready.
+    # --- Deferred patches (cleanup_dist_env_and_memory + sampler) ---
+    # We cannot import ``vllm.distributed.parallel_state`` or the sampler
+    # modules here, at platform-registration time.  Their import chain
+    # re-enters ``vllm.utils.torch_utils`` while it is still initialising
+    # (vllm PR #45424 made ``PIN_MEMORY`` resolve the current platform at
+    # ``torch_utils`` import time, and that platform resolution is exactly
+    # what triggers this plugin's registration).  The re-entry aborts HPU
+    # platform detection ("Failed to infer device type").  Instead we hook
+    # into ``load_general_plugins`` which runs in every process (parent +
+    # EngineCore subprocess) after the platform is ready.
     import vllm.plugins as _plugins_mod
 
     _original_load_general = _plugins_mod.load_general_plugins
 
     def _load_general_with_hpu_patches():
         _original_load_general()
+        _patch_cleanup_dist_env_and_memory()
         _patch_batched_count_greater_than()
         _patch_gather_logprobs()
 


### PR DESCRIPTION
This PR carries three independent fixes for failures observed in the hourly vLLM-Gaudi CI, all pinned against vLLM `ecf9d83520eb217401b47d8a5451a27c5231b8c2`.

## Bug 1: Multi-model server tokenization import broken at pinned vLLM SHA

- **Commits**: aca0d19277b63a2b425b2b8fd040a82f3af5703f (initial), 0cb6f27f2a5ccce934c7cebc7f48768bc8b0e011 (correction)

### Root cause
The multi-model API server failed to import its tokenization serving class. The pinned vLLM `ecf9d83` **predates** upstream PR #46022, so at that SHA the tokenize module exposes `OpenAIServingTokenization` (with `EngineClient` as the first positional constructor argument), not the later renamed `ServingTokenization`.

### Upstream PR
https://github.com/vllm-project/vllm/pull/46022 (the rename — NOT yet present at the pinned SHA)

### Fix
Import the name that actually exists at the pinned SHA: `OpenAIServingTokenization`, constructed with `EngineClient` as the first positional argument. The initial commit (aca0d192) wrongly adapted to the post-rename `ServingTokenization`, which raised `ImportError` at collection time in the `hpu_unit_tests` job; commit 0cb6f27f corrects it. Because we pin to a single vLLM SHA, no version-range shim is needed — import the name that exists at that SHA directly.

## Bug 2: Drop stale offloading take_events scheduler sub-test

- **Commit**: 946e4cf3cc5325b9a682843a83eabe5725cab81c

### Root cause
Upstream made `OffloadingConnector` emit one `BlockStored` event per key, so the vendored `take_events` sub-test asserted 4 events but got 2 (`AssertionError: assert 4 == 2`).

### Upstream PR
https://github.com/vllm-project/vllm/pull/43468

### Fix
Remove the stale `take_events` block and its sole-use imports from `test_scheduler.py`, mirroring the upstream deletion.

## Bug 3: Defer parallel_state and current_platform imports to fix HPU plugin registration

- **Commit**: 52331c002e634e80891ce2c57688ddcdf907d752

### Root cause
Two module-top-level imports in `vllm_gaudi/patches.py` each force re-entrant platform resolution during plugin registration, leaving the plugin partially initialized so the HPU platform is dropped and vLLM falls back to `UnspecifiedPlatform` ("Failed to infer device type / Device string must not be empty"). `current_platform` is a lazily-resolved attribute; `parallel_state` transitively imports `vllm.utils.torch_utils`, whose module-level `PIN_MEMORY = is_pin_memory_available()` resolves the platform at import time.

### Upstream PR
https://github.com/vllm-project/vllm/pull/45424
Made `PIN_MEMORY` resolve the current platform at `torch_utils` import time, exposing the latent re-entrancy.

### Fix
Import both `current_platform` and `parallel_state` lazily inside the functions that use them, and defer the `cleanup_dist_env_and_memory` monkey-patch from `apply()` to the `load_general_plugins` hook (after the platform is ready).
