### PR TITLE
[FIX_FOR_VLLM_CUSTOM=2396d91e931295df877cdad5e2ac0de4e35dab9f] fix: realign HPU plugin with upstream vLLM API drift (kv-offload OffloadingWorker + ServingRender + GraniteMoeHybrid layer types + FusedMoE shared_expert_weight) and fix DP teardown hang

### DIFF
--- a/examples/data_parallel.py
+++ b/examples/data_parallel.py
@@ -173,6 +173,21 @@ def main(
     # Give engines time to pause their processing loops before exiting.
     sleep(1)
 
+    # Explicitly shut down the engine before the driver process exits.
+    #
+    # On HPU the LLM/EngineCoreClient is kept alive past the end of main() by
+    # a live background monitor thread, so the weakref.finalize() that would
+    # send SIGTERM to the EngineCore processes never runs before
+    # multiprocessing's atexit handler joins those (non-daemon) processes.
+    # The EngineCore then sits idle in its input-queue busy loop forever and
+    # the join deadlocks, so each DP rank is force-killed after the 5-minute
+    # timeout. Shutting the engine down here guarantees the SIGTERM is
+    # delivered and the busy loop exits cleanly.
+    engine = getattr(llm, "llm_engine", None)
+    engine_core = getattr(engine, "engine_core", None)
+    if engine_core is not None and hasattr(engine_core, "shutdown"):
+        engine_core.shutdown()
+
 
 if __name__ == "__main__":
     args = parse_args()

--- a/tests/full_tests/spec_decode.py
+++ b/tests/full_tests/spec_decode.py
@@ -116,8 +116,29 @@ def create_error_result(e: Exception) -> dict:
     }
 
 
+def shutdown_llm(llm) -> None:
+    """Shut the vLLM v1 engine down so the worker process can exit cleanly.
+
+    vLLM v1 runs the EngineCore in a non-daemon child process. If the worker
+    returns without shutting the engine down, multiprocessing's atexit handler
+    joins that still-running process and the worker hangs forever. Calling
+    ``EngineCoreClient.shutdown()`` detaches the atexit finalizer and reaps the
+    EngineCore (freeing the HPU device). The v1 ``LLMEngine`` exposes no
+    ``shutdown()`` itself, so reach the client at ``llm_engine.engine_core``.
+    """
+    if llm is None:
+        return
+    # LLM keeps the engine at .llm_engine; the lm_eval VLLM wrapper nests it at
+    # .model.llm_engine.
+    engine = getattr(llm, "llm_engine", None) or getattr(getattr(llm, "model", None), "llm_engine", None)
+    engine_core = getattr(engine, "engine_core", None)
+    if engine_core is not None:
+        engine_core.shutdown()
+
+
 def test_ngram(is_enable, args, prompts, sampling_params, task_key, result_queue):
     VLLM_CLS = LLM if prompts is not None else VLLM
+    llm = None
     kwargs = {"model":"Qwen/Qwen3-4B",} if prompts is not None \
         else {"pretrained":"Qwen/Qwen3-4B","batch_size":"16"}
     try:
@@ -148,12 +169,14 @@ def test_ngram(is_enable, args, prompts, sampling_params, task_key, result_queue
     except Exception as e:
         logging.exception("Task %s failed: %s", task_key, e)
         result_dict = create_error_result(e)
-
+    finally:
+        shutdown_llm(llm)
     result_queue.put((task_key, result_dict))
 
 
 def test_eagle_model(is_enable, args, prompts, sampling_params, task_key, result_queue):
     VLLM_CLS = LLM if prompts is not None else VLLM
+    llm = None
     kwargs = {"model":"meta-llama/Meta-Llama-3-8B-Instruct"} if prompts is not None \
         else {"pretrained":"meta-llama/Meta-Llama-3-8B-Instruct","batch_size":"16"}
     try:
@@ -185,11 +208,14 @@ def test_eagle_model(is_enable, args, prompts, sampling_params, task_key, result
     except Exception as e:
         logging.exception("Task %s failed: %s", task_key, e)
         result_dict = create_error_result(e)
+    finally:
+        shutdown_llm(llm)
     result_queue.put((task_key, result_dict))
 
 
 def test_eagle3_model(is_enable, args, prompts, sampling_params, task_key, result_queue):
     VLLM_CLS = LLM if prompts is not None else VLLM
+    llm = None
     kwargs = {"model":"meta-llama/Meta-Llama-3-8B-Instruct",} if prompts is not None \
         else {"pretrained":"meta-llama/Meta-Llama-3-8B-Instruct","batch_size":"16"}
     try:
@@ -222,11 +248,14 @@ def test_eagle3_model(is_enable, args, prompts, sampling_params, task_key, resul
     except Exception as e:
         logging.exception("Task %s failed: %s", task_key, e)
         result_dict = create_error_result(e)
+    finally:
+        shutdown_llm(llm)
     result_queue.put((task_key, result_dict))
 
 
 def test_medusa_model(is_enable, args, prompts, sampling_params, task_key, result_queue):
     VLLM_CLS = LLM if prompts is not None else VLLM
+    llm = None
     kwargs = {"model":"JackFram/llama-68m",} if prompts is not None \
         else {"pretrained":"JackFram/llama-68m",}
     try:
@@ -258,11 +287,14 @@ def test_medusa_model(is_enable, args, prompts, sampling_params, task_key, resul
     except Exception as e:
         logging.exception("Task %s failed: %s", task_key, e)
         result_dict = create_error_result(e)
+    finally:
+        shutdown_llm(llm)
     result_queue.put((task_key, result_dict))
 
 
 def test_eaglemtp_model(is_enable, args, prompts, sampling_params, task_key, result_queue):
     VLLM_CLS = LLM if prompts is not None else VLLM
+    llm = None
     kwargs = {"model":"eagle618/deepseek-v3-random",} if prompts is not None \
         else {"pretrained":"eagle618/deepseek-v3-random",}
     try:
@@ -292,11 +324,14 @@ def test_eaglemtp_model(is_enable, args, prompts, sampling_params, task_key, res
     except Exception as e:
         logging.exception("Task %s failed: %s", task_key, e)
         result_dict = create_error_result(e)
+    finally:
+        shutdown_llm(llm)
     result_queue.put((task_key, result_dict))
 
 
 def test_mtp_model(is_enable, args, prompts, sampling_params, task_key, result_queue):
     VLLM_CLS = LLM if prompts is not None else VLLM
+    llm = None
     kwargs = {"model":"/mnt/weka/data/pytorch/DeepSeek-R1",} if prompts is not None \
         else {"pretrained":"/mnt/weka/data/pytorch/DeepSeek-R1",}
     try:
@@ -342,6 +377,8 @@ def test_mtp_model(is_enable, args, prompts, sampling_params, task_key, result_q
     except Exception as e:
         logging.exception("Task %s failed: %s", task_key, e)
         result_dict = create_error_result(e)
+    finally:
+        shutdown_llm(llm)
     result_queue.put((task_key, result_dict))
 
 

--- a/tests/unit_tests/kv_offload/offloading_connector/utils.py
+++ b/tests/unit_tests/kv_offload/offloading_connector/utils.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any
 from unittest.mock import MagicMock
@@ -38,18 +38,18 @@ from vllm.v1.kv_cache_interface import (
     KVCacheGroupSpec,
 )
 from vllm.v1.kv_offload.base import (
+    CanonicalKVCaches,
     GPULoadStoreSpec,
     LoadStoreSpec,
+    LookupResult,
     OffloadingManager,
     OffloadingSpec,
+    OffloadingWorker,
     OffloadKey,
     PrepareStoreOutput,
-    make_offload_key,
-)
-from vllm.v1.kv_offload.worker.worker import (
-    OffloadingHandler,
+    RequestOffloadingContext,
     TransferResult,
-    TransferSpec,
+    make_offload_key,
 )
 from vllm.v1.structured_output import StructuredOutputManager
 
@@ -75,10 +75,10 @@ class MockLoadStoreSpec(LoadStoreSpec):
         return repr(self.offload_keys)
 
 
-class MockOffloadingHandler(OffloadingHandler):
+class MockOffloadingWorker(OffloadingWorker):
 
     def __init__(self):
-        self.transfer_specs: dict[int, TransferSpec] = {}
+        self.transfer_specs: dict[int, tuple[LoadStoreSpec, LoadStoreSpec]] = {}
         self.completed_transfers: list[TransferResult] = []
         self.waiting_jobs: set[int] = set()
         self.completed_jobs: list[int] = []
@@ -89,8 +89,13 @@ class MockOffloadingHandler(OffloadingHandler):
         self.completed_transfers = []
         return finished
 
-    def transfer_async(self, job_id: int, spec: TransferSpec) -> bool:
-        self.transfer_specs[job_id] = spec
+    def submit_store(self, job_id: int, src_spec: LoadStoreSpec, dst_spec: LoadStoreSpec) -> bool:
+        self.transfer_specs[job_id] = (src_spec, dst_spec)
+        self.waiting_jobs.add(job_id)
+        return True
+
+    def submit_load(self, job_id: int, src_spec: LoadStoreSpec, dst_spec: LoadStoreSpec) -> bool:
+        self.transfer_specs[job_id] = (src_spec, dst_spec)
         self.waiting_jobs.add(job_id)
         return True
 
@@ -104,7 +109,6 @@ class MockOffloadingHandler(OffloadingHandler):
                     success=True,
                     transfer_size=None,
                     transfer_time=None,
-                    transfer_type=None,
                 )
                 self.completed_transfers.append(result)
 
@@ -119,22 +123,21 @@ class MockOffloadingSpec(OffloadingSpec):
         super().__init__(vllm_config, kv_cache_config)
 
         self.manager = MagicMock(spec=OffloadingManager)
-        self.manager.lookup.return_value = 0
         self.manager.prepare_load = lambda keys, req_context: MockLoadStoreSpec(keys)
-        self.manager.lookup.return_value = False
-        self.handler = MockOffloadingHandler()
+        self.manager.lookup.return_value = LookupResult.MISS
+        self.manager.on_new_request.return_value = RequestOffloadingContext()
+        self.handler = MockOffloadingWorker()
 
     def get_manager(self) -> OffloadingManager:
         return self.manager
 
-    def get_handlers(self, _) -> Iterator[tuple[type[LoadStoreSpec], type[LoadStoreSpec], OffloadingHandler]]:
-        yield GPULoadStoreSpec, MockLoadStoreSpec, self.handler
-        yield MockLoadStoreSpec, GPULoadStoreSpec, self.handler
+    def get_worker(self, _: CanonicalKVCaches) -> OffloadingWorker:
+        return self.handler
 
     def complete_transfers(self):
         self.handler.complete_jobs(self.handler.waiting_jobs.copy())
 
-    def get_completed_transfers(self) -> list[TransferSpec]:
+    def get_completed_transfers(self) -> list[tuple[LoadStoreSpec, LoadStoreSpec]]:
         specs = [self.handler.transfer_specs[job_id] for job_id in self.handler.completed_jobs]
         self.handler.completed_jobs.clear()
         return specs

--- a/vllm_gaudi/entrypoints/openai/multi_model_api_server.py
+++ b/vllm_gaudi/entrypoints/openai/multi_model_api_server.py
@@ -28,8 +28,10 @@ from vllm.entrypoints.openai.cli_args import make_arg_parser, validate_parsed_se
 from vllm.entrypoints.openai.models.protocol import BaseModelPath
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
 from vllm.entrypoints.serve.utils.server_utils import get_uvicorn_log_config
-from vllm.entrypoints.serve.render.serving import OpenAIServingRender
+from vllm.entrypoints.serve.render.serving import ServingRender
 from vllm.entrypoints.serve.tokenize.serving import ServingTokenization
+from vllm.renderers.online_derenderer import OnlineDerenderer
+from vllm.renderers.online_renderer import OnlineRenderer
 from vllm.entrypoints.serve.utils.api_utils import cli_env_setup, process_lora_modules
 from vllm.logger import init_logger
 from vllm.reasoning import ReasoningParserManager
@@ -498,10 +500,13 @@ async def _init_multi_model_state(
     frontend_settings = _resolve_frontend_settings(args, model_frontend_overrides, active_model_name)
     resolved_chat_template = load_chat_template(frontend_settings.chat_template)
 
-    state.openai_serving_render = OpenAIServingRender(
+    # Upstream vllm#44285 split OpenAIServingRender into a thin entrypoint
+    # (ServingRender) plus an OnlineRenderer/OnlineDerenderer pair that own the
+    # chat-template, tool and reasoning configuration. Mirror that construction
+    # here so the multi-model server matches the engine-backed api_server path.
+    render_kwargs = dict(
         model_config=engine_client.model_config,
         renderer=engine_client.renderer,
-        model_registry=state.openai_serving_models.registry,
         request_logger=request_logger,
         chat_template=resolved_chat_template,
         chat_template_content_format=args.chat_template_content_format,
@@ -512,10 +517,19 @@ async def _init_multi_model_state(
         default_chat_template_kwargs=args.default_chat_template_kwargs,
         log_error_stack=args.log_error_stack,
     )
+    state.online_renderer = OnlineRenderer(**render_kwargs)
+    state.online_derenderer = OnlineDerenderer(**render_kwargs)
+
+    state.openai_serving_render = ServingRender(
+        state.openai_serving_models,
+        state.online_renderer,
+        state.online_derenderer,
+        request_logger=request_logger,
+    )
 
     state.serving_tokenization = ServingTokenization(
         state.openai_serving_models,
-        state.openai_serving_render,
+        state.online_renderer,
         request_logger=request_logger,
         chat_template=resolved_chat_template,
         chat_template_content_format=args.chat_template_content_format,

--- a/vllm_gaudi/ops/hpu_fused_moe.py
+++ b/vllm_gaudi/ops/hpu_fused_moe.py
@@ -414,6 +414,11 @@ def create_fused_moe_router(
     topk_group: int | None = None,
     scoring_func: str = "softmax",
     num_fused_shared_experts: int = 0,
+    # Fused shared-expert slot weight (upstream vLLM d039c171+). Accepted for
+    # signature parity with the upstream factory caller (layer.py passes it);
+    # the HPU routers below do not use the fused-shared-expert scaling path
+    # (num_fused_shared_experts defaults to 0), so the default 1.0 is a no-op.
+    shared_expert_weight: float = 1.0,
     # grouped topk + fused topk bias parameters
     routed_scaling_factor: float = 1.0,
     e_score_correction_bias: torch.Tensor | None = None,
@@ -449,6 +454,9 @@ def create_fused_moe_router(
         topk_group: Top-k within each group (for grouped routing)
         scoring_func: Scoring function to use ("softmax" or "sigmoid")
         num_fused_shared_experts: Number of fused shared experts (for ROCm AITER)
+        shared_expert_weight: Weight of the fused shared-expert slot (upstream
+            vLLM d039c171+). Accepted for signature parity; unused on HPU since
+            the fused-shared-expert path is not taken (default 1.0 no-op).
 
     Grouped topk and fused topk bias arguments:
         routed_scaling_factor: Scaling factor for routed weights

--- a/vllm_gaudi/patches.py
+++ b/vllm_gaudi/patches.py
@@ -259,6 +259,124 @@ def _patch_batched_count_greater_than() -> None:
     _sampler_mod.batched_count_greater_than = _hpu_batched_count_greater_than
 
 
+_GRANITE_LEGACY_LAYER_ALIASES = {
+    "full_attention": "attention",
+    "linear_attention": "mamba",
+}
+
+
+def _patch_granite_hybrid_layer_types() -> None:
+    """Accept transformers>=5 remapped hybrid layer-type names for GraniteMoeHybrid.
+
+    transformers>=5 rewrites the legacy hybrid ``layer_types`` values on config
+    load ("attention" -> "full_attention", "mamba" -> "linear_attention"; see
+    ``remap_legacy_layer_types`` in transformers ``configuration_utils.py``).
+    Hub checkpoints still store the legacy names, so the rename happens in
+    memory. vLLM's ``ALL_DECODER_LAYER_TYPES`` in ``granitemoehybrid.py`` only
+    keys the legacy names, so the remapped values raise
+    ``KeyError: 'linear_attention'`` at ``get_layer`` during model construction
+    (before any HPU kernel runs).
+
+    Guarded so this is a no-op once the value is already keyed (e.g. upstream
+    vLLM PR #47634 merged, or the module shape changed).
+
+    Upstream ref: https://github.com/vllm-project/vllm/pull/47634
+    """
+    import vllm.model_executor.models.granitemoehybrid as _granite_mod
+
+    layer_types = getattr(_granite_mod, "ALL_DECODER_LAYER_TYPES", None)
+    if not isinstance(layer_types, dict):
+        return  # Module shape changed — nothing to patch.
+    if "linear_attention" in layer_types or "full_attention" in layer_types:
+        return  # Already handles the remapped names (e.g. PR #47634 merged).
+    if "attention" not in layer_types or "mamba" not in layer_types:
+        return  # Legacy keys absent — not the shape this patch targets.
+
+    layer_types["full_attention"] = layer_types["attention"]
+    layer_types["linear_attention"] = layer_types["mamba"]
+
+
+def _hpu_get_num_layers_by_block_type(self, parallel_config, block_type="attention"):
+    """HPU-safe replacement for ``ModelConfig.get_num_layers_by_block_type``.
+
+    Identical to the upstream implementation, but normalizes both sides of the
+    ``layers_block_type`` comparison so either naming convention matches. Under
+    transformers>=5 ``layers_block_type`` aliases the remapped ``layer_types``
+    ("attention" -> "full_attention", "mamba" -> "linear_attention"), while the
+    HPU model runner queries with the legacy names ("attention", "mamba"). Left
+    unpatched, the counts collapse to zero and the hybrid KV-cache setup breaks.
+
+    Upstream ref: https://github.com/vllm-project/vllm/pull/47634
+    """
+    attn_block_type = block_type == "attention"
+    is_transformer = not self.is_hybrid and not self.has_noops and not self.is_attention_free
+    start, end = self.get_layers_start_end_indices(parallel_config)
+
+    if is_transformer:
+        return end - start if attn_block_type else 0
+    elif self.is_attention_free:
+        return 0 if attn_block_type else end - start
+    elif self.has_noops:
+        block_configs = self.hf_config.block_configs
+        return sum(not bc.attention.no_op for bc in block_configs[start:end])
+    else:
+        # Hybrid model Jamba
+        layers_block_type_value = getattr(self.hf_text_config, "layers_block_type", None)
+        if layers_block_type_value is not None:
+            if self.model_arch_config.text_model_type == "zamba2":
+                if attn_block_type:
+                    return sum(t == "hybrid" for t in layers_block_type_value[start:end])
+                else:
+                    return self.get_num_layers(parallel_config)
+            aliases = _GRANITE_LEGACY_LAYER_ALIASES
+            normalized_block_type = aliases.get(block_type, block_type)
+            return sum(aliases.get(t, t) == normalized_block_type for t in layers_block_type_value[start:end])
+
+        # Hybrid model Minimax
+        attn_type_list = getattr(self.hf_config, "attn_type_list", None)
+        if attn_type_list:
+            return sum(t == 1 for t in attn_type_list[start:end])
+
+        # Hybrid model Qwen3Next Qwen3.5 Series
+        layer_types_value = getattr(self.hf_text_config, "layer_types", None)
+        if layer_types_value is not None:
+            if block_type == "attention":
+                return sum(t == "full_attention" for t in layer_types_value[start:end])
+            elif block_type == "linear_attention":
+                return sum(t == "linear_attention" for t in layer_types_value[start:end])
+            else:
+                return sum(t == block_type for t in layer_types_value[start:end])
+
+        if layers_block_type_value is None and attn_type_list is None and layer_types_value is None:
+            raise ValueError("The model is an hybrid without a layers_block_type or an "
+                             "attn_type_list, or a layer_types in the hf_config, "
+                             f"cannot determine the num of {block_type} layers")
+        raise AssertionError(f"Unsupported block type: {block_type}")
+
+
+def _patch_get_num_layers_by_block_type() -> None:
+    """Install the HPU-safe ``get_num_layers_by_block_type`` replacement.
+
+    Guarded by ``inspect.getsource`` so this is a no-op once upstream vLLM
+    normalizes the ``layers_block_type`` comparison itself (PR #47634).
+    """
+    import inspect
+
+    from vllm.config import ModelConfig
+
+    try:
+        source = inspect.getsource(ModelConfig.get_num_layers_by_block_type)
+    except (OSError, TypeError):
+        return  # Source unavailable — leave upstream in place.
+
+    if "get_num_layers_by_block_type" not in source or "layers_block_type" not in source:
+        return  # Method shape changed — do not risk an incompatible override.
+    if "_GRANITE_LEGACY_LAYER_ALIASES" in source or "normalized_block_type" in source:
+        return  # Already normalizes (e.g. PR #47634 merged).
+
+    ModelConfig.get_num_layers_by_block_type = _hpu_get_num_layers_by_block_type
+
+
 def _patch_cleanup_dist_env_and_memory() -> None:
     """Install the HPU-safe ``cleanup_dist_env_and_memory`` replacement.
 
@@ -305,6 +423,8 @@ def apply() -> None:
         _patch_cleanup_dist_env_and_memory()
         _patch_batched_count_greater_than()
         _patch_gather_logprobs()
+        _patch_granite_hybrid_layer_types()
+        _patch_get_num_layers_by_block_type()
 
     _plugins_mod.load_general_plugins = _load_general_with_hpu_patches
 

--- a/vllm_gaudi/v1/kv_offload/worker/cpu_hpu.py
+++ b/vllm_gaudi/v1/kv_offload/worker/cpu_hpu.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from collections import defaultdict, deque
+from collections.abc import Iterator
 from dataclasses import dataclass
 
 import numpy as np
@@ -21,6 +22,7 @@ from vllm.v1.kv_offload.cpu.gpu_worker import (
     CPUOffloadingWorker,
     SingleDirectionOffloadingHandler,
 )
+from vllm.v1.kv_offload.cpu.spec import CPUOffloadingSpec
 from vllm.distributed.kv_transfer.kv_connector.v1.offloading.worker import OffloadingConnectorWorker
 
 logger = init_logger(__name__)
@@ -430,3 +432,66 @@ def register_kv_caches(
 
 
 OffloadingConnectorWorker.register_kv_caches = register_kv_caches
+
+
+def _hpu_get_worker(self, kv_caches: CanonicalKVCaches):
+    """HPU ``CPUOffloadingSpec.get_worker`` without the CUDA/XPU platform guard.
+
+    Older-API upstream (e.g. vllm ``2396d91e``) gates ``get_worker`` on
+    ``current_platform.is_cuda_alike() or is_xpu()``. The HPU offloading path is
+    implemented and validated via the ``CPUOffloadingWorker`` overrides in this
+    module, so this mirrors upstream minus that guard, staying a thin wrapper
+    over ``create_worker``.
+
+    Args:
+        kv_caches: canonicalized GPU KV caches to offload.
+
+    Returns:
+        The cached ``OffloadingWorker`` for this spec.
+    """
+    if not self._worker:
+        self._worker = self.create_worker(kv_caches)
+
+    assert self._worker is not None
+    return self._worker
+
+
+def _hpu_get_handlers(
+    self,
+    kv_caches: CanonicalKVCaches,
+) -> Iterator[tuple[type[LoadStoreSpec], type[LoadStoreSpec], object]]:
+    """HPU ``CPUOffloadingSpec.get_handlers`` without the CUDA/XPU platform guard.
+
+    Newer-API upstream (vllm commit
+    810966453a2576f45880c899db2af2e604207ed4, PR #36423) gates ``get_handlers``
+    on ``current_platform.is_cuda_alike() or is_xpu()``. This mirrors upstream
+    minus that guard, staying a thin wrapper over ``create_handlers``. The
+    GPU/CPU ``LoadStoreSpec`` types are imported lazily so this module still
+    imports cleanly against the older API where they do not exist.
+
+    Args:
+        kv_caches: canonicalized GPU KV caches to offload.
+
+    Yields:
+        Tuples of ``(src_spec_type, dst_spec_type, offloading_handler)`` for the
+        GPU->CPU (store) and CPU->GPU (load) directions.
+    """
+    from vllm.v1.kv_offload.base import GPULoadStoreSpec
+    from vllm.v1.kv_offload.cpu.common import CPULoadStoreSpec
+
+    if not self._handlers:
+        self._handlers = self.create_handlers(kv_caches)
+
+    assert self._handlers is not None
+    yield GPULoadStoreSpec, CPULoadStoreSpec, self._handlers.gpu_to_cpu_handler
+    yield CPULoadStoreSpec, GPULoadStoreSpec, self._handlers.cpu_to_gpu_handler
+
+
+# Patch whichever guarded entry point this vLLM exposes. The offloading worker
+# API changed upstream: older trees gate ``get_worker`` (returns an
+# ``OffloadingWorker``); newer trees gate ``get_handlers`` (yields handler
+# tuples). Patch the one that exists so the HPU path survives either generation.
+if hasattr(CPUOffloadingSpec, "get_worker"):
+    CPUOffloadingSpec.get_worker = _hpu_get_worker
+if hasattr(CPUOffloadingSpec, "get_handlers"):
+    CPUOffloadingSpec.get_handlers = _hpu_get_handlers

--- a/vllm_gaudi/v1/kv_offload/worker/cpu_hpu.py
+++ b/vllm_gaudi/v1/kv_offload/worker/cpu_hpu.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 import numpy as np
 import torch
 
-from collections.abc import Iterator
 from vllm.logger import init_logger
 from vllm.utils.platform_utils import is_pin_memory_available
 from vllm.v1.kv_cache_interface import AttentionSpec, UniformTypeKVCacheSpecs
@@ -15,19 +14,12 @@ from vllm.v1.kv_offload.base import (
     CanonicalKVCacheRef,
     CanonicalKVCaches,
     CanonicalKVCacheTensor,
-    GPULoadStoreSpec,
     LoadStoreSpec,
-)
-from vllm.v1.kv_offload.cpu.common import CPULoadStoreSpec
-from vllm.v1.kv_offload.cpu.gpu_worker import (
-    CpuGpuOffloadingHandlers,
-    SingleDirectionOffloadingHandler,
-)
-from vllm.v1.kv_offload.cpu.spec import CPUOffloadingSpec
-from vllm.v1.kv_offload.worker.worker import (
-    OffloadingHandler,
     TransferResult,
-    TransferSpec,
+)
+from vllm.v1.kv_offload.cpu.gpu_worker import (
+    CPUOffloadingWorker,
+    SingleDirectionOffloadingHandler,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.offloading.worker import OffloadingConnectorWorker
 
@@ -140,7 +132,6 @@ def SingleDirectionOffloadingHandler_init_(
             group_block_size_in_bytes += self.tensor_block_size_in_bytes[kv_cache_data_ref.tensor_idx]
         self.group_block_size_in_bytes.append(group_block_size_in_bytes)
 
-    self.transfer_type = ("GPU", "CPU") if self.gpu_to_cpu else ("CPU", "GPU")
     # job_id -> event
     self._transfer_events: dict[int, torch.Event] = {}  # type: ignore[misc]
     # queue of transfers (job_id, stream, event)
@@ -151,8 +142,7 @@ def SingleDirectionOffloadingHandler_init_(
     self._event_pool: list[torch.Event] = []  # type: ignore[misc]
 
 
-def transfer_async(self, job_id: int, transfer_spec: TransferSpec) -> bool:
-    src_spec, dst_spec = transfer_spec
+def transfer_async(self, job_id: int, src_spec: LoadStoreSpec, dst_spec: LoadStoreSpec) -> bool:
     assert isinstance(src_spec, BlockIDsLoadStoreSpec)
     assert isinstance(dst_spec, BlockIDsLoadStoreSpec)
 
@@ -178,8 +168,8 @@ def transfer_async(self, job_id: int, transfer_spec: TransferSpec) -> bool:
     src_to_dst_tensor = torch.from_numpy(src_to_dst)
 
     stream = self._stream_pool.pop() if self._stream_pool else torch.hpu.Stream()
-    start_event = (self._event_pool.pop() if self._event_pool else torch.Event(enable_timing=True))
-    end_event = (self._event_pool.pop() if self._event_pool else torch.Event(enable_timing=True))
+    start_event = self._event_pool.pop() if self._event_pool else torch.Event(enable_timing=True)
+    end_event = self._event_pool.pop() if self._event_pool else torch.Event(enable_timing=True)
 
     if self.gpu_to_cpu:
         # wait for model computation to finish before offloading
@@ -235,7 +225,6 @@ def get_finished(self) -> list[TransferResult]:
             success=True,
             transfer_size=transfer.num_bytes,
             transfer_time=transfer_time,
-            transfer_type=self.transfer_type,
         )
         results.append(result)
         self._stream_pool.append(transfer.stream)
@@ -243,6 +232,13 @@ def get_finished(self) -> list[TransferResult]:
         self._event_pool.append(transfer.start_event)
         del self._transfer_events[transfer.job_id]
     return results
+
+
+def wait(self, job_ids: set[int]) -> None:
+    for job_id in job_ids:
+        event = self._transfer_events.get(job_id)
+        if event is not None:
+            event.synchronize()
 
 
 def shutdown(self) -> None:
@@ -256,12 +252,27 @@ def shutdown(self) -> None:
     self.dst_tensors.clear()
 
 
-def CpuGpuOffloadingHandlers_init_(
+def CPUOffloadingWorker_init_(
     self,
     kv_caches: CanonicalKVCaches,
     block_size_factor: int,
     num_cpu_blocks: int,
+    mmap_region=None,
 ):
+    """HPU CPUOffloadingWorker initializer.
+
+    Allocates CPU staging tensors and composes one store-direction and one
+    load-direction ``SingleDirectionOffloadingHandler`` exposed through the
+    explicit ``submit_store`` / ``submit_load`` API introduced upstream in
+    vLLM PR #45053.
+
+    Args:
+        kv_caches: canonical GPU KV cache tensors to offload.
+        block_size_factor: ratio of CPU page size to GPU page size.
+        num_cpu_blocks: number of CPU blocks to allocate.
+        mmap_region: unused on HPU; accepted for upstream API parity.
+    """
+    del mmap_region  # HPU offloading does not use a shared mmap region.
     pin_memory = is_pin_memory_available()
     logger.info("Allocating %d CPU tensors...", len(kv_caches.tensors))
     gpu_tensors: list[torch.Tensor] = []
@@ -280,7 +291,7 @@ def CpuGpuOffloadingHandlers_init_(
         gpu_tensors.append(gpu_tensor)
         cpu_tensors.append(cpu_tensor)
 
-    self.gpu_to_cpu_handler = SingleDirectionOffloadingHandler(
+    self._store_handler = SingleDirectionOffloadingHandler(
         gpu_tensors=gpu_tensors,
         cpu_tensors=cpu_tensors,
         block_size_factor=block_size_factor,
@@ -288,7 +299,7 @@ def CpuGpuOffloadingHandlers_init_(
         gpu_to_cpu=True,
     )
 
-    self.cpu_to_gpu_handler = SingleDirectionOffloadingHandler(
+    self._load_handler = SingleDirectionOffloadingHandler(
         gpu_tensors=gpu_tensors,
         cpu_tensors=cpu_tensors,
         block_size_factor=block_size_factor,
@@ -297,28 +308,42 @@ def CpuGpuOffloadingHandlers_init_(
     )
 
 
-def get_handlers(
-    self,
-    kv_caches: CanonicalKVCaches,
-) -> Iterator[tuple[type[LoadStoreSpec], type[LoadStoreSpec], OffloadingHandler]]:
-    if not self._handlers:
-        self._handlers = CpuGpuOffloadingHandlers(
-            kv_caches=kv_caches,
-            block_size_factor=self.block_size_factor,
-            num_cpu_blocks=self.num_blocks,
-        )
-
-    assert self._handlers is not None
-    yield GPULoadStoreSpec, CPULoadStoreSpec, self._handlers.gpu_to_cpu_handler
-    yield CPULoadStoreSpec, GPULoadStoreSpec, self._handlers.cpu_to_gpu_handler
+def submit_store(self, job_id: int, src_spec: LoadStoreSpec, dst_spec: LoadStoreSpec) -> bool:
+    """Async GPU -> CPU transfer."""
+    return self._store_handler.transfer_async(job_id, src_spec, dst_spec)
 
 
-CPUOffloadingSpec.get_handlers = get_handlers
+def submit_load(self, job_id: int, src_spec: LoadStoreSpec, dst_spec: LoadStoreSpec) -> bool:
+    """Async CPU -> GPU transfer."""
+    return self._load_handler.transfer_async(job_id, src_spec, dst_spec)
+
+
+def worker_get_finished(self) -> list[TransferResult]:
+    return self._store_handler.get_finished() + self._load_handler.get_finished()
+
+
+def worker_wait(self, job_ids: set[int]) -> None:
+    self._store_handler.wait(job_ids)
+    self._load_handler.wait(job_ids)
+
+
+def worker_shutdown(self) -> None:
+    self._store_handler.shutdown()
+    self._load_handler.shutdown()
+
+
 SingleDirectionOffloadingHandler.__init__ = SingleDirectionOffloadingHandler_init_
 SingleDirectionOffloadingHandler.transfer_async = transfer_async
 SingleDirectionOffloadingHandler.get_finished = get_finished
+SingleDirectionOffloadingHandler.wait = wait
 SingleDirectionOffloadingHandler.shutdown = shutdown
-CpuGpuOffloadingHandlers.__init__ = CpuGpuOffloadingHandlers_init_
+
+CPUOffloadingWorker.__init__ = CPUOffloadingWorker_init_
+CPUOffloadingWorker.submit_store = submit_store
+CPUOffloadingWorker.submit_load = submit_load
+CPUOffloadingWorker.get_finished = worker_get_finished
+CPUOffloadingWorker.wait = worker_wait
+CPUOffloadingWorker.shutdown = worker_shutdown
 
 
 def register_kv_caches(
@@ -360,7 +385,7 @@ def register_kv_caches(
                 # because HPU may have extra padding blocks in storage.
                 per_tensor_page_size = t[0].numel() * t.element_size()
                 # Reshape to (num_blocks, page_size_bytes) as int8
-                canonical = (t.contiguous().view(torch.int8).reshape(num_blocks, per_tensor_page_size))
+                canonical = t.contiguous().view(torch.int8).reshape(num_blocks, per_tensor_page_size)
                 block_tensors_for_layer.append(canonical)
 
             tensors_per_block[layer_name] = tuple(block_tensors_for_layer)
@@ -401,7 +426,7 @@ def register_kv_caches(
         group_data_refs=group_data_refs,
     )
 
-    self._register_handlers(canonical_kv_caches)
+    self._init_worker(canonical_kv_caches)
 
 
 OffloadingConnectorWorker.register_kv_caches = register_kv_caches


### PR DESCRIPTION
## Summary

Realigns the HPU plugin with the current upstream vLLM main build
(`2396d91e931295df877cdad5e2ac0de4e35dab9f`) after several breaking API changes,
and fixes two unrelated engine-teardown hangs surfaced by the same build (data
parallel + spec-decode CI jobs).

Eight independent changes, grouped below.

---

### 1. kv-offload: migrate to the `OffloadingWorker` API (upstream vLLM #45053)

**Problem:** Upstream reworked the v1 kv_offload worker API — removed
`CpuGpuOffloadingHandlers` from `vllm.v1.kv_offload.cpu.gpu_worker`, deleted the
`vllm.v1.kv_offload.worker` package, and replaced handler registration with an
explicit `OffloadingWorker` / `CPUOffloadingWorker` exposing
`submit_store` / `submit_load`. The HPU plugin still imported the removed symbols
at module load, so every job touching the HPU CPU-offload path failed with
`ImportError: cannot import name 'CpuGpuOffloadingHandlers'`.

**Fix (`vllm_gaudi/v1/kv_offload/worker/cpu_hpu.py`):** Monkeypatch
`CPUOffloadingWorker` (`submit_store` / `submit_load` / `get_finished` / `wait` /
`shutdown`) instead of `CpuGpuOffloadingHandlers`; change `transfer_async` to take
`(src_spec, dst_spec)` directly; drop the removed `TransferResult.transfer_type`
field; initialize the store/load handlers in `_init_worker` instead of the removed
`_register_handlers` path.

Upstream: https://github.com/vllm-project/vllm/pull/45053

### 2. kv-offload: bypass the CUDA/XPU platform guard for HPU

**Problem:** Upstream `CPUOffloadingSpec.get_worker` gates the CPU KV-offload entry
point on `current_platform.is_cuda_alike()` or `is_xpu()`, which raises on HPU even
though the HPU offload path is fully implemented via the `CPUOffloadingWorker`
overrides in this module.

**Fix (`vllm_gaudi/v1/kv_offload/worker/cpu_hpu.py`):** Replace
`CPUOffloadingSpec.get_worker` with an HPU variant that reuses `create_worker`
without the guard, mirroring upstream otherwise.

### 3. multi-model server: adapt to the `ServingRender` split (upstream vLLM #44285)

**Problem:** Upstream split `OpenAIServingRender` into a thin `ServingRender`
entrypoint plus `OnlineRenderer` / `OnlineDerenderer`. The HPU multi-model server
still imported `OpenAIServingRender`, causing an `ImportError` on every model-swap
job.

**Fix (`vllm_gaudi/entrypoints/openai/multi_model_api_server.py`):** Build
`OnlineRenderer` / `OnlineDerenderer` and the thin `ServingRender`, and feed
`ServingTokenization` the `OnlineRenderer`.

Upstream: https://github.com/vllm-project/vllm/pull/44285

### 4. test mock: adapt offloading_connector helper to `OffloadingWorker` (#45053)

**Problem:** The same #45053 change deleted `vllm/v1/kv_offload/worker/worker.py`;
the `offloading_connector` test helper still imported the deleted module, breaking
unit-test collection (`ModuleNotFoundError`).

**Fix (`tests/unit_tests/kv_offload/offloading_connector/utils.py`):** Migrate only
the production-facing mock interface, leaving the test-facing `RequestRunner` API
intact (`test_scheduler.py` still relies on the old signatures):
`MockOffloadingHandler` → `MockOffloadingWorker`; single-spec `transfer_async` →
directional `submit_store` / `submit_load`; drop `TransferResult.transfer_type`;
`get_handlers` → `get_worker`; manager mock returns `LookupResult.MISS` and
`on_new_request` → `RequestOffloadingContext()`.

### 5. examples: shut DP engine cores down explicitly on exit (DP teardown hang)

**Problem:** The `hpu_dp_tests` CI job hangs on EngineCore teardown against the
current upstream build. `examples/data_parallel.py` relies on garbage collection of
the `LLM` object at the end of `main()` to trigger `EngineCoreClient`'s
`weakref.finalize`, which sends SIGTERM to the (non-daemon) EngineCore processes.
Against the newer vLLM a live background monitor thread keeps the client referenced
past the end of `main()`, so the finalizer never runs before multiprocessing's
atexit handler joins those processes. Each EngineCore then sits idle in its
input-queue busy loop forever, the join deadlocks, and every DP rank is
force-killed after the 5-minute timeout (~11 min job, non-zero exit).

**Fix (`examples/data_parallel.py`):** Explicitly shut the engine core down before
`main()` returns, so SIGTERM is always delivered and each EngineCore exits its busy
loop cleanly:
```python
engine = getattr(llm, "llm_engine", None)
engine_core = getattr(engine, "engine_core", None)
if engine_core is not None and hasattr(engine_core, "shutdown"):
    engine_core.shutdown()
```
### 6. GraniteMoeHybrid: accept transformers>=5 remapped layer types (upstream vLLM #47634)
**Problem:**  Every GraniteMoeHybrid checkpoint fails at EngineCore init with
KeyError: 'linear_attention' at granitemoehybrid.py:347
(ALL_DECODER_LAYER_TYPES[config.layer_types[layer_idx]]). transformers >= 5
rewrites the legacy hybrid layer-type names on every config load
("mamba" -> "linear_attention", "attention" -> "full_attention", via
remap_legacy_layer_types), while vLLM's ALL_DECODER_LAYER_TYPES only keys the
legacy names. The vllm-gaudi transformers bump (#1560) activated the rename,
surfacing this on hourly CI.

**Fix (vllm_gaudi/patches.py):** Deferred monkeypatches (installed via the
load_general_plugins hook) that alias the remapped names in
ALL_DECODER_LAYER_TYPES and normalize both sides of the layers_block_type
comparison in ModelConfig.get_num_layers_by_block_type (the HPU runner counts
layers with the legacy names). Both guards no-op once upstream merges.

Upstream: https://github.com/vllm-project/vllm/pull/47634

### 7. FusedMoE router: accept upstream shared_expert_weight kwarg (upstream vLLM #46545)
**Problem:**  Upstream added a shared_expert_weight: float = 1.0 parameter to
create_fused_moe_router and the FusedMoE factory (layer.py) now forwards it
on every router creation. The HPU plugin ships a forked create_fused_moe_router
in vllm_gaudi/ops/hpu_fused_moe.py and monkeypatches it over the upstream symbol;
the fork lacked the new kwarg, so every FusedMoE(...) construction raised
TypeError: create_fused_moe_router() got an unexpected keyword argument 'shared_expert_weight' at model build — blocking both the unit tests
(test_hpu_fused_moe, test_hpu_compressed_tensors) and GraniteMoeHybrid
generation.

**Fix (vllm_gaudi/ops/hpu_fused_moe.py):** Accept shared_expert_weight in the
same signature position as upstream. The HPU routers do not take the
fused-shared-expert scaling path (num_fused_shared_experts defaults to 0), so the
default 1.0 is a no-op; the kwarg exists purely for signature parity with the
caller.

Upstream: https://github.com/vllm-project/vllm/pull/46545

### 8. spec_decode: shut the vLLM engine down in each worker (spec-decode CI hang)
**Problem:**  The single-runner spec-decode e2e matrix (tests/full_tests/spec_decode.py)
hangs on engine teardown against the current upstream build. Each spec-decode worker
(test_ngram / test_eagle_model / test_eagle3_model / test_medusa_model /
test_eaglemtp_model / test_mtp_model) returns without shutting the engine down;
multiprocessing's atexit handler then joins the still-running non-daemon EngineCore
process, so the worker hangs indefinitely. This stalls the matrix until the CI
global timeout and cascades the remaining jobs to cancelled.

**Fix (tests/full_tests/spec_decode.py):** Add a shutdown_llm() helper that
reaches the client at llm_engine.engine_core (also handling the lm_eval VLLM
wrapper's nested .model.llm_engine) and calls EngineCoreClient.shutdown(),
detaching the atexit finalizer and reaping the EngineCore (freeing the HPU device).
Each worker calls it in a finally block. Mirrors the teardown added in
examples/data_parallel.py (§5).