### PR TITLE
Fix runtime errors on Qwen single process model swapping

### DIFF
--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -1,8 +1,10 @@
 import itertools
+from unittest.mock import MagicMock, patch
 
 import pytest
+import torch
 
-from vllm_gaudi.extension.utils import align_and_pad
+from vllm_gaudi.extension.utils import VLLMKVCache, align_and_pad
 from vllm_gaudi.utils import getattr_nested, setattr_nested
 
 
@@ -184,3 +186,74 @@ class TestSetattrNested:
         root = _Root()
         with pytest.raises(AttributeError):
             setattr_nested(root, "no_such.attr.value", 1)
+
+
+# ---------------------------------------------------------------------------
+# VLLMKVCache.fetch_from_cache – contiguous-PA fast path regression tests
+# (Why: narrow() makes blocks.size(0) > cache.size(0)
+#  a hard error vllm_gaudi/extension/utils.py ln 91; these tests verify both the valid-input behaviour and the
+#  out-of-bounds failure mode, as well as the _fetch_by_id escape hatch.)
+# ---------------------------------------------------------------------------
+
+
+def _make_kv_cache(use_contiguous_pa: bool) -> VLLMKVCache:
+    cfg = MagicMock()
+    cfg.use_contiguous_pa = use_contiguous_pa
+    cfg.per_token_kv_scaling_support = False
+    with patch("vllm_gaudi.extension.utils.get_config", return_value=cfg):
+        return VLLMKVCache()
+
+
+def _make_cache(n_blocks: int, cols: int = 4) -> torch.Tensor:
+    """Return a (n_blocks, cols) float tensor where row i has value i."""
+    return torch.arange(n_blocks * cols, dtype=torch.float32).view(n_blocks, cols)
+
+
+class TestVLLMKVCacheFetchFromCache:
+    """Regression tests for the contiguous-PA fast path in
+    VLLMKVCache.fetch_from_cache introduced via narrow() (PR #1604).
+    """
+
+    @pytest.fixture
+    def kv_cache(self):
+        return _make_kv_cache(use_contiguous_pa=True)
+
+    def test_returns_correct_rows_valid_input(self, kv_cache):
+        """Fast path must return rows 0..n-1, identical to cache[:n]."""
+        cache = _make_cache(8)
+        blocks = torch.arange(5)
+        result = kv_cache.fetch_from_cache(cache, blocks)
+        assert result.shape == (5, 4)
+        assert torch.equal(result, cache[:5])
+
+    def test_boundary_n_equals_cache_size(self, kv_cache):
+        """blocks.size(0) == cache.size(0) is a valid boundary case."""
+        cache = _make_cache(6)
+        blocks = torch.arange(6)
+        result = kv_cache.fetch_from_cache(cache, blocks)
+        assert torch.equal(result, cache)
+
+    def test_oob_raises_when_blocks_exceeds_cache(self, kv_cache):
+        """blocks.size(0) > cache.size(0) must raise (narrow() contract).
+        In normal operation the bucket-size cap in hpu_model_runner.py prevents
+        this; if the cap is bypassed this test catches the regression."""
+        cache = _make_cache(5)
+        blocks = torch.arange(8)  # 8 > 5
+        with pytest.raises(RuntimeError):
+            kv_cache.fetch_from_cache(cache, blocks)
+
+    def test_fetch_by_id_bypasses_fast_path(self, kv_cache):
+        """Setting _fetch_by_id routes to index_select for scattered IDs."""
+        kv_cache._fetch_by_id = True
+        cache = _make_cache(8)
+        blocks = torch.tensor([3, 1, 5])
+        result = kv_cache.fetch_from_cache(cache, blocks)
+        assert torch.equal(result, cache.index_select(0, blocks))
+
+    def test_non_contiguous_pa_uses_index_select(self):
+        """With use_contiguous_pa=False the cache is always gathered by ID."""
+        kv = _make_kv_cache(use_contiguous_pa=False)
+        cache = _make_cache(8)
+        blocks = torch.tensor([7, 2, 0])
+        result = kv.fetch_from_cache(cache, blocks)
+        assert torch.equal(result, cache.index_select(0, blocks))

--- a/vllm_gaudi/extension/ops.py
+++ b/vllm_gaudi/extension/ops.py
@@ -188,7 +188,7 @@ def flat_pa_mla(query, key_cache, value_cache, block_list, block_mapping, block_
 
     key = key.transpose(1, 2)
     value = value.transpose(1, 2)
-    block_bias = block_bias.view(key.size(0), 1, 1, -1)
+    block_bias = block_bias.unsqueeze(1).unsqueeze(2)
     if kv_heads != q_heads:
         block_bias = block_bias.unsqueeze(1)
         query = query.unflatten(1, (kv_heads, -1))
@@ -240,7 +240,7 @@ def flat_pa(query, key_cache, value_cache, block_list, block_mapping, block_bias
                           **get_kv_fetch_extra_args(blocks=block_list, scales=k_scales_uf)).transpose(1, 2)
     value = values_fetch_func(value_cache.unflatten(0, (-1, block_size)),
                               **get_kv_fetch_extra_args(blocks=block_list, scales=v_scales_uf)).transpose(1, 2)
-    block_bias = block_bias.view(key.size(0), 1, 1, -1)
+    block_bias = block_bias.unsqueeze(1).unsqueeze(2)
     sink = None
     if sinks is not None:
         sinks = sinks.reshape(sinks.shape[0], 1)

--- a/vllm_gaudi/extension/utils.py
+++ b/vllm_gaudi/extension/utils.py
@@ -84,7 +84,11 @@ class VLLMKVCache(torch.nn.Module):
         # keeps the zero-copy slice. We use an instance flag rather than a kwarg
         # because INC's PatchedVLLMKVCache wraps this method with a fixed signature.
         if self.use_contiguous_pa and not getattr(self, "_fetch_by_id", False):
-            return cache[:blocks.size(0)]
+            # Use narrow() instead of a Python slice [:n] so that Dynamo tracks
+            # the output's first dimension as blocks.size(0) (= block_bucket_size,
+            # the same symbolic variable as block_mapping.shape[0]) rather than
+            # collapsing it to cache.shape[0] via aten.slice's min(end, size) rule.
+            return cache.narrow(0, 0, blocks.size(0))
         else:
             return cache.index_select(0, blocks)
 

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -2431,6 +2431,28 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
                                                           actual_blocks_needed)[2]
             block_bucket_size += self.get_dp_padding(block_bucket_size)
             block_bucket_size = max(block_bucket_size, actual_blocks_needed)
+            # After a model stash-restore the KV cache may be reinitialized with
+            # fewer blocks than the bucket table was built for.  Cap so that
+            # block_bucket_size never exceeds the allocated KV cache size
+            # (PAD_BLOCK_ID + 1 = total_blocks including the pad block), which
+            # keeps narrow()/shape checks in flat_pa valid and prevents OOB reads.
+            kv_total_blocks = self._PAD_BLOCK_ID + 1
+            if block_bucket_size > kv_total_blocks:
+                # Fail fast if actual requests need more blocks than are
+                # allocated.
+                if actual_blocks_needed > kv_total_blocks:
+                    raise RuntimeError(f"actual_blocks_needed ({actual_blocks_needed}) "
+                                       f"exceeds total KV blocks ({kv_total_blocks}). "
+                                       "The KV cache is under-provisioned for the current "
+                                       "batch; cannot proceed safely after stash-restore.")
+                if not getattr(self, '_block_bucket_cap_warned', False):
+                    logger.warning(
+                        "block_bucket_size (%d) exceeds total KV blocks "
+                        "(%d); capping to prevent OOB after stash-restore. "
+                        "This is expected on a model swap with a smaller "
+                        "KV cache.", block_bucket_size, kv_total_blocks)
+                    self._block_bucket_cap_warned = True
+                block_bucket_size = kv_total_blocks
 
             indices: list[Any]
             indices = [None] * block_bucket_size


### PR DESCRIPTION
This pull request focuses on improving the safety and correctness of cache and tensor operations in the HPU model runner and related attention ops, particularly in scenarios involving dynamic cache sizes (such as after model stash-restore). The main changes ensure that tensor shapes are handled consistently and prevent potential out-of-bounds (OOB) memory access, while also enhancing compatibility with PyTorch Dynamo.

**Cache safety and dynamic sizing:**

* In `vllm_gaudi/v1/worker/hpu_model_runner.py`, added logic to cap `block_bucket_size` so it never exceeds the allocated KV cache size after a model stash-restore, preventing out-of-bounds reads and logging a warning when this situation is detected.

**Tensor shape handling and Dynamo compatibility:**

* In both `flat_pa_mla` and `flat_pa` functions in `vllm_gaudi/extension/ops.py`, replaced `.view()` with `.unsqueeze()` calls for `block_bias` (nice-to-have but not the core issue I faced with stash-restore mechanism)
* In `fetch_from_cache` in `vllm_gaudi/extension/utils.py`, replaced Python slicing with `.narrow()` to ensure that PyTorch Dynamo tracks the output's first dimension symbolically, maintaining correct shape propagation and avoiding shape collapsing issues.