### PR TITLE
[kimi2.6] enable model text only initial

### DIFF
--- a/docs/configuration/env_variables.md
+++ b/docs/configuration/env_variables.md
@@ -35,9 +35,10 @@ Leave `VLLM_EXPONENTIAL_BUCKETING` unset when using `VLLM_BUCKETING_STRATEGY`. T
 
 To enter developer mode use `VLLM_DEVELOPER_MODE`:
 
-| Parameter name     | Description              | Default value |
-| ------------------ | ------------------------ | ------------- |
-| `VLLM_SKIP_WARMUP` | Skips the warm-up phase. | `false`       |
+| Parameter name        | Description                                                                                                                                                                                                                                  | Default value |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `VLLM_SKIP_WARMUP`    | Skips the warm-up phase.                                                                                                                                                                                                                     | `false`       |
+| `VLLM_SKIP_MM_WARMUP` | Skips ONLY the multimodal-graph warm-up while still running prompt/decode warm-up. Useful for multimodal models whose vision tower fails to compile on HPU when the user is running text-only and does not need the vision path.             | `false`       |
 
 ## Additional Parameters
 

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -5669,8 +5669,17 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
         # to avoid GC errors. In torch.compile mode, run it inside
         # for faster recipe-only compilation.
         use_torch_compile = (not htorch.utils.internal.is_lazy() and not self.model_config.enforce_eager)
-        if self.supports_mm_inputs and not use_torch_compile:
+        # VLLM_SKIP_MM_WARMUP: when set, skip ONLY the multimodal-graph warmup
+        # while still running prompt+decode warmup. Useful for models whose
+        # vision tower fails to compile on HPU (e.g. when an upstream module
+        # uses a torch._inductor path without an 'hpu' backend), and when the
+        # user is running the model text-only and does not need the vision
+        # path. Differs from VLLM_SKIP_WARMUP, which disables all warmup.
+        skip_mm_warmup = os.environ.get('VLLM_SKIP_MM_WARMUP', '0').lower() in ('1', 'true')
+        if self.supports_mm_inputs and not use_torch_compile and not skip_mm_warmup:
             self.warmup_multimodal_graphs(self.get_model().vision_bucket_manager.multimodal_buckets)
+        elif self.supports_mm_inputs and not use_torch_compile and skip_mm_warmup:
+            logger.info("Skipping multimodal warmup graphs because VLLM_SKIP_MM_WARMUP is set.")
 
         compile_only_mode_context = functools.partial(bc.env_setting, "PT_COMPILE_ONLY_MODE", True)
         can_use_compile_only_mode = True
@@ -5684,8 +5693,10 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
                            'Warmup time will be negatively impacted. '
                            'Please update Gaudi Software Suite.')
         with compile_only_mode_context() if can_use_compile_only_mode else contextlib.nullcontext():
-            if self.supports_mm_inputs and use_torch_compile:
+            if self.supports_mm_inputs and use_torch_compile and not skip_mm_warmup:
                 self.warmup_multimodal_graphs(self.get_model().vision_bucket_manager.multimodal_buckets)
+            elif self.supports_mm_inputs and use_torch_compile and skip_mm_warmup:
+                logger.info("Skipping multimodal warmup graphs because VLLM_SKIP_MM_WARMUP is set.")
 
             if not self.model_config.enforce_eager and not self.is_pooling_model:
                 assert self.mem_margin is not None, \


### PR DESCRIPTION
Adds VLLM_SKIP_MM_WARMUP=1 to skip only the multimodal-graph warm-up while still running the prompt and decode graph warm-up.

Motivation: some multimodal models include vision towers whose upstream implementation hits a torch._inductor code path that has no 'hpu' backend registered, causing engine init to crash in warmup_multimodal_graphs. Today the only workaround is VLLM_SKIP_WARMUP, which disables all warmup and causes runtime JIT-compile stalls on every new bucket size hit. With this knob, users running such models text-only can keep the normal prompt/decode bucket warmup and avoid the runtime stalls, while skipping just the vision compile that they don't need.

Pattern follows existing in-file env-var gates such as VLLM_SKIP_MARK_UNBACKED. Documents the new variable under Developer Mode Parameters next to VLLM_SKIP_WARMUP.