### PR TITLE
Port of #1607: Warn when calibrate_model.sh -u is used on TP>1 without -r

### DIFF
--- a/calibration/calibrate_model.sh
+++ b/calibration/calibrate_model.sh
@@ -22,7 +22,7 @@ usage() {
     echo "  -l    - limit number of samples in calibration dataset"
     echo "  -t    - tensor parallel size to run at (default: 1); NOTE: if t > 8 then we need a multi-node setup"
     echo "  -r    - rank of unified measurements, it should be smaller than original rank number and should be a factor of the original rank number"
-    echo "  -u    - unify measurement results based on expert parallelism rules (default: False), expert parallelism unification rule is unique, card 1 expert measurement will be extended to card 0 if unified to x from 2x cards number"
+    echo "  -u    - measure/quantize with expert parallelism and unify results based on expert-parallelism rules (default: False); the unification rule is unique, card 1 expert measurement will be extended to card 0 if unified to x from 2x cards number. NOTE: the unify step runs only when -r is also given; with TP>1 and -u but no -r the per-rank measurements are NOT unified and cover only each rank's EP-local experts, which degrades FP8 accuracy for many-expert MoE models (e.g. Llama-4 Maverick, DeepSeek)"
     echo "  -e    - set this flag to enable enforce_eager execution"
     echo
 }
@@ -138,6 +138,27 @@ if [[ -z "$MODEL_PATH" && -z "$FP8_DIR" && -z "$DATASET_PATH_OR_NAME" ]]; then
     echo "Model stub, source dataset path and output path for fp8 measurements must be provided."
     usage
     exit 1
+fi
+
+# With -u, measure/quantize (steps 2/4) run with expert parallelism, so on
+# TP>1 each rank only measures its EP-LOCAL experts (e.g. 16 of 128 per rank
+# for Llama-4 Maverick on TP8). The unify step (step 5) then merges these
+# per-rank sets back into the full global expert set - but it runs only when a
+# target rank is given via -r. Passing -u with TP>1 but WITHOUT -r leaves the
+# per-rank measurements un-unified: for models whose experts are split across
+# ranks, the resulting scales cover only the local experts, and the rest fall
+# back to coarse quantization at serve time -> FP8 accuracy loss. Warn so this
+# is caught early. (Small-expert models like Mixtral are unaffected.)
+if [[ -n "$USE_EP" && -z "$RANK" && $TP_SIZE -gt 1 ]]; then
+    echo "WARNING: -u is set with tensor-parallel size $TP_SIZE but -r is not." >&2
+    echo "         Steps 2/4 measure experts with expert parallelism (per-rank," >&2
+    echo "         EP-local experts only), and the unify step that merges them into" >&2
+    echo "         the full expert set runs only when -r is given. Without -r the" >&2
+    echo "         measurements may cover only each rank's local experts, which" >&2
+    echo "         degrades FP8 accuracy for models with many experts (e.g. Llama-4" >&2
+    echo "         Maverick, DeepSeek). Re-run with -r (e.g. -r 1 to unify onto a" >&2
+    echo "         single card), then use step-6-expand-measurements.py to expand to" >&2
+    echo "         the target card count. See the calibration docs (MoE section)." >&2
 fi
 
 # Store the provided MODEL_PATH name in a variable

--- a/docs/configuration/calibration/calibration.md
+++ b/docs/configuration/calibration/calibration.md
@@ -32,6 +32,8 @@ The calibration procedure works with any dataset that contains the `system_promp
 
 For the [DeepSeek-R1](https://huggingface.co/collections/deepseek-ai/deepseek-r1-678e1e131c0169c0bc89728d) series models, which contain 256 experts, provide a diverse and sufficiently large sample set to ensure that all experts are properly activated during calibration. Through testing, we observed that using [NeelNanda/pile-10k](https://huggingface.co/datasets/NeelNanda/pile-10k) and selecting 512 samples, each with at least 1,024 tokens, provides effective calibration coverage.
 
+> **Important (MoE models calibrated with expert parallelism).** When you calibrate a Mixture-of-Experts model with `-u` (expert parallelism) on more than one card, each rank only measures its **EP-local** experts (for example, 16 of 128 experts per rank for Llama-4 Maverick on TP8/EP8). These per-rank measurements must be unified so that every expert has its own scale, otherwise the non-local experts fall back to coarse quantization at serve time and FP8 accuracy drops. The unify step runs only when a target rank is given, so pass **both `-u` and `-r`** to `calibrate_model.sh` (for example `-r 1` to unify onto a single card), then use `step-6-expand-measurements.py` to expand to the deployment card count. **Passing `-u` with `TP>1` but without `-r` skips unification** and leaves only the EP-local experts measured. (Small-expert models such as Mixtral are not affected.) See the [MoE recommendations](calibration_multi_node.md#recommendations-for-advanced-usage-for-moe-models) for the full unify-and-expand procedure.
+
 ## Calibration Procedures
 
 Refer to the following chapters to follow the calibration procedure for your setup:


### PR DESCRIPTION
Port of #1607 from `releases/v0.24.0` to `main`.

## Problem
With `-u`, the measure/quantize steps (2 and 4) run with expert parallelism, so on `TP>1` each rank only measures its **EP-local** experts (e.g. 16 of 128 for Llama-4 Maverick on TP8). The unify step (step 5) merges these per-rank measurements back into the full expert set, but it runs **only when a target rank is given via `-r`**.

Passing `-u` on `TP>1` without `-r` therefore leaves the measurements covering only each rank's local experts. For models with many experts split across ranks (Llama-4 Maverick, DeepSeek), the non-local experts get no dedicated scale and fall back to coarse quantization at serve time, which lowers FP8 accuracy. There is no error today — just a silently worse result. (Small-expert models such as Mixtral are unaffected.)

## Change
- Emit a warning when `-u` is set with `TP>1` but `-r` is missing.
- Clarify the `-u` help text (it also enables expert parallelism in steps 2/4; unification needs `-r`).
- Document the unify requirement for MoE models in the calibration docs.

No behavior change to existing valid workflows.

## Port note
Cherry-picked cleanly from `releases/v0.24.0` (`ff44a3f9`); the ported diff is byte-identical to the original. Documentation/shell-only change.
