### PR TITLE
Fix model banner and runtime logging issues - multi models runs

### DIFF
--- a/vllm_gaudi/entrypoints/openai/multi_model_api_server.py
+++ b/vllm_gaudi/entrypoints/openai/multi_model_api_server.py
@@ -710,6 +710,11 @@ async def _run_multi_model_server_worker(
 async def _run_multi_model_server(args: Namespace) -> None:
     decorate_logs("APIServer")
 
+    # Patch args.model with the actual default model from the multi-model config
+    # so that setup_server logs the correct model name in the banner.
+    config = _load_multi_model_config(_resolve_multi_model_config_path())
+    args.model = config.model_configs[config.default_model].model
+
     listen_address, sock = setup_server(args, reuse_port=False)
     await _run_multi_model_server_worker(listen_address, sock, args)
 

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -32,7 +32,7 @@ from vllm_gaudi.extension.bucketing.common import HPUBucketingManager
 from vllm_gaudi.extension.defragmentation import OnlineDefragmenter
 from vllm_gaudi.extension.profiler import (HabanaHighLevelProfiler, HabanaMemoryProfiler, HabanaProfilerCounterHelper,
                                            format_bytes, setup_profiler)
-from vllm_gaudi.extension.runtime import finalize_config, get_config
+from vllm_gaudi.extension.runtime import clear_config, finalize_config, get_config
 from vllm_gaudi.extension.utils import align_and_pad, pad_list, with_default
 from vllm_gaudi.extension.debug import init_debug_logger
 from vllm_gaudi.v1.worker.hpu_dp_utils import set_hpu_dp_metadata
@@ -1239,6 +1239,7 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
         # TODO: use ModelRunnerBase.__init__(self, vllm_config=vllm_config)
         environment.set_vllm_config(vllm_config)
 
+        clear_config()
         finalize_config()
         self.vllm_config = vllm_config
         self.model_config = vllm_config.model_config


### PR DESCRIPTION

**Configuration Handling Improvements**

* In `vllm_gaudi/v1/worker/hpu_model_runner.py`, the `clear_config()` function is now called before `finalize_config()` during initialization to ensure a clean and accurate configuration state for each model runner instance. 
* In `multi_model_api_server.py`, the server now patches `args.model` with the actual default model from the multi-model config before server setup. This ensures that the correct model name is logged in the server banner, improving clarity and debugging.

Overall marginal changes, not to have misleading logs