### PR TITLE
Free dead INC-quantized FP8 MoE weight copy to halve device memory, fix for MoE refactor #41184

### DIFF
--- a/vllm_gaudi/models/gptoss_mxfp4.py
+++ b/vllm_gaudi/models/gptoss_mxfp4.py
@@ -118,6 +118,21 @@ def _load_weights_mxfp4_dequantize_hpu(
     params_dict = dict(self.named_parameters())
     loaded_params: set[str] = set()
 
+    def _param_key(n: str) -> str:
+        # Upstream PR #41184 nests routed expert weights under a
+        # ``routed_experts`` child module, so checkpoint names like
+        # ``...experts.w13_weight`` now map to parameters
+        # ``...experts.routed_experts.w13_weight``. Resolve to the actual
+        # parameter key. No-op on vLLM versions without the refactor and for
+        # non-expert weights.
+        if n in params_dict:
+            return n
+        if ".experts." in n and ".experts.routed_experts." not in n:
+            cand = n.replace(".experts.", ".experts.routed_experts.", 1)
+            if cand in params_dict:
+                return cand
+        return n
+
     use_ep = self.parallel_config.enable_expert_parallel
 
     # In MoE, we need to flatten the tensor parallel size across the data
@@ -174,7 +189,7 @@ def _load_weights_mxfp4_dequantize_hpu(
             if block_name not in block_weight_dict:
                 raise ValueError(f"Expected block weight for {block_name} not found when processing {name}")
             block_weight = block_weight_dict[block_name]
-            param = params_dict[block_name]
+            param = params_dict[_param_key(block_name)]
 
             weight = convert_moe_packed_tensors(block_weight, narrow_weight_scale)
             if use_ep:
@@ -191,7 +206,7 @@ def _load_weights_mxfp4_dequantize_hpu(
                 narrow_weight = weight[:, 2 * tp_rank_start:2 * tp_rank_end, :, :]
             narrow_weight = narrow_weight.contiguous()
             block_weight_dict[name] = narrow_weight
-            loaded_params.add(name)
+            loaded_params.add(_param_key(name))
             continue
         elif ".w2_weight_scale" in name:
             # Handle MLP down projection weights
@@ -206,7 +221,7 @@ def _load_weights_mxfp4_dequantize_hpu(
             if block_name not in block_weight_dict:
                 raise ValueError(f"Expected block weight for {block_name} not found when processing {name}")
             block_weight = block_weight_dict[block_name]
-            param = params_dict[block_name]
+            param = params_dict[_param_key(block_name)]
 
             weight = convert_moe_packed_tensors(block_weight, narrow_weight_scale)
             if use_ep:
@@ -224,7 +239,7 @@ def _load_weights_mxfp4_dequantize_hpu(
                 narrow_weight = weight[:, :, k_block_start:k_block_end, :]
             narrow_weight = narrow_weight.contiguous()
             block_weight_dict[name] = narrow_weight
-            loaded_params.add(name)
+            loaded_params.add(_param_key(name))
             continue
         elif ".w13_bias" in name:
             # Handle MLP gate and up projection biases
@@ -235,12 +250,12 @@ def _load_weights_mxfp4_dequantize_hpu(
                 narrow_weight = weight[:, 2 * tp_rank_start:2 * tp_rank_end]
             narrow_weight = narrow_weight.contiguous()
 
-            param = params_dict[name]
+            param = params_dict[_param_key(name)]
             if use_ep:
                 param.copy_(narrow_weight)
             else:
                 param[:, :2 * (tp_rank_end - tp_rank_start)] = narrow_weight
-            loaded_params.add(name)
+            loaded_params.add(_param_key(name))
             continue
         elif ".w2_bias" in name:
             # Handle MLP down projection bias
@@ -250,9 +265,9 @@ def _load_weights_mxfp4_dequantize_hpu(
                 # (only load on rank 0 to avoid duplication)
                 if tp_rank != 0:
                     weight.zero_()
-            param = params_dict[name]
+            param = params_dict[_param_key(name)]
             param.copy_(weight)
-            loaded_params.add(name)
+            loaded_params.add(_param_key(name))
             continue
         elif "sinks" in name:
             # Handle attention sinks (distributed across ranks)

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -282,6 +282,53 @@ def _move_remaining_tensors_to_device(model: torch.nn.Module, device: str) -> No
         logger.info("Moved %d stray tensors to %s", moved, device)
 
 
+def _dedup_moe_op_weights(model: torch.nn.Module) -> None:
+    """Release the dead duplicate device copy of MoE expert weights after INC.
+
+    For FP8 MoE, INC's ``fp8_quant`` conversion re-registers each per-expert
+    weight as a fresh (transposed, contiguous) Parameter inside the patched
+    ``moe_op`` (copy B). The original ``w13_weight`` / ``w2_weight`` Parameter
+    (copy A) is then dead — the forward runs entirely through ``moe_op`` — yet
+    it is still moved to device, doubling expert-weight memory and starving the
+    KV cache.
+
+    Free copy A only when every expert weight is accounted for in ``moe_op`` and
+    none of them share storage with the Parameter (i.e. INC made a genuine
+    second copy). It is a no-op when the op still aliases the Parameter
+    (non-INC / measure path), detected via storage identity.
+    """
+
+    def _storage_id(t: torch.Tensor) -> int:
+        try:
+            return t.untyped_storage().data_ptr()
+        except Exception:
+            return t.data_ptr()
+
+    for module in model.modules():
+        moe_op = getattr(module, "moe_op", None)
+        if moe_op is None:
+            continue
+        for param_name, list_name in (("w13_weight", "w13_list"), ("w2_weight", "w2_list")):
+            param = getattr(module, param_name, None)
+            weight_list = getattr(moe_op, list_name, None)
+            if not isinstance(param, torch.Tensor) or weight_list is None:
+                continue
+            if param.dim() == 0 or param.shape[0] != len(weight_list):
+                continue
+            op_storages = set()
+            op_tensors = 0
+            for item in weight_list:
+                w = getattr(item, "weight", None)
+                if isinstance(w, torch.Tensor):
+                    op_tensors += 1
+                    op_storages.add(_storage_id(w))
+            if op_tensors != len(weight_list):
+                continue
+            if _storage_id(param) in op_storages:
+                continue
+            param.data = torch.empty(0, dtype=param.dtype, device=param.device)
+
+
 class BucketingFailedException(Exception):
     pass
 
@@ -4493,6 +4540,7 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
                 if not is_fake_hpu():
                     self.model = self.model.to("hpu")
                     _move_remaining_tensors_to_device(self.model, "hpu")
+                    _dedup_moe_op_weights(self.model)
                     htorch.core.mark_step()
                 if not disable_mark_scales_as_const:
                     htcore.hpu_initialize(self.model, mark_only_scales_as_const=True)


### PR DESCRIPTION
1. Release duplicate FP8 MoE expert weights after INC conversion
2. Fix FP8 MoE device-memory doubling under INC quantization
3. Drop dead w13/w2 Parameter copy after INC FP8 MoE convert