### PR TITLE
granite-4.0-h-small - remove OOM workaround

### DIFF
--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -5241,41 +5241,6 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
         if prompt_cfg:
             prompt_bs, prompt_query_len, prompt_num_blocks = prompt_cfg
 
-            # Granite 4.0-H (non-GDN mamba hybrid): self.block_size is 528
-            # (mamba page alignment). The prompt-warmup context is materialized
-            # as prompt_num_blocks * self.block_size KV tokens, so the largest
-            # long-context bucket (e.g. 249 blocks) would build a ~131K-token
-            # context and OOM at gpu_memory_util 0.9 during warmup. The compiled
-            # graph key is (bs, query_len, num_blocks) where num_blocks is the
-            # context-block COUNT, so we cap only the warmed block COUNT here;
-            # this bounds the warmup activation peak WITHOUT changing the 528
-            # kernel/bucketing/runtime semantics. Realistic tool-calling and
-            # humaneval requests carry only a short context (tool defs + query,
-            # far below this cap), so they still hit warmed buckets and incur no
-            # runtime "not warmed-up" recompilation; only requests approaching
-            # the 131K max capacity would. GDN hybrids and non-mamba models are
-            # untouched (block_size stays 128 there, so no oversized context).
-            if (self.num_mamba_like_layers > 0 and self.num_gdn == 0 and not self.is_pooling_model):
-                # ~33K tokens matches the historically OOM-safe short-context
-                # warmup peak (the short-ctx profile warms up to ~64 blocks of
-                # 528 ≈ 33K tokens at 0.9 without OOM).
-                warmup_ctx_token_cap = 33792
-                max_warmup_ctx_blocks = max(1, warmup_ctx_token_cap // self.block_size)
-                if prompt_num_blocks > max_warmup_ctx_blocks:
-                    # Emit once so a cold-start "Configuration was not
-                    # warmed-up" on a genuinely long-context request is
-                    # traceable back to this intentional warmup cap rather
-                    # than mistaken for a bucketing bug.
-                    logger.warning_once(
-                        "Capping non-GDN mamba-hybrid prompt warmup context "
-                        "from %s to %s blocks (block_size=%s, ~%s tokens) to "
-                        "bound the warmup activation peak. Requests whose "
-                        "prompt context exceeds ~%s tokens are not pre-warmed "
-                        "and may recompile once on first use.", prompt_num_blocks, max_warmup_ctx_blocks,
-                        self.block_size, max_warmup_ctx_blocks * self.block_size,
-                        max_warmup_ctx_blocks * self.block_size)
-                prompt_num_blocks = min(prompt_num_blocks, max_warmup_ctx_blocks)
-
             if self.is_pooling_model:
                 prompt_total_tokens = [prompt_query_len]
                 prompt_num_context_blocks = [0]


### PR DESCRIPTION
This pull request removes the logic that capped the prompt warmup context size for non-GDN Mamba-hybrid models in the `_prepare_dummy_scenario` method. Previously, this cap was used to prevent out-of-memory (OOM) issues during model warmup by limiting the number of context blocks, but this logic and its warning message have now been deleted.

**Prompt warmup context handling:**

* Removed the block of code that limited the number of prompt context blocks (`prompt_num_blocks`) for non-GDN Mamba-hybrid models, including the associated warning message and explanatory comments. This means prompt warmup will no longer be artificially capped for these models.