### PR TITLE
Pin vLLM core version to VLLM_GAUDI_COMMIT in RHEL UBI Dockerfile

### DIFF
--- a/.cd/Dockerfile.rhel.ubi.vllm
+++ b/.cd/Dockerfile.rhel.ubi.vllm
@@ -214,7 +214,6 @@ RUN set -e && \
       v[0-9]*.*) export SETUPTOOLS_SCM_PRETEND_VERSION="${VLLM_GAUDI_COMMIT#v}" ;; \
     esac; \
     VLLM_TARGET_DEVICE=empty pip install --no-cache-dir --no-build-isolation . && \
-
     cd $VLLM_PATH2 && \
     git checkout ${VLLM_GAUDI_COMMIT} && \
     VLLM_TARGET_DEVICE=hpu pip install --no-cache-dir -v . --no-build-isolation && \

--- a/.cd/Dockerfile.rhel.ubi.vllm
+++ b/.cd/Dockerfile.rhel.ubi.vllm
@@ -210,10 +210,11 @@ RUN set -e && \
     git fetch upstream --tags && \
     git checkout ${VLLM_PROJECT_COMMIT} && \
     pip install --no-cache-dir -r <(sed '/^torch/d' requirements/build/cuda.txt) && \
-    if [ "${VLLM_GAUDI_COMMIT}" != "main" ]; then \
-    export SETUPTOOLS_SCM_PRETEND_VERSION=${VLLM_GAUDI_COMMIT#v}; \
-    fi && \
+    case "${VLLM_GAUDI_COMMIT}" in \
+      v[0-9]*.*) export SETUPTOOLS_SCM_PRETEND_VERSION="${VLLM_GAUDI_COMMIT#v}" ;; \
+    esac; \
     VLLM_TARGET_DEVICE=empty pip install --no-cache-dir --no-build-isolation . && \
+
     cd $VLLM_PATH2 && \
     git checkout ${VLLM_GAUDI_COMMIT} && \
     VLLM_TARGET_DEVICE=hpu pip install --no-cache-dir -v . --no-build-isolation && \

--- a/.cd/Dockerfile.rhel.ubi.vllm
+++ b/.cd/Dockerfile.rhel.ubi.vllm
@@ -210,6 +210,9 @@ RUN set -e && \
     git fetch upstream --tags && \
     git checkout ${VLLM_PROJECT_COMMIT} && \
     pip install --no-cache-dir -r <(sed '/^torch/d' requirements/build/cuda.txt) && \
+    if [ "${VLLM_GAUDI_COMMIT}" != "main" ]; then \
+    export SETUPTOOLS_SCM_PRETEND_VERSION=${VLLM_GAUDI_COMMIT#v}; \
+    fi && \
     VLLM_TARGET_DEVICE=empty pip install --no-cache-dir --no-build-isolation . && \
     cd $VLLM_PATH2 && \
     git checkout ${VLLM_GAUDI_COMMIT} && \


### PR DESCRIPTION
When VLLM_GAUDI_COMMIT is a release tag, set SETUPTOOLS_SCM_PRETEND_VERSION during the vLLM core install so `vllm --version` reports the vllm-gaudi release version (e.g. 0.19.1.post1) instead of the upstream core version with the +empty local segment (e.g. 0.19.1+empty).

 The override is skipped when VLLM_GAUDI_COMMIT=main to preserve setuptools_scm's  git-derived version for dev builds.