### PR TITLE
Fix DeepSeek-R1 FP8 grouped-topk MoE graph compile failure

### DIFF
--- a/vllm_gaudi/ops/hpu_fp8.py
+++ b/vllm_gaudi/ops/hpu_fp8.py
@@ -230,9 +230,17 @@ class HPUFp8MoEMethod(Fp8MoEMethod):
             topk_weights /= topk_weights.sum(dim=-1, keepdim=True)
             topk_weights = topk_weights.to(x.dtype)
 
-        if not layer.use_grouped_topk:
-            topk_ids = topk_ids.to(torch.int64)
-            topk_weights = topk_weights.to(x.dtype)
+        # The HPU mixture_of_experts kernel (including the chunked
+        # weighted_sum_reduction_bf16 reduction) compiles for int64 routing
+        # tables and bf16 (x.dtype) router weights. The grouped-topk /
+        # custom-routing helper returns int32 ids and float32 weights; the
+        # regular-topk branch above already normalized them, but the grouped
+        # path was previously left unconverted -> the bf16 reduction kernel
+        # received float32 router_weights and failed to compile
+        # (GLUE_INCOMPATIBLE_DATA_TYPE). Normalize for every routing path so the
+        # kernel graph receives dtype-consistent inputs.
+        topk_ids = topk_ids.to(torch.int64)
+        topk_weights = topk_weights.to(x.dtype)
 
         if layer.moe_config.dp_size > 1:
             dp_metadata = get_hpu_dp_metadata()


### PR DESCRIPTION

## Root cause

`HPUFp8MoEMethod.apply_monolithic` gated its routing-tensor dtype normalization
behind `if not layer.use_grouped_topk:`. Models that use grouped-topk (DeepSeek-R1)
therefore passed the raw output of `select_experts_from_routed` — `int32` expert
ids and `float32` router weights — straight into `layer.moe_op`.

The FP8 op dequantizes its experts to bf16 and runs the chunked
`torch.ops.hpu.mixture_of_experts` kernel, whose `weighted_sum_reduction_bf16`
reduction requires **bf16** (`x.dtype`) router weights and **int64** routing
tables. Receiving `float32` router weights fails to compile
(`GLUE_INCOMPATIBLE_DATA_TYPE`).

The non-grouped branch already normalized these dtypes; only the grouped path was
left unconverted.

## Fix

Normalize `topk_ids -> int64` and `topk_weights -> x.dtype` for **every** routing
path in `HPUFp8MoEMethod.apply_monolithic`, mirroring the normalization already
applied in the unquantized `HPUUnquantizedFusedMoEMethod`. This is a dtype-only
change; no numerical behavior changes for the previously-working non-grouped path.

## Testing

- DeepSeek-R1 FP8, TP8 / EP8, bfloat16, `kv_cache_dtype=fp8_inc`, block_size 128:
  graph compile now succeeds and the model serves/generates without the
  `weighted_sum_reduction_bf16` failure.
- Non-grouped-topk FP8 MoE models unaffected (dtype outcome is identical to before).