### PR TITLE
Fix hetero HPU NIXL connector for kv_buffer_device=hpu (GDR) PD

### DIFF
--- a/examples/nixl/requirements.txt
+++ b/examples/nixl/requirements.txt
@@ -1,4 +1,6 @@
+# NIXL is NOT installed from PyPI here: the HPU GDR (kv_buffer_device=hpu) path
+# needs the gaudi_gdr-enabled build produced by ../../install_nixl.py, which also
+# pip-installs its own nixl wheel. The run_*.sh scripts build it on first run.
 pytest
-nixl
 lm-eval
 lm-eval[api]

--- a/examples/nixl/run_hpu_disagg_accuracy_test_hpubuf.sh
+++ b/examples/nixl/run_hpu_disagg_accuracy_test_hpubuf.sh
@@ -1,0 +1,247 @@
+#!/bin/bash
+set -xe
+
+# Models to run
+MODELS=(
+    "Qwen/Qwen3-0.6B"
+)
+MODELS=(
+	"meta-llama/Llama-3.1-8B"
+)
+
+export VLLM_SKIP_WARMUP="true"
+
+# --- HPU GDR (kv_buffer_device=hpu) setup ---
+# Build the gaudi_gdr-capable UCX + NIXL only if not already present (marker lib
+# libuct_gaudi.so). Compiles from source on first run; re-runs are a no-op.
+# Set NIXL_SKIP_INSTALL=1 to bypass.
+UCX_INSTALL_DIR=${UCX_INSTALL_DIR:-/tmp/ucx_install}
+VLLM_GAUDI_PREFIX=${VLLM_GAUDI_PREFIX:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}
+if [[ -z "${NIXL_SKIP_INSTALL:-}" && ! -f "$UCX_INSTALL_DIR/lib/ucx/libuct_gaudi.so" ]]; then
+    echo "gaudi_gdr UCX not found at $UCX_INSTALL_DIR; building via install_nixl.py..."
+    python "$VLLM_GAUDI_PREFIX/install_nixl.py"
+fi
+export LD_LIBRARY_PATH=$UCX_INSTALL_DIR/lib:/usr/lib/habanalabs:$LD_LIBRARY_PATH
+export UCX_TLS=ib,rc,gaudi_gdr
+export UCX_MEMTYPE_CACHE=0
+# Homogeneous Gaudi<->Gaudi (TP1<->TP1): use the plain hpu_nixl_connector
+# (NOT the hetero layout). kv_buffer_device=hpu gives true GDR from HPU memory.
+COMMON_GDR_ENV="UCX_TLS=ib,rc,gaudi_gdr UCX_MEMTYPE_CACHE=0"
+PREFILL_ENV="$COMMON_GDR_ENV"
+DECODE_ENV="$COMMON_GDR_ENV"
+
+# Number of prefill and decode instances to create
+NUM_PREFILL_INSTANCES=${NUM_PREFILL_INSTANCES:-1} # Default to 1
+NUM_DECODE_INSTANCES=${NUM_DECODE_INSTANCES:-1}   # Default to 1
+PREFILLER_TP_SIZE=${PREFILLER_TP_SIZE:-1}
+DECODER_TP_SIZE=${DECODER_TP_SIZE:-1}
+
+# Find the git repository root directory
+#GIT_ROOT=$(git rev-parse --show-toplevel)
+GIT_ROOT="/home/vllm-nixl/vllm"
+
+#SMI_BIN=$(which nvidia-smi || which rocm-smi)
+
+# Trap the SIGINT signal (triggered by Ctrl+C)
+trap 'kill $(jobs -pr)' SIGINT SIGTERM EXIT
+
+# Waits for vLLM to start.
+wait_for_server() {
+  local port=$1
+  timeout 1200 bash -c "
+    until curl -s localhost:${port}/v1/completions > /dev/null; do
+      sleep 1
+    done" && return 0 || return 1
+}
+
+# Function to clean up previous instances
+cleanup_instances() {
+  echo "Cleaning up any running vLLM instances..."
+  pkill -f "vllm serve" || true
+  sleep 2
+}
+
+# Handle to get model-specific arguments for deepseek
+get_model_args() {
+  local model_name=$1
+  local extra_args=""
+
+  if [[ "$model_name" == "deepseek-ai/deepseek-vl2-tiny" ]]; then
+    extra_args="--hf_overrides '{\"architectures\": [\"DeepseekVLV2ForCausalLM\"]}' --trust-remote-code"
+  fi
+
+  echo "$extra_args"
+}
+
+get_num_gpus() {
+  if [[ "$SMI_BIN" == *"nvidia"* ]]; then
+    echo "$($SMI_BIN --query-gpu=name --format=csv,noheader | wc -l)"
+  else
+    echo "$($SMI_BIN -l | grep GPU | wc -l)"
+  fi
+}
+
+# Function to run tests for a specific model
+run_tests_for_model() {
+  local model_name=$1
+  echo "================================"
+  echo "Testing model: $model_name"
+  echo "================================"
+
+  # Get model-specific arguments
+  local model_args=$(get_model_args "$model_name")
+
+  # Arrays to store all hosts and ports
+  PREFILL_HOSTS=()
+  PREFILL_PORTS=()
+  DECODE_HOSTS=()
+  DECODE_PORTS=()
+
+  # Start prefill instances
+  for i in $(seq 0 $((NUM_PREFILL_INSTANCES-1))); do
+    # Calculate GPU ID - we'll distribute across available GPUs
+    #GPU_ID=$((i % $(get_num_gpus)))
+    GPU_ID=3
+
+    # Calculate port number (base port + instance number)
+    PORT=$((8300 + i))
+    # Calculate side channel port. Avoid clash with with TP workers. 
+    SIDE_CHANNEL_PORT=$((6559 + i))
+
+    echo "Starting prefill instance $i on GPU $GPU_ID, port $PORT"
+
+    # Build the command with or without model-specific args
+    BASE_CMD="$PREFILL_ENV \
+    CUDA_VISIBLE_DEVICES=$GPU_ID VLLM_NIXL_SIDE_CHANNEL_PORT=$SIDE_CHANNEL_PORT vllm serve $model_name \
+    --port $PORT \
+    --enforce-eager \
+    --gpu-memory-utilization 0.3 \
+    --tensor-parallel-size $PREFILLER_TP_SIZE \
+    --block-size 128 \
+    --max-model-len 8192 \
+    --max-num-batched-tokens 99999 \
+    --kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\",\"kv_buffer_device\":\"hpu\"}'"
+
+    if [ -n "$model_args" ]; then
+    FULL_CMD="$BASE_CMD $model_args"
+    else
+    FULL_CMD="$BASE_CMD"
+    fi
+
+    eval "$FULL_CMD &"
+
+    # Store host and port for proxy configuration
+    PREFILL_HOSTS+=("localhost")
+    PREFILL_PORTS+=($PORT)
+  done
+
+  # Start decode instances
+  for i in $(seq 0 $((NUM_DECODE_INSTANCES-1))); do
+    # Calculate GPU ID - we'll distribute across available GPUs, starting from after prefill GPUs
+    #GPU_ID=$(((i + NUM_PREFILL_INSTANCES) % $(get_num_gpus)))
+    GPU_ID=6
+    # Calculate port number (base port + instance number)
+    PORT=$((8400 + i))
+    # Calculate side channel port
+    SIDE_CHANNEL_PORT=$((5659 + i * $DECODER_TP_SIZE))
+
+    echo "Starting decode instance $i on GPU $GPU_ID, port $PORT"
+
+    # Build the command with or without model-specific args
+    BASE_CMD="$DECODE_ENV \
+    CUDA_VISIBLE_DEVICES=$GPU_ID VLLM_NIXL_SIDE_CHANNEL_PORT=$SIDE_CHANNEL_PORT vllm serve $model_name \
+    --port $PORT \
+    --enforce-eager \
+    --gpu-memory-utilization 0.3 \
+    --tensor-parallel-size $DECODER_TP_SIZE \
+    --block-size 128 \
+    --max-model-len 8192 \
+    --max-num-batched-tokens 99999 \
+    --no-enable-prefix-caching \
+    --kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\",\"kv_buffer_device\":\"hpu\"}'"
+
+    if [ -n "$model_args" ]; then
+    FULL_CMD="$BASE_CMD $model_args"
+    else
+    FULL_CMD="$BASE_CMD"
+    fi
+
+    eval "$FULL_CMD &"
+
+    # Store host and port for proxy configuration
+    DECODE_HOSTS+=("localhost")
+    DECODE_PORTS+=($PORT)
+  done
+
+  # Wait for all instances to start
+  for PORT in "${PREFILL_PORTS[@]}"; do
+    echo "Waiting for prefill instance on port $PORT to start..."
+    wait_for_server $PORT
+  done
+
+  for PORT in "${DECODE_PORTS[@]}"; do
+    echo "Waiting for decode instance on port $PORT to start..."
+    wait_for_server $PORT
+  done
+
+  # Build the command for the proxy server with all the hosts and ports
+  PROXY_CMD="python toy_proxy_server.py --port 9195"
+
+  # Add all prefill hosts and ports
+  PROXY_CMD+=" --prefiller-hosts ${PREFILL_HOSTS[@]}"
+  PROXY_CMD+=" --prefiller-ports ${PREFILL_PORTS[@]}"
+
+  # Add all decode hosts and ports
+  PROXY_CMD+=" --decoder-hosts ${DECODE_HOSTS[@]}"
+  PROXY_CMD+=" --decoder-ports ${DECODE_PORTS[@]}"
+
+  # Start the proxy server
+  echo "Starting proxy server with command: $PROXY_CMD"
+  $PROXY_CMD &
+
+  # Wait for the proxy to start
+  sleep 10
+  
+# curl -X POST -s http://localhost:9192/v1/completions \
+#	-H "Content-Type: application/json" \
+#	-d '{
+#	"model": "meta-llama/Llama-3.1-8B",
+#	"prompt": "Mark Elliot Zuckerberg is an American businessman who co-founded the social media service Facebook and its parent company Meta Platforms, of which he is the chairman, chief executive officer, and controlling shareholder. Zuckerberg has been the subject of multiple lawsuits regarding the creation and ownership of the website as well as issues such as user privacy. Born in White Plains, New York, Zuckerberg briefly attended Harvard College, where he launched Facebook in February 2004 with his roommates Eduardo Saverin, Andrew McCollum, Dustin Moskovitz and Chris Hughes. Zuckerberg took the company public in May 2012 with majority shares. He became the worlds youngest self-made billionaire[a] in 2008, at age 23, and has consistently ranked among the worlds wealthiest individuals. According to Forbes, Zuckerbergs estimated net worth stood at US$221.2 billion as of May 2025, making him the second-richest individual in the world.[2]",
+#	"max_tokens": 5,
+#	"temperature": 0
+#	}'
+	sleep 5
+	echo "--------------------===================-------------"
+curl -X POST -s http://localhost:9195/v1/completions \
+        -H "Content-Type: application/json" \
+        -d '{
+        "model": "meta-llama/Llama-3.1-8B",
+        "prompt": "Mark Elliot Zuckerberg is an American businessman who co-founded the social media service Facebook and its parent company Meta Platforms, of which he is the chairman, chief executive officer, and controlling shareholder. Zuckerberg has been the subject of multiple lawsuits regarding the creation and ownership of the website as well as issues such as user privacy. Born in White Plains, New York, Zuckerberg briefly attended Harvard College, where he launched Facebook in February 2004 with his roommates Eduardo Saverin, Andrew McCollum, Dustin Moskovitz and Chris Hughes. Zuckerberg took the company public in May 2012 with majority shares. He became the worlds youngest self-made billionaire[a] in 2008, at age 23, and has consistently ranked among the worlds wealthiest individuals. According to Forbes, Zuckerbergs estimated net worth stood at US$221.2 billion as of May 2025, making him the second-richest individual in the world.[2] Intel opened its first international manufacturing facility in 1972, in Malaysia, which would host multiple Intel operations, before opening assembly facilities and semiconductor plants in Singapore and Jerusalem in the early 1980s, and manufacturing and development centers in China, India, and Costa Rica in the 1990s.[31] By the early 1980s, its business was dominated by DRAM chips. However, increased competition from Japanese semiconductor manufacturers had, by 1983, dramatically reduced the profitability of this market. The growing success of the IBM personal computer, based on an Intel microprocessor, was among factors that convinced Gordon Moore (CEO since 1975) to shift the companys focus to microprocessors and to change fundamental aspects of that business model. Moores decision to sole-source Intels 386 chip played into the companys continuing success.",
+        "max_tokens": 5,
+        "temperature": 0
+        }'
+ curl -X POST -s http://localhost:9195/v1/completions \
+       -H "Content-Type: application/json" \
+       -d '{
+       "model": "meta-llama/Llama-3.1-8B",
+       "prompt": ["This was a few months ago. It was my day off and the only thing I had to do was pick my girlfriend up from work at 9:00 pm. Other than that, I was free to loaf on the couch from morning to night, which is what I did. Around 8:00, I decided to shower before I left the house. Now, I have short hair that dries pretty quickly, but I am deeply vain about it, so I always dry it with the hairdryer right after I shower to ensure my hair doesnt get flat and weird. I never skip this step. So, I get out of the shower, start drying my hair... And then I wake up in bed. Its half an hour later. I feel like garbage, my entire body mysteriously hurts, and I am slowly realizing that I dont remember exiting the bathroom. My only clear thought is: oh shit, its 9:00! I have to pick up my girlfriend! Better shake myself awake. I dragged my aching carcass back to the bathroom, and this was when I noticed the massive blisters forming all over my hand. I was still pretty out of it, but I knew that this was a hospital visit kind of burn. My girlfriend then called to check in because I was running late and, despite my undoubtedly convincing argument that I was still perfectly fine to drive, she immediately knew something was wrong. She cabbed home and we got a ride to the ER. Turns out, I had my first ever seizure! It seems like during the seizure, I clenched the hairdryer in my fist and had it pointed at my other hand long enough to thoroughly cook it. The tissue loss is pretty deep in some areas and there was concerns about me retaining my mobility, but its been healing well so far.", 
+       "Mark Elliot Zuckerberg is an American businessman who co-founded the social media service Facebook and its parent company Meta Platforms, of which he is the chairman, chief executive officer, and controlling shareholder. Zuckerberg has been the subject of multiple lawsuits regarding the creation and ownership of the website as well as issues such as user privacy. Born in White Plains, New York, Zuckerberg briefly attended Harvard College, where he launched Facebook in February 2004 with his roommates Eduardo Saverin, Andrew McCollum, Dustin Moskovitz and Chris Hughes. Zuckerberg took the company public in May 2012 with majority shares. He became the worlds youngest self-made billionaire[a] in 2008, at age 23, and has consistently ranked among the worlds wealthiest individuals. According to Forbes, Zuckerbergs estimated net worth stood at US$221.2 billion as of May 2025, making him the second-richest individual in the world.[2]"],
+       "max_tokens": 2,
+       "temperature": 0
+       }'
+  #sleep 10000
+  # Run lm eval for this model
+  echo "Running tests for $model_name"
+  TEST_MODEL=$model_name python -m pytest -s -x test_accuracy.py
+
+  # Clean up before running next model
+  cleanup_instances
+  sleep 3
+}
+
+# Run tests for each model
+for model in "${MODELS[@]}"; do
+  run_tests_for_model "$model"
+done
+
+echo "All tests completed!"

--- a/examples/nixl/run_hpu_disagg_hetero_combined.sh
+++ b/examples/nixl/run_hpu_disagg_hetero_combined.sh
@@ -1,0 +1,260 @@
+#!/bin/bash
+set -xe
+
+# Models to run
+MODELS=(
+    "Qwen/Qwen3-0.6B"
+)
+MODELS=(
+	"meta-llama/Llama-3.1-8B"
+)
+
+export VLLM_SKIP_WARMUP="true"
+
+# --- HPU GDR (kv_buffer_device=hpu) setup ---
+# Build the gaudi_gdr-capable UCX + NIXL only if not already present. The marker
+# lib is libuct_gaudi.so (the Gaudi GDR transport). This compiles from source
+# (network + a few minutes) on first run; re-runs are a no-op. Set
+# NIXL_SKIP_INSTALL=1 to bypass (e.g. if NIXL is provided another way).
+UCX_INSTALL_DIR=${UCX_INSTALL_DIR:-/tmp/ucx_install}
+VLLM_GAUDI_PREFIX=${VLLM_GAUDI_PREFIX:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}
+if [[ -z "${NIXL_SKIP_INSTALL:-}" && ! -f "$UCX_INSTALL_DIR/lib/ucx/libuct_gaudi.so" ]]; then
+    echo "gaudi_gdr UCX not found at $UCX_INSTALL_DIR; building via install_nixl.py..."
+    python "$VLLM_GAUDI_PREFIX/install_nixl.py"
+fi
+export LD_LIBRARY_PATH=$UCX_INSTALL_DIR/lib:/usr/lib/habanalabs:$LD_LIBRARY_PATH
+export UCX_TLS=ib,rc,gaudi_gdr
+export UCX_MEMTYPE_CACHE=0
+# COMBINED HETERO path: both Gaudi, both TP=1, both native NHD kernels.
+# enable_permute_local_kv triggers a REAL NHD<->HND permute (no faked layout):
+#   - prefill (sender) converts NHD->HND on save (kv_postprocess_*_on_save)
+#   - decode  (receiver) converts HND->NHD on receive
+# Different block sizes (agreed_block_size / decode block) exercise the combined
+# layout+blocksize functions. HND exists only transiently on the wire (the exact
+# bytes a real GPU would produce), so the round-trip is faithful.
+COMMON_GDR_ENV="UCX_TLS=ib,rc,gaudi_gdr UCX_MEMTYPE_CACHE=0 VLLM_HPU_HETERO_KV_LAYOUT=true VLLM_KV_CACHE_LAYOUT=NHD"
+PREFILL_ENV="$COMMON_GDR_ENV"
+DECODE_ENV="$COMMON_GDR_ENV PT_HPU_ENABLE_RESTORE_KV_LAYOUT=1"
+
+# Number of prefill and decode instances to create
+NUM_PREFILL_INSTANCES=${NUM_PREFILL_INSTANCES:-1} # Default to 1
+NUM_DECODE_INSTANCES=${NUM_DECODE_INSTANCES:-1}   # Default to 1
+PREFILLER_TP_SIZE=${PREFILLER_TP_SIZE:-1}
+DECODER_TP_SIZE=${DECODER_TP_SIZE:-1}
+# Different block sizes drive the hetero block_size_ratio path.
+PREFILL_BLOCK_SIZE=${PREFILL_BLOCK_SIZE:-128}
+DECODE_BLOCK_SIZE=${DECODE_BLOCK_SIZE:-256}
+# On-the-wire block size the prefill saves to. When smaller than
+# PREFILL_BLOCK_SIZE, the sender resizes down during the on-save postprocess.
+AGREED_BLOCK_SIZE=${AGREED_BLOCK_SIZE:-$DECODE_BLOCK_SIZE}
+
+# Find the git repository root directory
+#GIT_ROOT=$(git rev-parse --show-toplevel)
+GIT_ROOT="/home/vllm-nixl/vllm"
+
+#SMI_BIN=$(which nvidia-smi || which rocm-smi)
+
+# Trap the SIGINT signal (triggered by Ctrl+C)
+trap 'kill $(jobs -pr)' SIGINT SIGTERM EXIT
+
+# Waits for vLLM to start.
+wait_for_server() {
+  local port=$1
+  timeout 1200 bash -c "
+    until curl -s localhost:${port}/v1/completions > /dev/null; do
+      sleep 1
+    done" && return 0 || return 1
+}
+
+# Function to clean up previous instances
+cleanup_instances() {
+  echo "Cleaning up any running vLLM instances..."
+  pkill -f "vllm serve" || true
+  sleep 2
+}
+
+# Handle to get model-specific arguments for deepseek
+get_model_args() {
+  local model_name=$1
+  local extra_args=""
+
+  if [[ "$model_name" == "deepseek-ai/deepseek-vl2-tiny" ]]; then
+    extra_args="--hf_overrides '{\"architectures\": [\"DeepseekVLV2ForCausalLM\"]}' --trust-remote-code"
+  fi
+
+  echo "$extra_args"
+}
+
+get_num_gpus() {
+  if [[ "$SMI_BIN" == *"nvidia"* ]]; then
+    echo "$($SMI_BIN --query-gpu=name --format=csv,noheader | wc -l)"
+  else
+    echo "$($SMI_BIN -l | grep GPU | wc -l)"
+  fi
+}
+
+# Function to run tests for a specific model
+run_tests_for_model() {
+  local model_name=$1
+  echo "================================"
+  echo "Testing model: $model_name"
+  echo "================================"
+
+  # Get model-specific arguments
+  local model_args=$(get_model_args "$model_name")
+
+  # Arrays to store all hosts and ports
+  PREFILL_HOSTS=()
+  PREFILL_PORTS=()
+  DECODE_HOSTS=()
+  DECODE_PORTS=()
+
+  # Start prefill instances
+  for i in $(seq 0 $((NUM_PREFILL_INSTANCES-1))); do
+    # Calculate GPU ID - we'll distribute across available GPUs
+    #GPU_ID=$((i % $(get_num_gpus)))
+    GPU_ID=3
+
+    # Calculate port number (base port + instance number)
+    PORT=$((8300 + i))
+    # Calculate side channel port. Avoid clash with with TP workers. 
+    SIDE_CHANNEL_PORT=$((6559 + i))
+
+    echo "Starting prefill instance $i on GPU $GPU_ID, port $PORT"
+
+    # Build the command with or without model-specific args
+    BASE_CMD="$PREFILL_ENV \
+    CUDA_VISIBLE_DEVICES=$GPU_ID VLLM_NIXL_SIDE_CHANNEL_PORT=$SIDE_CHANNEL_PORT vllm serve $model_name \
+    --port $PORT \
+    --enforce-eager \
+    --gpu-memory-utilization 0.3 \
+    --tensor-parallel-size $PREFILLER_TP_SIZE \
+    --block-size $PREFILL_BLOCK_SIZE \
+    --max-model-len 8192 \
+    --max-num-batched-tokens 99999 \
+    --no-enable-prefix-caching \
+    --kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\",\"kv_buffer_device\":\"hpu\",\"enable_permute_local_kv\":true,\"kv_connector_extra_config\":{\"agreed_block_size\":'$AGREED_BLOCK_SIZE'}}'"
+
+    if [ -n "$model_args" ]; then
+    FULL_CMD="$BASE_CMD $model_args"
+    else
+    FULL_CMD="$BASE_CMD"
+    fi
+
+    eval "$FULL_CMD &"
+
+    # Store host and port for proxy configuration
+    PREFILL_HOSTS+=("localhost")
+    PREFILL_PORTS+=($PORT)
+  done
+
+  # Start decode instances
+  for i in $(seq 0 $((NUM_DECODE_INSTANCES-1))); do
+    # Calculate GPU ID - we'll distribute across available GPUs, starting from after prefill GPUs
+    #GPU_ID=$(((i + NUM_PREFILL_INSTANCES) % $(get_num_gpus)))
+    GPU_ID=4
+    # Calculate port number (base port + instance number)
+    PORT=$((8400 + i))
+    # Calculate side channel port
+    SIDE_CHANNEL_PORT=$((5659 + i * $DECODER_TP_SIZE))
+
+    echo "Starting decode instance $i on GPU $GPU_ID, port $PORT"
+
+    # Build the command with or without model-specific args
+    BASE_CMD="$DECODE_ENV \
+    CUDA_VISIBLE_DEVICES=$GPU_ID VLLM_NIXL_SIDE_CHANNEL_PORT=$SIDE_CHANNEL_PORT vllm serve $model_name \
+    --port $PORT \
+    --enforce-eager \
+    --gpu-memory-utilization 0.3 \
+    --tensor-parallel-size $DECODER_TP_SIZE \
+    --block-size $DECODE_BLOCK_SIZE \
+    --max-model-len 8192 \
+    --max-num-batched-tokens 99999 \
+    --no-enable-prefix-caching \
+    --kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\",\"kv_buffer_device\":\"hpu\",\"enable_permute_local_kv\":true,\"kv_connector_extra_config\":{\"agreed_block_size\":'$AGREED_BLOCK_SIZE'}}'"
+
+    if [ -n "$model_args" ]; then
+    FULL_CMD="$BASE_CMD $model_args"
+    else
+    FULL_CMD="$BASE_CMD"
+    fi
+
+    eval "$FULL_CMD &"
+
+    # Store host and port for proxy configuration
+    DECODE_HOSTS+=("localhost")
+    DECODE_PORTS+=($PORT)
+  done
+
+  # Wait for all instances to start
+  for PORT in "${PREFILL_PORTS[@]}"; do
+    echo "Waiting for prefill instance on port $PORT to start..."
+    wait_for_server $PORT
+  done
+
+  for PORT in "${DECODE_PORTS[@]}"; do
+    echo "Waiting for decode instance on port $PORT to start..."
+    wait_for_server $PORT
+  done
+
+  # Build the command for the proxy server with all the hosts and ports
+  PROXY_CMD="python toy_proxy_server.py --port 9195"
+
+  # Add all prefill hosts and ports
+  PROXY_CMD+=" --prefiller-hosts ${PREFILL_HOSTS[@]}"
+  PROXY_CMD+=" --prefiller-ports ${PREFILL_PORTS[@]}"
+
+  # Add all decode hosts and ports
+  PROXY_CMD+=" --decoder-hosts ${DECODE_HOSTS[@]}"
+  PROXY_CMD+=" --decoder-ports ${DECODE_PORTS[@]}"
+
+  # Start the proxy server
+  echo "Starting proxy server with command: $PROXY_CMD"
+  $PROXY_CMD &
+
+  # Wait for the proxy to start
+  sleep 10
+  
+# curl -X POST -s http://localhost:9192/v1/completions \
+#	-H "Content-Type: application/json" \
+#	-d '{
+#	"model": "meta-llama/Llama-3.1-8B",
+#	"prompt": "Mark Elliot Zuckerberg is an American businessman who co-founded the social media service Facebook and its parent company Meta Platforms, of which he is the chairman, chief executive officer, and controlling shareholder. Zuckerberg has been the subject of multiple lawsuits regarding the creation and ownership of the website as well as issues such as user privacy. Born in White Plains, New York, Zuckerberg briefly attended Harvard College, where he launched Facebook in February 2004 with his roommates Eduardo Saverin, Andrew McCollum, Dustin Moskovitz and Chris Hughes. Zuckerberg took the company public in May 2012 with majority shares. He became the worlds youngest self-made billionaire[a] in 2008, at age 23, and has consistently ranked among the worlds wealthiest individuals. According to Forbes, Zuckerbergs estimated net worth stood at US$221.2 billion as of May 2025, making him the second-richest individual in the world.[2]",
+#	"max_tokens": 5,
+#	"temperature": 0
+#	}'
+	sleep 5
+	echo "--------------------===================-------------"
+curl -X POST -s http://localhost:9195/v1/completions \
+        -H "Content-Type: application/json" \
+        -d '{
+        "model": "meta-llama/Llama-3.1-8B",
+        "prompt": "Mark Elliot Zuckerberg is an American businessman who co-founded the social media service Facebook and its parent company Meta Platforms, of which he is the chairman, chief executive officer, and controlling shareholder. Zuckerberg has been the subject of multiple lawsuits regarding the creation and ownership of the website as well as issues such as user privacy. Born in White Plains, New York, Zuckerberg briefly attended Harvard College, where he launched Facebook in February 2004 with his roommates Eduardo Saverin, Andrew McCollum, Dustin Moskovitz and Chris Hughes. Zuckerberg took the company public in May 2012 with majority shares. He became the worlds youngest self-made billionaire[a] in 2008, at age 23, and has consistently ranked among the worlds wealthiest individuals. According to Forbes, Zuckerbergs estimated net worth stood at US$221.2 billion as of May 2025, making him the second-richest individual in the world.[2] Intel opened its first international manufacturing facility in 1972, in Malaysia, which would host multiple Intel operations, before opening assembly facilities and semiconductor plants in Singapore and Jerusalem in the early 1980s, and manufacturing and development centers in China, India, and Costa Rica in the 1990s.[31] By the early 1980s, its business was dominated by DRAM chips. However, increased competition from Japanese semiconductor manufacturers had, by 1983, dramatically reduced the profitability of this market. The growing success of the IBM personal computer, based on an Intel microprocessor, was among factors that convinced Gordon Moore (CEO since 1975) to shift the companys focus to microprocessors and to change fundamental aspects of that business model. Moores decision to sole-source Intels 386 chip played into the companys continuing success.",
+        "max_tokens": 5,
+        "temperature": 0
+        }'
+ curl -X POST -s http://localhost:9195/v1/completions \
+       -H "Content-Type: application/json" \
+       -d '{
+       "model": "meta-llama/Llama-3.1-8B",
+       "prompt": ["This was a few months ago. It was my day off and the only thing I had to do was pick my girlfriend up from work at 9:00 pm. Other than that, I was free to loaf on the couch from morning to night, which is what I did. Around 8:00, I decided to shower before I left the house. Now, I have short hair that dries pretty quickly, but I am deeply vain about it, so I always dry it with the hairdryer right after I shower to ensure my hair doesnt get flat and weird. I never skip this step. So, I get out of the shower, start drying my hair... And then I wake up in bed. Its half an hour later. I feel like garbage, my entire body mysteriously hurts, and I am slowly realizing that I dont remember exiting the bathroom. My only clear thought is: oh shit, its 9:00! I have to pick up my girlfriend! Better shake myself awake. I dragged my aching carcass back to the bathroom, and this was when I noticed the massive blisters forming all over my hand. I was still pretty out of it, but I knew that this was a hospital visit kind of burn. My girlfriend then called to check in because I was running late and, despite my undoubtedly convincing argument that I was still perfectly fine to drive, she immediately knew something was wrong. She cabbed home and we got a ride to the ER. Turns out, I had my first ever seizure! It seems like during the seizure, I clenched the hairdryer in my fist and had it pointed at my other hand long enough to thoroughly cook it. The tissue loss is pretty deep in some areas and there was concerns about me retaining my mobility, but its been healing well so far.", 
+       "Mark Elliot Zuckerberg is an American businessman who co-founded the social media service Facebook and its parent company Meta Platforms, of which he is the chairman, chief executive officer, and controlling shareholder. Zuckerberg has been the subject of multiple lawsuits regarding the creation and ownership of the website as well as issues such as user privacy. Born in White Plains, New York, Zuckerberg briefly attended Harvard College, where he launched Facebook in February 2004 with his roommates Eduardo Saverin, Andrew McCollum, Dustin Moskovitz and Chris Hughes. Zuckerberg took the company public in May 2012 with majority shares. He became the worlds youngest self-made billionaire[a] in 2008, at age 23, and has consistently ranked among the worlds wealthiest individuals. According to Forbes, Zuckerbergs estimated net worth stood at US$221.2 billion as of May 2025, making him the second-richest individual in the world.[2]"],
+       "max_tokens": 2,
+       "temperature": 0
+       }'
+  #sleep 10000
+  # Run lm eval for this model
+  echo "Running tests for $model_name"
+  TEST_MODEL=$model_name python -m pytest -s -x test_accuracy.py
+
+  # Clean up before running next model
+  cleanup_instances
+  sleep 3
+}
+
+# Run tests for each model
+for model in "${MODELS[@]}"; do
+  run_tests_for_model "$model"
+done
+
+echo "All tests completed!"

--- a/examples/nixl/test_accuracy.py
+++ b/examples/nixl/test_accuracy.py
@@ -15,6 +15,9 @@ RTOL = 0.03
 EXPECTED_VALUES = {
     "Qwen/Qwen3-0.6B": 0.41,
     "deepseek-ai/deepseek-vl2-small": 0.59,
+    # No-PD standalone gsm8k baseline (limit=128), used to assert PD paths
+    # (cpu/hpu buffer, hetero) don't degrade accuracy.
+    "meta-llama/Llama-3.1-8B": 0.47,
 }
 
 SIMPLE_PROMPT = "The best part about working on vLLM is that I got to meet so many people across various different organizations like UCB, Google, and Meta which means"  # noqa: E501

--- a/vllm_gaudi/distributed/kv_transfer/kv_connector/v1/hetero_hpu_nixl_connector.py
+++ b/vllm_gaudi/distributed/kv_transfer/kv_connector/v1/hetero_hpu_nixl_connector.py
@@ -436,10 +436,18 @@ def request_finished(
             block_ids,
             block_ids_on_save,
         )
+    # remote_block_ids nesting is path-dependent. When the sender resizes blocks
+    # on save (block_size_ratio > 1), block_ids_on_save is a fresh flat list that
+    # is NOT re-nested downstream, so wrap it per-group here. When ratio == 1 the
+    # downstream _logical_to_remote_kernel_block_ids re-nests, so send it flat.
+    if block_size_ratio > 1:
+        remote_block_ids_payload = [block_ids_on_save]
+    else:
+        remote_block_ids_payload = block_ids_on_save
     return delay_free_blocks, dict(
         do_remote_prefill=True,
         do_remote_decode=False,
-        remote_block_ids=[block_ids_on_save],  # Wrap in list for GPU compatibility (list[list[int]])
+        remote_block_ids=remote_block_ids_payload,
         remote_engine_id=self.engine_id,
         remote_request_id=request.request_id,
         remote_host=self.side_channel_host,
@@ -579,6 +587,10 @@ def NixlConnectorWorker_init_(self, vllm_config: VllmConfig, engine_id: str, kv_
     # Protects _handshake_futures and _remote_agents.
     self._handshake_lock = threading.RLock()
 
+    # TTL-based eviction of stale remote engine state.
+    self._engine_last_active: dict[EngineId, float] = {}  # type: ignore[misc]
+    self._engine_ttl: float = vllm_config.kv_transfer_config.get_from_extra_config("engine_ttl", 3600.0)
+
     self.block_size = vllm_config.cache_config.block_size
     self.model_config = vllm_config.model_config
     self.cache_config = vllm_config.cache_config
@@ -646,6 +658,24 @@ def NixlConnectorWorker_init_(self, vllm_config: VllmConfig, engine_id: str, kv_
     self._is_hma_required = (not vllm_config.scheduler_config.disable_hybrid_kv_cache_manager
                              and any(not isinstance(g.kv_cache_spec, FullAttentionSpec)
                                      for g in kv_cache_config.kv_cache_groups))
+
+    # Attributes expected by the (non-overridden) upstream base_worker
+    # handshake/validation code. Mirror upstream NixlConnectorWorker.__init__.
+    self.attn_backends = [backend]
+    self.kv_cache_config = kv_cache_config
+    self._layer_specs = {
+        layer: group.kv_cache_spec
+        for group in kv_cache_config.kv_cache_groups
+        for layer in group.layer_names
+    }
+    self.hma_group_size = len(kv_cache_config.kv_cache_tensors)
+    # Conv state sub-projection decomposition (None when no Mamba).
+    self._conv_decomp = None
+    # Per-region MLA flags; populated in register_kv_caches once regions known.
+    self._region_is_mla = list[bool]()
+    # Set in register_kv_caches; safe defaults for pre-registration reads.
+    self._logical_num_blocks = 0
+    self.num_descs = 0
 
     # Initialize lease extension for heartbeat handling
     kv_lease_duration: int = vllm_config.kv_transfer_config.get_from_extra_config("kv_lease_duration", 30)
@@ -783,6 +813,12 @@ def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         # be able to index K/V separately. Hence we double the number
         # of 'virtual' regions here and halve `block_len` below.
         self.num_regions *= 2
+
+    # Attributes expected by upstream base_worker handshake/validation.
+    # Non-MLA HPU path: no region is a replicated (MLA) region.
+    self._region_is_mla = [False] * len(self.block_len_per_layer)
+    self._logical_num_blocks = self.num_blocks
+    self.num_descs = self.num_regions * self.num_blocks
 
     # Register local/src descr for NIXL xfer.
     self.seen_base_addresses = seen_base_addresses


### PR DESCRIPTION
The hetero HPU NIXL connector had drifted behind the pinned vLLM base_worker and failed on the kv_buffer_device=hpu disaggregation path. Two fixes:

1. Restore attributes the (non-overridden) upstream base_worker handshake/validation code expects. The connector monkey-patches NixlConnectorWorker.__init__ but no longer set: _engine_ttl, _engine_last_active, attn_backends, kv_cache_config, _layer_specs, hma_group_size, _conv_decomp, _region_is_mla, _logical_num_blocks, num_descs. Init defaults added, with register-time values populated in register_kv_caches. Fixes a cascade of AttributeErrors during the NIXL handshake on the decode worker.

2. Make remote_block_ids nesting path-dependent in request_finished. When the sender resizes blocks on save (block_size_ratio > 1), block_ids_on_save is a fresh flat list that is NOT re-nested by the downstream _logical_to_remote_kernel_block_ids, so wrap it per-group here; when ratio == 1 it is re-nested downstream, so send it flat. A single constant wrap satisfied only one of the two hetero paths (block-size vs layout+blocksize), causing either an int-not-iterable TypeError or a descriptor-count AssertionError.
Config	gsm8k
no-PD baseline	0.469
cpu-buffer PD	0.461
hpu-GDR PD	0.539
combined sender	0.508
combined receiver	0.523



Example scripts under examples/nixl/:
  - run_hpu_disagg_accuracy_test_hpubuf.sh: homogeneous hpu-GDR
  - run_hpu_disagg_hetero_combined.sh: parametrized hetero (block-size and NHD<->HND layout permute, both sender and receiver side) via PREFILL_BLOCK_SIZE / DECODE_BLOCK_SIZE / AGREED_BLOCK_SIZE
  - run_hpu_disagg_baseline_nogsm8k.sh: quick smoke variant (cpu buffer) The GDR scripts build the gaudi_gdr UCX+NIXL via install_nixl.py on first run (guarded on libuct_gaudi.so; NIXL_SKIP_INSTALL=1 to bypass). Drop the PyPI `nixl` from examples/nixl/requirements.txt since install_nixl.py provides the gaudi_gdr-enabled wheel that serves both cpu- and hpu-buffer paths.