### PR TITLE
Fix runtime errors on Qwen single process model swapping

### DIFF
--- a/vllm_gaudi/extension/ops.py
+++ b/vllm_gaudi/extension/ops.py
@@ -162,6 +162,7 @@ def flat_pa_mla(query, key_cache, value_cache, block_list, block_mapping, block_
     kv_heads = key_cache.size(1)
 
     query = batch2block(scale * query, block_mapping, batch2block_matmul_op).unsqueeze(-2)
+    n_blocks = query.shape[0]  # anchor for Dynamo: key/value must share this symbolic dim
     key = keys_fetch_func(key_cache.unflatten(0, (-1, block_size)), block_list)
     if value_cache is not None:
         value = values_fetch_func(value_cache.unflatten(0, (-1, block_size)), block_list)
@@ -171,9 +172,9 @@ def flat_pa_mla(query, key_cache, value_cache, block_list, block_mapping, block_
     else:
         assert False, "value_cache is None and kv_lora_rank is None"
 
-    key = key.transpose(1, 2)
-    value = value.transpose(1, 2)
-    block_bias = block_bias.unsqueeze(1).unsqueeze(2)
+    key = key.transpose(1, 2)[:n_blocks]
+    value = value.transpose(1, 2)[:n_blocks]
+    block_bias = block_bias[:n_blocks].unsqueeze(1).unsqueeze(2)
     if kv_heads != q_heads:
         block_bias = block_bias.unsqueeze(1)
         query = query.unflatten(1, (kv_heads, -1))
@@ -221,11 +222,12 @@ def flat_pa(query, key_cache, value_cache, block_list, block_mapping, block_bias
 
     query_shape = (-1, q_heads, 1, head_size)
     query = batch2block(scale * query, block_mapping, batch2block_matmul_op).view(query_shape)
+    n_blocks = query.shape[0]  # anchor for Dynamo: key/value must share this symbolic dim
     key = keys_fetch_func(key_cache.unflatten(0, (-1, block_size)),
-                          **get_kv_fetch_extra_args(blocks=block_list, scales=k_scales_uf)).transpose(1, 2)
+                          **get_kv_fetch_extra_args(blocks=block_list, scales=k_scales_uf)).transpose(1, 2)[:n_blocks]
     value = values_fetch_func(value_cache.unflatten(0, (-1, block_size)),
-                              **get_kv_fetch_extra_args(blocks=block_list, scales=v_scales_uf)).transpose(1, 2)
-    block_bias = block_bias.unsqueeze(1).unsqueeze(2)
+                              **get_kv_fetch_extra_args(blocks=block_list, scales=v_scales_uf)).transpose(1, 2)[:n_blocks]
+    block_bias = block_bias[:n_blocks].unsqueeze(1).unsqueeze(2)
     sink = None
     if sinks is not None:
         sinks = sinks.reshape(sinks.shape[0], 1)

--- a/vllm_gaudi/extension/ops.py
+++ b/vllm_gaudi/extension/ops.py
@@ -161,10 +161,6 @@ def flat_pa_mla(query, key_cache, value_cache, block_list, block_mapping, block_
     q_heads = query.size(1)
     kv_heads = key_cache.size(1)
 
-    # Same symbolic shape constraints as flat_pa — see comment there.
-    torch._check(block_list.size(0) == block_mapping.shape[0])
-    torch._check(block_mapping.shape[0] * block_size <= key_cache.shape[0])
-
     query = batch2block(scale * query, block_mapping, batch2block_matmul_op).unsqueeze(-2)
     n_blocks = query.shape[0]  # anchor for Dynamo: key/value must share this symbolic dim
     key = keys_fetch_func(key_cache.unflatten(0, (-1, block_size)), block_list)
@@ -223,19 +219,6 @@ def flat_pa(query, key_cache, value_cache, block_list, block_mapping, block_bias
         k_scales_uf = k_scales.unflatten(0, (-1, block_size))
     if v_scales is not None:
         v_scales_uf = (v_scales[0].unflatten(0, (-1, block_size)), v_scales[1])
-
-    # Establish symbolic shape constraints for Dynamo so that the three
-    # independently-tracked symbolic variables:
-    #   s_bl  = block_list.size(0)           (= block_bucket_size for this batch)
-    #   s_bm  = block_mapping.shape[0]       (= block_bucket_size, from one_hot(block_groups))
-    #   s_kc//block_size                     (= total_kv_blocks from KV cache allocation)
-    # satisfy s_bl == s_bm <= s_kc//block_size.  Without these constraints Dynamo
-    # cannot prove narrow()'s bound (0 + s_bl <= s_kc//block_size) or the matmul
-    # broadcast (s_bm == s_bl) after a stash-restore recompilation.
-    # NOTE: the equality below is always True at runtime (both equal block_bucket_size).
-    # The inequality is also always True (batch blocks <= total KV blocks).
-    torch._check(block_list.size(0) == block_mapping.shape[0])
-    torch._check(block_mapping.shape[0] * block_size <= key_cache.shape[0])
 
     query_shape = (-1, q_heads, 1, head_size)
     query = batch2block(scale * query, block_mapping, batch2block_matmul_op).view(query_shape)

--- a/vllm_gaudi/extension/ops.py
+++ b/vllm_gaudi/extension/ops.py
@@ -163,7 +163,7 @@ def flat_pa_mla(query, key_cache, value_cache, block_list, block_mapping, block_
 
     # Same symbolic shape constraints as flat_pa — see comment there.
     torch._check(block_list.size(0) == block_mapping.shape[0])
-    torch._check(key_cache.shape[0] == block_mapping.shape[0] * block_size)
+    torch._check(block_mapping.shape[0] * block_size <= key_cache.shape[0])
 
     query = batch2block(scale * query, block_mapping, batch2block_matmul_op).unsqueeze(-2)
     n_blocks = query.shape[0]  # anchor for Dynamo: key/value must share this symbolic dim
@@ -226,14 +226,16 @@ def flat_pa(query, key_cache, value_cache, block_list, block_mapping, block_bias
 
     # Establish symbolic shape constraints for Dynamo so that the three
     # independently-tracked symbolic variables:
-    #   s_bl  = block_list.size(0)           (from block_usage / block_groups)
-    #   s_bm  = block_mapping.shape[0]       (from one_hot(block_groups))
-    #   s_kc//block_size = key_cache dims    (from KV cache allocation)
-    # are all recognised as equal (= block_bucket_size).  Without these checks
-    # Dynamo cannot prove narrow()'s bounds (0 + s_bl <= s_kc//block_size) or
-    # the matmul broadcast (s_bm == s_bl) after a stash-restore recompilation.
+    #   s_bl  = block_list.size(0)           (= block_bucket_size for this batch)
+    #   s_bm  = block_mapping.shape[0]       (= block_bucket_size, from one_hot(block_groups))
+    #   s_kc//block_size                     (= total_kv_blocks from KV cache allocation)
+    # satisfy s_bl == s_bm <= s_kc//block_size.  Without these constraints Dynamo
+    # cannot prove narrow()'s bound (0 + s_bl <= s_kc//block_size) or the matmul
+    # broadcast (s_bm == s_bl) after a stash-restore recompilation.
+    # NOTE: the equality below is always True at runtime (both equal block_bucket_size).
+    # The inequality is also always True (batch blocks <= total KV blocks).
     torch._check(block_list.size(0) == block_mapping.shape[0])
-    torch._check(key_cache.shape[0] == block_mapping.shape[0] * block_size)
+    torch._check(block_mapping.shape[0] * block_size <= key_cache.shape[0])
 
     query_shape = (-1, q_heads, 1, head_size)
     query = batch2block(scale * query, block_mapping, batch2block_matmul_op).view(query_shape)

--- a/vllm_gaudi/extension/ops.py
+++ b/vllm_gaudi/extension/ops.py
@@ -173,7 +173,7 @@ def flat_pa_mla(query, key_cache, value_cache, block_list, block_mapping, block_
 
     key = key.transpose(1, 2)
     value = value.transpose(1, 2)
-    block_bias = block_bias.view(key.size(0), 1, 1, -1)
+    block_bias = block_bias.unsqueeze(1).unsqueeze(2)
     if kv_heads != q_heads:
         block_bias = block_bias.unsqueeze(1)
         query = query.unflatten(1, (kv_heads, -1))
@@ -225,7 +225,7 @@ def flat_pa(query, key_cache, value_cache, block_list, block_mapping, block_bias
                           **get_kv_fetch_extra_args(blocks=block_list, scales=k_scales_uf)).transpose(1, 2)
     value = values_fetch_func(value_cache.unflatten(0, (-1, block_size)),
                               **get_kv_fetch_extra_args(blocks=block_list, scales=v_scales_uf)).transpose(1, 2)
-    block_bias = block_bias.view(key.size(0), 1, 1, -1)
+    block_bias = block_bias.unsqueeze(1).unsqueeze(2)
     sink = None
     if sinks is not None:
         sinks = sinks.reshape(sinks.shape[0], 1)

--- a/vllm_gaudi/extension/ops.py
+++ b/vllm_gaudi/extension/ops.py
@@ -162,7 +162,6 @@ def flat_pa_mla(query, key_cache, value_cache, block_list, block_mapping, block_
     kv_heads = key_cache.size(1)
 
     query = batch2block(scale * query, block_mapping, batch2block_matmul_op).unsqueeze(-2)
-    n_blocks = query.shape[0]  # anchor for Dynamo: key/value must share this symbolic dim
     key = keys_fetch_func(key_cache.unflatten(0, (-1, block_size)), block_list)
     if value_cache is not None:
         value = values_fetch_func(value_cache.unflatten(0, (-1, block_size)), block_list)
@@ -172,9 +171,9 @@ def flat_pa_mla(query, key_cache, value_cache, block_list, block_mapping, block_
     else:
         assert False, "value_cache is None and kv_lora_rank is None"
 
-    key = key.transpose(1, 2)[:n_blocks]
-    value = value.transpose(1, 2)[:n_blocks]
-    block_bias = block_bias[:n_blocks].unsqueeze(1).unsqueeze(2)
+    key = key.transpose(1, 2)
+    value = value.transpose(1, 2)
+    block_bias = block_bias.unsqueeze(1).unsqueeze(2)
     if kv_heads != q_heads:
         block_bias = block_bias.unsqueeze(1)
         query = query.unflatten(1, (kv_heads, -1))
@@ -222,12 +221,11 @@ def flat_pa(query, key_cache, value_cache, block_list, block_mapping, block_bias
 
     query_shape = (-1, q_heads, 1, head_size)
     query = batch2block(scale * query, block_mapping, batch2block_matmul_op).view(query_shape)
-    n_blocks = query.shape[0]  # anchor for Dynamo: key/value must share this symbolic dim
     key = keys_fetch_func(key_cache.unflatten(0, (-1, block_size)),
-                          **get_kv_fetch_extra_args(blocks=block_list, scales=k_scales_uf)).transpose(1, 2)[:n_blocks]
+                          **get_kv_fetch_extra_args(blocks=block_list, scales=k_scales_uf)).transpose(1, 2)
     value = values_fetch_func(value_cache.unflatten(0, (-1, block_size)),
-                              **get_kv_fetch_extra_args(blocks=block_list, scales=v_scales_uf)).transpose(1, 2)[:n_blocks]
-    block_bias = block_bias[:n_blocks].unsqueeze(1).unsqueeze(2)
+                              **get_kv_fetch_extra_args(blocks=block_list, scales=v_scales_uf)).transpose(1, 2)
+    block_bias = block_bias.unsqueeze(1).unsqueeze(2)
     sink = None
     if sinks is not None:
         sinks = sinks.reshape(sinks.shape[0], 1)

--- a/vllm_gaudi/extension/ops.py
+++ b/vllm_gaudi/extension/ops.py
@@ -161,6 +161,10 @@ def flat_pa_mla(query, key_cache, value_cache, block_list, block_mapping, block_
     q_heads = query.size(1)
     kv_heads = key_cache.size(1)
 
+    # Same symbolic shape constraints as flat_pa — see comment there.
+    torch._check(block_list.size(0) == block_mapping.shape[0])
+    torch._check(key_cache.shape[0] == block_mapping.shape[0] * block_size)
+
     query = batch2block(scale * query, block_mapping, batch2block_matmul_op).unsqueeze(-2)
     n_blocks = query.shape[0]  # anchor for Dynamo: key/value must share this symbolic dim
     key = keys_fetch_func(key_cache.unflatten(0, (-1, block_size)), block_list)
@@ -219,6 +223,17 @@ def flat_pa(query, key_cache, value_cache, block_list, block_mapping, block_bias
         k_scales_uf = k_scales.unflatten(0, (-1, block_size))
     if v_scales is not None:
         v_scales_uf = (v_scales[0].unflatten(0, (-1, block_size)), v_scales[1])
+
+    # Establish symbolic shape constraints for Dynamo so that the three
+    # independently-tracked symbolic variables:
+    #   s_bl  = block_list.size(0)           (from block_usage / block_groups)
+    #   s_bm  = block_mapping.shape[0]       (from one_hot(block_groups))
+    #   s_kc//block_size = key_cache dims    (from KV cache allocation)
+    # are all recognised as equal (= block_bucket_size).  Without these checks
+    # Dynamo cannot prove narrow()'s bounds (0 + s_bl <= s_kc//block_size) or
+    # the matmul broadcast (s_bm == s_bl) after a stash-restore recompilation.
+    torch._check(block_list.size(0) == block_mapping.shape[0])
+    torch._check(key_cache.shape[0] == block_mapping.shape[0] * block_size)
 
     query_shape = (-1, q_heads, 1, head_size)
     query = batch2block(scale * query, block_mapping, batch2block_matmul_op).view(query_shape)

--- a/vllm_gaudi/extension/utils.py
+++ b/vllm_gaudi/extension/utils.py
@@ -84,7 +84,11 @@ class VLLMKVCache(torch.nn.Module):
         # keeps the zero-copy slice. We use an instance flag rather than a kwarg
         # because INC's PatchedVLLMKVCache wraps this method with a fixed signature.
         if self.use_contiguous_pa and not getattr(self, "_fetch_by_id", False):
-            return cache[:blocks.size(0)]
+            # Use narrow() instead of a Python slice [:n] so that Dynamo tracks
+            # the output's first dimension as blocks.size(0) (= block_bucket_size,
+            # the same symbolic variable as block_mapping.shape[0]) rather than
+            # collapsing it to cache.shape[0] via aten.slice's min(end, size) rule.
+            return cache.narrow(0, 0, blocks.size(0))
         else:
             return cache.index_select(0, blocks)
 

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -2378,11 +2378,13 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
             # keeps narrow()/shape checks in flat_pa valid and prevents OOB reads.
             kv_total_blocks = self._PAD_BLOCK_ID + 1
             if block_bucket_size > kv_total_blocks:
-                logger.warning(
-                    "block_bucket_size (%d) exceeds total KV blocks (%d); "
-                    "capping to prevent OOB after stash-restore. "
-                    "This is expected on a model swap with a smaller KV cache.",
-                    block_bucket_size, kv_total_blocks)
+                if not getattr(self, '_block_bucket_cap_warned', False):
+                    logger.warning(
+                        "block_bucket_size (%d) exceeds total KV blocks (%d); "
+                        "capping to prevent OOB after stash-restore. "
+                        "This is expected on a model swap with a smaller KV cache.",
+                        block_bucket_size, kv_total_blocks)
+                    self._block_bucket_cap_warned = True
                 block_bucket_size = kv_total_blocks
 
             indices: list[Any]

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -2371,6 +2371,19 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
                                                           actual_blocks_needed)[2]
             block_bucket_size += self.get_dp_padding(block_bucket_size)
             block_bucket_size = max(block_bucket_size, actual_blocks_needed)
+            # After a model stash-restore the KV cache may be reinitialized with
+            # fewer blocks than the bucket table was built for.  Cap so that
+            # block_bucket_size never exceeds the allocated KV cache size
+            # (PAD_BLOCK_ID + 1 = total_blocks including the pad block), which
+            # keeps narrow()/shape checks in flat_pa valid and prevents OOB reads.
+            kv_total_blocks = self._PAD_BLOCK_ID + 1
+            if block_bucket_size > kv_total_blocks:
+                logger.warning(
+                    "block_bucket_size (%d) exceeds total KV blocks (%d); "
+                    "capping to prevent OOB after stash-restore. "
+                    "This is expected on a model swap with a smaller KV cache.",
+                    block_bucket_size, kv_total_blocks)
+                block_bucket_size = kv_total_blocks
 
             indices: list[Any]
             indices = [None] * block_bucket_size

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -2382,8 +2382,7 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
                     logger.warning(
                         "block_bucket_size (%d) exceeds total KV blocks (%d); "
                         "capping to prevent OOB after stash-restore. "
-                        "This is expected on a model swap with a smaller KV cache.",
-                        block_bucket_size, kv_total_blocks)
+                        "This is expected on a model swap with a smaller KV cache.", block_bucket_size, kv_total_blocks)
                     self._block_bucket_cap_warned = True
                 block_bucket_size = kv_total_blocks
 


### PR DESCRIPTION
This pull request focuses on improving the safety and correctness of cache and tensor operations in the HPU model runner and related attention ops, particularly in scenarios involving dynamic cache sizes (such as after model stash-restore). The main changes ensure that tensor shapes are handled consistently and prevent potential out-of-bounds (OOB) memory access, while also enhancing compatibility with PyTorch Dynamo.

**Cache safety and dynamic sizing:**

* In `vllm_gaudi/v1/worker/hpu_model_runner.py`, added logic to cap `block_bucket_size` so it never exceeds the allocated KV cache size after a model stash-restore, preventing out-of-bounds reads and logging a warning when this situation is detected.

**Tensor shape handling and Dynamo compatibility:**

* In both `flat_pa_mla` and `flat_pa` functions in `vllm_gaudi/extension/ops.py`, replaced `.view()` with `.unsqueeze()` calls for `block_bias` (nice-to-have but not the core issue I faced with stash-restore mechanism)
* In `fetch_from_cache` in `vllm_gaudi/extension/utils.py`, replaced Python slicing with `.narrow()` to ensure that PyTorch Dynamo tracks the output's first dimension symbolically, maintaining correct shape propagation and avoiding shape collapsing issues.