### PR TITLE
[v0.24.0] Fix dense-model INC quant OOM regression from #1590 (GAUDISW-250139)

### DIFF
--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -282,6 +282,24 @@ def _move_remaining_tensors_to_device(model: torch.nn.Module, device: str) -> No
         logger.info("Moved %d stray tensors to %s", moved, device)
 
 
+def _model_has_moe_experts(model: torch.nn.Module) -> bool:
+    """Return True if the model has any fused-MoE op with per-expert weight views.
+
+    Only MoE models carry the ``moe_op`` (``VllmMixtureOfExpertsOpBase``) whose
+    per-expert ``MoeMatmul.weight`` attributes are plain-tensor views that go
+    stale after ``model.to(device)`` and must be rebound. Dense models (e.g.
+    Llama-3.3-70B) have none, so the INC pre-stage ``model.to('hpu')`` + rebind
+    is pure overhead for them -- and worse, it eagerly materializes the full
+    (pre-quantization) weights on a single card, OOMing large dense models
+    before ``convert()`` can shrink them (GAUDISW-250139).
+    """
+    from vllm_gaudi.extension.ops import VllmMixtureOfExpertsOpBase  # local to avoid circular import
+    for module in model.modules():
+        if isinstance(getattr(module, "moe_op", None), VllmMixtureOfExpertsOpBase):
+            return True
+    return False
+
+
 def _rebind_moe_expert_weights(model: torch.nn.Module) -> None:
     """Re-derive MoeMatmul.weight slices from the parent layer's registered weights.
 
@@ -4697,7 +4715,16 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
                 # INC's internal move is a no-op. (Regressed by upstream PR #41184
                 # moving the weights onto a RoutedExperts child, which changed the
                 # .to() traversal order.)
-                if not is_fake_hpu():
+                #
+                # Restrict this pre-stage to MoE models only. Dense models have no
+                # moe_op views to rebind, so the pre-stage move is pure overhead --
+                # and for a large dense model (e.g. Llama-3.3-70B FP8 on 1 card) it
+                # eagerly materializes the full pre-quantization weights on device
+                # BEFORE convert() can shrink them, OOMing on model.to('hpu')
+                # (GAUDISW-250139). Leaving dense models on host until the post-INC
+                # move restores the pre-#1590 behavior that convert() shrinks them
+                # first.
+                if not is_fake_hpu() and _model_has_moe_experts(self.model):
                     self.model = self.model.to("hpu")
                     _rebind_moe_expert_weights(self.model)
                     htorch.core.mark_step()

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -294,10 +294,8 @@ def _model_has_moe_experts(model: torch.nn.Module) -> bool:
     before ``convert()`` can shrink them.
     """
     from vllm_gaudi.extension.ops import VllmMixtureOfExpertsOpBase  # local to avoid circular import
-    for module in model.modules():
-        if isinstance(getattr(module, "moe_op", None), VllmMixtureOfExpertsOpBase):
-            return True
-    return False
+    return any(
+        isinstance(getattr(module, "moe_op", None), VllmMixtureOfExpertsOpBase) for module in model.modules())
 
 
 def _rebind_moe_expert_weights(model: torch.nn.Module) -> None:

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -294,8 +294,7 @@ def _model_has_moe_experts(model: torch.nn.Module) -> bool:
     before ``convert()`` can shrink them.
     """
     from vllm_gaudi.extension.ops import VllmMixtureOfExpertsOpBase  # local to avoid circular import
-    return any(
-        isinstance(getattr(module, "moe_op", None), VllmMixtureOfExpertsOpBase) for module in model.modules())
+    return any(isinstance(getattr(module, "moe_op", None), VllmMixtureOfExpertsOpBase) for module in model.modules())
 
 
 def _rebind_moe_expert_weights(model: torch.nn.Module) -> None:

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -291,7 +291,7 @@ def _model_has_moe_experts(model: torch.nn.Module) -> bool:
     Llama-3.3-70B) have none, so the INC pre-stage ``model.to('hpu')`` + rebind
     is pure overhead for them -- and worse, it eagerly materializes the full
     (pre-quantization) weights on a single card, OOMing large dense models
-    before ``convert()`` can shrink them (GAUDISW-250139).
+    before ``convert()`` can shrink them.
     """
     from vllm_gaudi.extension.ops import VllmMixtureOfExpertsOpBase  # local to avoid circular import
     for module in model.modules():
@@ -4720,10 +4720,9 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
                 # moe_op views to rebind, so the pre-stage move is pure overhead --
                 # and for a large dense model (e.g. Llama-3.3-70B FP8 on 1 card) it
                 # eagerly materializes the full pre-quantization weights on device
-                # BEFORE convert() can shrink them, OOMing on model.to('hpu')
-                # (GAUDISW-250139). Leaving dense models on host until the post-INC
-                # move restores the pre-#1590 behavior that convert() shrinks them
-                # first.
+                # BEFORE convert() can shrink them, OOMing on model.to('hpu').
+                # Leaving dense models on host until the post-INC move restores the
+                # pre-#1590 behavior that convert() shrinks them first.
                 if not is_fake_hpu() and _model_has_moe_experts(self.model):
                     self.model = self.model.to("hpu")
                     _rebind_moe_expert_weights(self.model)


### PR DESCRIPTION
## Problem

**GAUDISW-250139** (P1-Stopper). Dense FP8 INC-quantized serving OOMs on model load:

```
llama3_3_70b_1xcard_fp8_4096_1024_torch_compile_serving_benchmark_vllm_v1_g3
```

```
File ".../vllm_gaudi/v1/worker/hpu_model_runner.py", line 4701, in load_model
    self.model = self.model.to("hpu")
RuntimeError: [Rank:0] FATAL ERROR :: MODULE:PT_DEVMEM Allocation failed for size::134217728 (128)MB
```

- First bad build: `0.24.0rc1.dev21+gf1568b28c`; last good: `0.24.0rc1.dev18+gc73fd5221`.
- Culprit commit identified by QA: **`ffe0900c` (PR #1590)** — "Fix Maverick FP8 INC calibration OOM after #41184 MoE refactor".

## Root cause

PR #1590 added an **unconditional** pre-stage `self.model.to("hpu")` before INC `prepare()`/`convert()`, so MoE per-expert weight views (`moe_op` / `MoeMatmul.weight`) could be rebound onto the moved on-device Parameters and avoid duplicate copies on large EP models (Llama-4 Maverick TP8/EP8).

That pre-stage move is only meaningful for **MoE** models — dense models have no `moe_op` views to rebind. For a large **dense** model quantized with INC on a single card (Llama-3.3-70B FP8, TP1, `--quantization inc`, `--gpu-memory-util 0.6`), the move eagerly materializes the **full bf16 weights** on device *before* `convert()` can shrink them to fp8, exceeding HBM and crashing at `model.to("hpu")`.

Pre-#1590 the dense model stayed on host through `convert()`; only the smaller post-quantized model was moved to HPU.

## Fix

Gate the pre-stage move + rebind on a new `_model_has_moe_experts()` check. Dense models now stay on host through `prepare()`/`convert()` and are moved to HPU only by the unconditional **post-INC** block — restoring the pre-#1590 behavior where `convert()` shrinks the weights first. MoE models (the case #1590 fixed) take the identical path as before.

Minimal, MoE-scoped, no behavior change for expert-parallel models.

## Validation

- [ ] Llama-3.3-70B FP8 1-card `--quantization inc` serving starts (repro of GAUDISW-250139) — *in progress on Gaudi3 pod*
- [ ] Llama-4-Maverick FP8 TP8/EP8 (original #1590 case) still starts — no regression

Draft for QA to validate in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)