### PR TITLE
[FIX_FOR_VLLM_CUSTOM=e23b19309b8705b21c3b3ff4129c9974ba15a419] Resolve 10 vLLM API-drift breaks (MoE/MLA/quant/server/attn)

### DIFF
--- a/vllm_gaudi/entrypoints/openai/multi_model_api_server.py
+++ b/vllm_gaudi/entrypoints/openai/multi_model_api_server.py
@@ -710,7 +710,7 @@ async def _run_multi_model_server_worker(
 async def _run_multi_model_server(args: Namespace) -> None:
     decorate_logs("APIServer")
 
-    listen_address, sock = setup_server(args)
+    listen_address, sock = setup_server(args, reuse_port=False)
     await _run_multi_model_server_worker(listen_address, sock, args)
 
 

--- a/vllm_gaudi/entrypoints/openai/multi_model_api_server.py
+++ b/vllm_gaudi/entrypoints/openai/multi_model_api_server.py
@@ -30,7 +30,6 @@ from vllm.entrypoints.openai.models.serving import OpenAIServingModels
 from vllm.entrypoints.serve.utils.server_utils import get_uvicorn_log_config
 from vllm.entrypoints.scale_out.render.serving import ServingRender
 from vllm.entrypoints.serve.tokenize.serving import ServingTokenization
-from vllm.renderers.online_derenderer import OnlineDerenderer
 from vllm.renderers.online_renderer import OnlineRenderer
 from vllm.entrypoints.serve.utils.api_utils import cli_env_setup, process_lora_modules
 from vllm.logger import init_logger
@@ -501,10 +500,10 @@ async def _init_multi_model_state(
     resolved_chat_template = load_chat_template(frontend_settings.chat_template)
 
     # Upstream vllm#44285 split OpenAIServingRender into a thin entrypoint
-    # (ServingRender) plus an OnlineRenderer/OnlineDerenderer pair that own the
-    # chat-template, tool and reasoning configuration. Mirror that construction
-    # here so the multi-model server matches the engine-backed api_server path.
-    # vllm#44512 (scale-out consolidation) then dropped the derenderer arg from
+    # (ServingRender) plus an OnlineRenderer that owns the chat-template, tool
+    # and reasoning configuration. Mirror that construction here so the
+    # multi-model server matches the engine-backed api_server path. vllm#44512
+    # (scale-out consolidation) then dropped the derenderer arg from
     # ServingRender.__init__; derender now lives in a separate ServingDerender.
     render_kwargs = dict(
         model_config=engine_client.model_config,
@@ -520,7 +519,6 @@ async def _init_multi_model_state(
         log_error_stack=args.log_error_stack,
     )
     state.online_renderer = OnlineRenderer(**render_kwargs)
-    state.online_derenderer = OnlineDerenderer(**render_kwargs)
 
     state.openai_serving_render = ServingRender(
         state.openai_serving_models,

--- a/vllm_gaudi/entrypoints/openai/multi_model_api_server.py
+++ b/vllm_gaudi/entrypoints/openai/multi_model_api_server.py
@@ -28,7 +28,7 @@ from vllm.entrypoints.openai.cli_args import make_arg_parser, validate_parsed_se
 from vllm.entrypoints.openai.models.protocol import BaseModelPath
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
 from vllm.entrypoints.serve.utils.server_utils import get_uvicorn_log_config
-from vllm.entrypoints.serve.render.serving import ServingRender
+from vllm.entrypoints.scale_out.render.serving import ServingRender
 from vllm.entrypoints.serve.tokenize.serving import ServingTokenization
 from vllm.renderers.online_derenderer import OnlineDerenderer
 from vllm.renderers.online_renderer import OnlineRenderer
@@ -504,6 +504,8 @@ async def _init_multi_model_state(
     # (ServingRender) plus an OnlineRenderer/OnlineDerenderer pair that own the
     # chat-template, tool and reasoning configuration. Mirror that construction
     # here so the multi-model server matches the engine-backed api_server path.
+    # vllm#44512 (scale-out consolidation) then dropped the derenderer arg from
+    # ServingRender.__init__; derender now lives in a separate ServingDerender.
     render_kwargs = dict(
         model_config=engine_client.model_config,
         renderer=engine_client.renderer,
@@ -523,7 +525,6 @@ async def _init_multi_model_state(
     state.openai_serving_render = ServingRender(
         state.openai_serving_models,
         state.online_renderer,
-        state.online_derenderer,
         request_logger=request_logger,
     )
 

--- a/vllm_gaudi/extension/ops.py
+++ b/vllm_gaudi/extension/ops.py
@@ -953,17 +953,27 @@ def gaudi_weight_wrapper(weight_loader):
 
     def wrapper(*args, **kwargs):
         if get_config().scale_adjustment:
-            # args[0] is parameter, args[1] is loaded_weight
+            # loaded_weight may be passed positionally (args[1]) or as a
+            # keyword. Upstream FusedMoE (vllm#47197) now calls
+            # param.weight_loader(param=..., loaded_weight=..., ...) with
+            # keyword-only args, so probe both.
             # weights will be always in fp8, but scales will be in fp32,
             # so we can detect it by dtype
-            loaded_weight = args[1]
+            in_kwargs = "loaded_weight" in kwargs
+            if in_kwargs:
+                loaded_weight = kwargs["loaded_weight"]
+            else:
+                loaded_weight = args[1]
             if loaded_weight.dtype == torch.float8_e4m3fn:
                 loaded_weight = (loaded_weight.float() * 0.5).to(torch.float8_e4m3fn)
             else:
                 loaded_weight = (loaded_weight.data * 2.0)
-            args = (args[0], loaded_weight) + args[2:]
+            if in_kwargs:
+                kwargs["loaded_weight"] = loaded_weight
+            else:
+                args = (args[0], loaded_weight) + args[2:]
 
-        weight_loader(*args, **kwargs)
+        return weight_loader(*args, **kwargs)
 
     return wrapper
 

--- a/vllm_gaudi/models/deepseek_v2.py
+++ b/vllm_gaudi/models/deepseek_v2.py
@@ -1,5 +1,9 @@
 import torch
+from itertools import islice
+
+from vllm.distributed import get_pp_group
 from vllm.model_executor.models import deepseek_v2
+from vllm.sequence import IntermediateTensors
 
 
 def _get_hpu_llama_4_scaling(original_max_position_embeddings: int, scaling_beta: float,
@@ -13,3 +17,69 @@ def _get_hpu_llama_4_scaling(original_max_position_embeddings: int, scaling_beta
 
 
 deepseek_v2._get_llama_4_scaling = _get_hpu_llama_4_scaling
+
+
+def _hpu_deepseek_v2_model_forward(
+    self,
+    input_ids: torch.Tensor | None,
+    positions: torch.Tensor,
+    intermediate_tensors: IntermediateTensors | None,
+    inputs_embeds: torch.Tensor | None = None,
+) -> torch.Tensor | IntermediateTensors:
+    """HPU DeepseekV2Model.forward without the TP sequence-parallel all-gather.
+
+    Upstream vllm #46635 (5c91039c41) added a ``torch.cat([hidden_states,
+    residual])`` all-gather block gated on ``hidden_states.shape[0] !=
+    positions.shape[0]``. That guard assumes the GPU shape contract (flat 2D
+    hidden_states, 1D positions). On HPU ``positions`` is 2D ``[bs, seq]`` while
+    ``DeepseekV2MoE.forward`` returns a flattened ``[bs*seq, H]``, so the guard
+    fires spuriously for any prompt and crashes cat'ing a 2D tensor with a 3D
+    residual. HPU handles MoE parallelism in its own kernels, so this block is
+    dead here — restore the pre-#46635 plain loop.
+    """
+    if get_pp_group().is_first_rank:
+        if inputs_embeds is not None:
+            hidden_states = inputs_embeds
+        else:
+            if input_ids is None:
+                raise ValueError("Either input_ids or inputs_embeds must be provided "
+                                 "to DeepseekV2Model.forward")
+            hidden_states = self.embed_input_ids(input_ids)
+        residual = None
+    else:
+        assert intermediate_tensors is not None
+        hidden_states = intermediate_tensors["hidden_states"]
+        residual = intermediate_tensors["residual"]
+
+    # Compute llama 4 scaling once per forward pass if enabled
+    llama_4_scaling_config = getattr(self.config, "llama_4_scaling", None)
+    llama_4_scaling: torch.Tensor | None
+    if llama_4_scaling_config is not None:
+        llama_4_scaling = deepseek_v2._get_llama_4_scaling(
+            original_max_position_embeddings=llama_4_scaling_config["original_max_position_embeddings"],
+            scaling_beta=llama_4_scaling_config["beta"],
+            positions=positions,
+        )
+    else:
+        llama_4_scaling = None
+
+    aux_hidden_states = []
+    for idx, layer in enumerate(
+            islice(self.layers, self.start_layer, self.end_layer),
+            start=self.start_layer,
+    ):
+        if idx in self.aux_hidden_state_layers:
+            aux_hidden_states.append(hidden_states + residual)
+        hidden_states, residual = layer(positions, hidden_states, residual, llama_4_scaling)
+
+    if not get_pp_group().is_last_rank:
+        return IntermediateTensors({"hidden_states": hidden_states, "residual": residual})
+
+    hidden_states, _ = self.norm(hidden_states, residual)
+    if len(aux_hidden_states) > 0:
+        return hidden_states, aux_hidden_states
+    return hidden_states
+
+
+# Applies to DeepseekV2/V3/Deepseek/GlmMoe/DSA — all share model_cls = DeepseekV2Model.
+deepseek_v2.DeepseekV2Model.forward = _hpu_deepseek_v2_model_forward

--- a/vllm_gaudi/models/qwen3_5.py
+++ b/vllm_gaudi/models/qwen3_5.py
@@ -123,14 +123,18 @@ class HPUGatedDeltaNetAttention(QwenGatedDeltaNetAttention):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        output: torch.Tensor,
-    ):
+    ) -> torch.Tensor:
         """HPU compile-friendly GDN forward.
 
         Bypasses the upstream ``gdn_attention_core`` custom-op and
         drives the HPU conv1d + GDN kernels directly with
         ``HPUAttentionMetadataV1``.
+
+        Return-based since upstream vLLM #46998 (300e33797f) dropped the
+        ``output`` in-place buffer; caller now does
+        ``hidden_states = self.linear_attn(hidden_states=...)``.
         """
+        orig_shape = hidden_states.shape
         hidden_states = hidden_states.view(-1, hidden_states.size(-1))
         num_tokens = hidden_states.size(0)
 
@@ -289,8 +293,10 @@ class HPUGatedDeltaNetAttention(QwenGatedDeltaNetAttention):
         core_attn_out = core_attn_out.reshape(z_shape_og)
         core_attn_out = core_attn_out.flatten(-2)
 
-        output_flat = output.view(-1, output.size(-1))
-        output_flat[:num_tokens], _ = self.out_proj(core_attn_out)
+        output, _ = self.out_proj(core_attn_out)
+        # Restore caller's original layout (2-D flat or 3-D [B, L, H]) so
+        # the residual add in the decoder layer stays shape-consistent.
+        return output.view(orig_shape)
 
 
 # Replace the class in the upstream modules so that both Qwen3-Next and

--- a/vllm_gaudi/models/qwen3_next.py
+++ b/vllm_gaudi/models/qwen3_next.py
@@ -13,32 +13,38 @@ _orig_qwen3next_attention_forward = Qwen3NextAttention.forward
 # ====================================================================
 # Qwen3NextAttention.forward  (full-attention layers)
 # Patch any 3D layout (decode or bucketed prefill with BS > 1):
-#   hidden_states: [B, L, H],  output: [B, L, H_out]
+#   hidden_states: [B, L, H] -> returns [B, L, H_out]
+#
+# Return-based since upstream vLLM #46998 (300e33797f) dropped the
+# ``output`` in-place buffer; caller now does
+#   hidden_states = self.self_attn(hidden_states=..., positions=...)
 # ====================================================================
-def _hpu_qwen3next_attention_forward(self, positions, output, hidden_states):
+def _hpu_qwen3next_attention_forward(self, positions, hidden_states):
 
     # Patch any 3D layout (BS > 1):
-    #   Decode:  hidden_states [B, 1, H],  output [B, 1, H_out]
-    #   Prefill: hidden_states [B, L, H],  output [B, L, H_out]
+    #   Decode:  hidden_states [B, 1, H]
+    #   Prefill: hidden_states [B, L, H]
     #
     # Upstream forward assumes 2D (tokens, dim) for attn_output but
     # preserves 3D for gate when hidden_states is 3D, causing a shape
     # mismatch in `attn_output * gate`.  We flatten both to 2D.
-    is_3d = (hidden_states is not None and output is not None and hidden_states.dim() == 3 and output.dim() == 3)
+    is_3d = (hidden_states is not None and hidden_states.dim() == 3)
     if not is_3d:
-        return _orig_qwen3next_attention_forward(self, positions, output, hidden_states)
+        return _orig_qwen3next_attention_forward(self, positions, hidden_states)
+
+    orig_shape = hidden_states.shape
 
     qkv, _ = self.qkv_proj(hidden_states)
 
     gate = None
     if self.attn_output_gate:
         q_gate, k, v = qkv.split([self.q_size * 2, self.kv_size, self.kv_size], dim=-1)
-        orig_shape = q_gate.shape[:-1]
-        q_gate = q_gate.view(*orig_shape, self.num_heads, -1)
+        gate_shape = q_gate.shape[:-1]
+        q_gate = q_gate.view(*gate_shape, self.num_heads, -1)
         q, gate = torch.chunk(q_gate, 2, dim=-1)
 
-        q = q.reshape(*orig_shape, -1)
-        gate = gate.reshape(*orig_shape, -1)
+        q = q.reshape(*gate_shape, -1)
+        gate = gate.reshape(*gate_shape, -1)
     else:
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
 
@@ -58,10 +64,9 @@ def _hpu_qwen3next_attention_forward(self, positions, output, hidden_states):
 
     proj_out, _ = self.o_proj(attn_output_2d)
 
-    # Output buffer may be [B, 1, H_out] in decode.
-    output_2d = output.view(-1, output.shape[-1])
-    proj_out_2d = proj_out.view(-1, proj_out.shape[-1])
-    output_2d[:proj_out_2d.shape[0]].copy_(proj_out_2d)
+    # Restore caller's original 3-D layout [B, L, H_out] so the residual
+    # add in the decoder layer stays shape-consistent.
+    return proj_out.view(*orig_shape[:-1], proj_out.shape[-1])
 
 
 # ====================================================================

--- a/vllm_gaudi/ops/hpu_awq.py
+++ b/vllm_gaudi/ops/hpu_awq.py
@@ -48,6 +48,7 @@ class AWQHPUConfig(QuantizationConfig):
         zero_point: bool,
         modules_to_not_convert: Optional[list[str]] = None,
     ) -> None:
+        super().__init__()
         self.weight_bits = weight_bits
         self.group_size = group_size
         self.zero_point = zero_point

--- a/vllm_gaudi/ops/hpu_compressed_tensors.py
+++ b/vllm_gaudi/ops/hpu_compressed_tensors.py
@@ -1188,6 +1188,14 @@ def oot_maybe_remap_kv_scale_name(name: str, params_dict: dict) -> str | None:
         None: If the remapped name is not found in params_dict.
     """
 
+    # Already in vLLM's expected form. Upstream `base_config.get_cache_scale_mapper`
+    # (activated in vllm #44589) now pre-maps raw checkpoint scales to their
+    # `.attn.` form in `AutoWeightsLoader` before this OOT remap runs, so for
+    # regular attention the pre-mapped name already matches a param. Skip the
+    # regex remap, which would otherwise double-apply the `.attn` prefix.
+    if name in params_dict:
+        return name
+
     if name.endswith(".kv_scale"):
         logger.warning_once("DEPRECATED. Found kv_scale in the checkpoint. "
                             "This format is deprecated in favor of separate k_scale and "
@@ -1213,6 +1221,18 @@ def oot_maybe_remap_kv_scale_name(name: str, params_dict: dict) -> str | None:
         attn_str = "attn"
     # Define scale name mapping patterns in order of precedence
     scale_mapping_patterns = [
+        # Pre-mapped format (vllm #44589): upstream
+        # `base_config.get_cache_scale_mapper` already rewrites raw checkpoint
+        # `.self_attn.{q,k,v}_scale` -> `.self_attn.attn.{q,k,v}_scale` in
+        # `AutoWeightsLoader` before this OOT remap runs. On HPU the real MLA
+        # param lives under `mla_attn.mla_attn`, so redirect the pre-mapped
+        # `.attn.` form to `.{attn_str}.`. For regular attention the pre-mapped
+        # name is already a param and is short-circuited by the
+        # `if name in params_dict` guard above, so this never fires there.
+        (
+            r"\.self_attn\.attn\.([qkv])_scale$",
+            rf".self_attn.{attn_str}.\1_scale",
+        ),
         # LLMC format:  .self_attn.{q,k,v}_scale ->
         #   .attn.{attn_str}.{q,k,v}_scale
         (
@@ -1235,8 +1255,8 @@ def oot_maybe_remap_kv_scale_name(name: str, params_dict: dict) -> str | None:
         # Qwen3 MoE format: .self_attn.qkqkv_proj.{k,v}_scale ->
         # .self_attn.attn.{k,v}_scale
         (r"\.self_attn\.qkqkv_proj\.([kv])_scale$", r".self_attn.attn.\1_scale"),
-        # Default format: .{k,v}_scale -> .attn.{k,v}_scale
-        (r"\.([kv])_scale$", r".attn.\1_scale"),
+        # Default format: .{q,k,v}_scale -> .attn.{q,k,v}_scale
+        (r"\.([qkv])_scale$", r".attn.\1_scale"),
     ]
 
     # Check if name ends with k_scale or v_scale

--- a/vllm_gaudi/ops/hpu_fused_moe.py
+++ b/vllm_gaudi/ops/hpu_fused_moe.py
@@ -414,10 +414,6 @@ def create_fused_moe_router(
     topk_group: int | None = None,
     scoring_func: str = "softmax",
     num_fused_shared_experts: int = 0,
-    # Fused shared-expert slot weight (upstream vLLM d039c171+). Accepted for
-    # signature parity with the upstream factory caller (layer.py passes it);
-    # the HPU routers below do not use the fused-shared-expert scaling path
-    # (num_fused_shared_experts defaults to 0), so the default 1.0 is a no-op.
     shared_expert_weight: float = 1.0,
     # grouped topk + fused topk bias parameters
     routed_scaling_factor: float = 1.0,
@@ -544,6 +540,8 @@ def create_fused_moe_router(
             renormalize=renormalize,
             routed_scaling_factor=routed_scaling_factor,
             hash_indices_table=hash_indices_table,
+            num_fused_shared_experts=num_fused_shared_experts,
+            shared_expert_weight=shared_expert_weight,
         )
 
     return FusedTopKRouter(

--- a/vllm_gaudi/ops/hpu_gptq.py
+++ b/vllm_gaudi/ops/hpu_gptq.py
@@ -61,6 +61,7 @@ class GPTQHPUConfig(QuantizationConfig):
         desc_act: bool,
         lm_head_quantized: bool,
     ) -> None:
+        super().__init__()
         self.weight_bits = weight_bits
         self.group_size = group_size
         self.desc_act = desc_act

--- a/vllm_gaudi/v1/kv_offload/worker/cpu_hpu.py
+++ b/vllm_gaudi/v1/kv_offload/worker/cpu_hpu.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from collections import defaultdict, deque
-from collections.abc import Iterator
 from dataclasses import dataclass
 
 import numpy as np
@@ -437,11 +436,11 @@ OffloadingConnectorWorker.register_kv_caches = register_kv_caches
 def _hpu_get_worker(self, kv_caches: CanonicalKVCaches):
     """HPU ``CPUOffloadingSpec.get_worker`` without the CUDA/XPU platform guard.
 
-    Older-API upstream (e.g. vllm ``2396d91e``) gates ``get_worker`` on
-    ``current_platform.is_cuda_alike() or is_xpu()``. The HPU offloading path is
-    implemented and validated via the ``CPUOffloadingWorker`` overrides in this
-    module, so this mirrors upstream minus that guard, staying a thin wrapper
-    over ``create_worker``.
+    Upstream ``get_worker`` gates the CPU KV-offload entry point on
+    ``current_platform.is_cuda_alike() or is_xpu()``, which raises on HPU. The
+    HPU offloading path is implemented and validated via the
+    ``CPUOffloadingWorker`` overrides in this module, so this mirrors upstream
+    minus that guard, staying a thin wrapper over ``create_worker``.
 
     Args:
         kv_caches: canonicalized GPU KV caches to offload.
@@ -456,42 +455,4 @@ def _hpu_get_worker(self, kv_caches: CanonicalKVCaches):
     return self._worker
 
 
-def _hpu_get_handlers(
-    self,
-    kv_caches: CanonicalKVCaches,
-) -> Iterator[tuple[type[LoadStoreSpec], type[LoadStoreSpec], object]]:
-    """HPU ``CPUOffloadingSpec.get_handlers`` without the CUDA/XPU platform guard.
-
-    Newer-API upstream (vllm commit
-    810966453a2576f45880c899db2af2e604207ed4, PR #36423) gates ``get_handlers``
-    on ``current_platform.is_cuda_alike() or is_xpu()``. This mirrors upstream
-    minus that guard, staying a thin wrapper over ``create_handlers``. The
-    GPU/CPU ``LoadStoreSpec`` types are imported lazily so this module still
-    imports cleanly against the older API where they do not exist.
-
-    Args:
-        kv_caches: canonicalized GPU KV caches to offload.
-
-    Yields:
-        Tuples of ``(src_spec_type, dst_spec_type, offloading_handler)`` for the
-        GPU->CPU (store) and CPU->GPU (load) directions.
-    """
-    from vllm.v1.kv_offload.base import GPULoadStoreSpec
-    from vllm.v1.kv_offload.cpu.common import CPULoadStoreSpec
-
-    if not self._handlers:
-        self._handlers = self.create_handlers(kv_caches)
-
-    assert self._handlers is not None
-    yield GPULoadStoreSpec, CPULoadStoreSpec, self._handlers.gpu_to_cpu_handler
-    yield CPULoadStoreSpec, GPULoadStoreSpec, self._handlers.cpu_to_gpu_handler
-
-
-# Patch whichever guarded entry point this vLLM exposes. The offloading worker
-# API changed upstream: older trees gate ``get_worker`` (returns an
-# ``OffloadingWorker``); newer trees gate ``get_handlers`` (yields handler
-# tuples). Patch the one that exists so the HPU path survives either generation.
-if hasattr(CPUOffloadingSpec, "get_worker"):
-    CPUOffloadingSpec.get_worker = _hpu_get_worker
-if hasattr(CPUOffloadingSpec, "get_handlers"):
-    CPUOffloadingSpec.get_handlers = _hpu_get_handlers
+CPUOffloadingSpec.get_worker = _hpu_get_worker

--- a/vllm_gaudi/v1/worker/hpu_input_batch.py
+++ b/vllm_gaudi/v1/worker/hpu_input_batch.py
@@ -13,6 +13,7 @@ from vllm.multimodal.inputs import MultiModalFeatureSpec
 from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import SamplingParams, SamplingType
 from vllm.utils.collection_utils import swap_dict_values
+from vllm.utils.math_utils import cdiv
 from vllm.v1.outputs import LogprobsTensors
 from vllm.v1.pool.metadata import PoolingMetadata, PoolingStates
 from vllm.v1.sample.metadata import SamplingMetadata
@@ -114,13 +115,18 @@ class InputBatch:
             self.num_computed_tokens_cpu_tensor.numpy()
 
         # Block table.
+        # vLLM #40996 dropped max_model_len from MultiGroupBlockTable and now
+        # requires the caller to pass the per-group block count. HPU does not
+        # use DCP (cp_world_size == 1), so max_num_blocks reduces to
+        # cdiv(max_model_len, block_size) per KV cache group.
+        max_num_blocks = [cdiv(max_model_len, block_size) for block_size in block_sizes]
         self.block_table = MultiGroupBlockTable(max_num_reqs=max_num_reqs,
-                                                max_model_len=max_model_len,
                                                 max_num_batched_tokens=max_num_batched_tokens,
                                                 pin_memory=pin_memory,
                                                 device=device,
                                                 block_sizes=block_sizes,
-                                                kernel_block_sizes=kernel_block_sizes)
+                                                kernel_block_sizes=kernel_block_sizes,
+                                                max_num_blocks=max_num_blocks)
 
         # Sampling-related.
         self.temperature = torch.empty((max_num_reqs, ), dtype=torch.float32, device=device)


### PR DESCRIPTION
## Summary

Realigns the HPU plugin with upstream vLLM `e23b19309b8705b21c3b3ff4129c9974ba15a419` after ten independent breaking API changes surfaced on hourly CI. Each fix is a standalone commit.

| # | Upstream | Symptom |
|---|----------|---------|
| 1 | vllm#44512 | `ImportError` on every model-swap job |
| 2 | vllm#46545 | `TypeError` on every `FusedMoE(...)` build |
| 3 | vllm#46635 | DeepSeek-V2 MLA+MoE generate crash (2D/3D cat) |
| 4 | vllm#44589 | FP8-QKV DeepSeek-V2 MLA fails to load (`KeyError q_scale`) |
| 5 | vllm#44589 | AWQ/GPTQ `AttributeError: packed_modules_mapping` |
| 6 | vllm#44589 / #44512 | dead back-compat paths (kv_offload `get_handlers`, unused derenderer) |
| 7 | vllm#47197 | `IndexError` on FP8/compressed-tensor MoE weight load |
| 8 | vllm#40996 | `TypeError` on MultiGroupBlockTable init (54 failed + 20 err) |
| 9 | vllm#46998 | Qwen3.5/Qwen3-Next `TypeError: forward() missing 'output'` |
| 10 | vllm#47529 | `TypeError` on model-swap server start (`setup_server`) |

---

### 1. multi-model server: ServingRender moved to `scale_out` (vllm#44512)

**Problem:** vllm#44512 moved `vllm.entrypoints.serve.render` -> `.scale_out.render` and dropped the `online_derenderer` arg from `ServingRender.__init__`. The HPU multi-model server still used the old import path, `ImportError` on every model-swap job.

**Fix (`vllm_gaudi/entrypoints/openai/multi_model_api_server.py`):** Update import path; stop passing `state.online_derenderer` to the constructor.

### 2. FusedMoE router: accept `shared_expert_weight` kwarg (vllm#46545)

**Problem:** vllm#46545 added `shared_expert_weight: float = 1.0` to `create_fused_moe_router`; the FusedMoE factory now forwards it on every router creation. The HPU fork of the factory rejected the new kwarg -> `TypeError` on every `FusedMoE(...)` construction, blocking `test_hpu_fused_moe`, `test_hpu_compressed_tensors`, and GraniteMoeHybrid generation.

**Fix (`vllm_gaudi/ops/hpu_fused_moe.py`):** Accept `shared_expert_weight` in upstream's signature position and forward it into the `FusedTopKBiasRouter` branch. No-op on HPU (`num_fused_shared_experts` defaults 0, weight stays 1.0); kwarg exists purely for caller parity. The ROCm-AITER-gated `AiterSharedRoutedFusedMoERouter` branch is intentionally not ported (never active on HPU).

### 3. DeepseekV2: restore forward without SP-MoE all-gather (vllm#46635)

**Problem:** vllm#46635 added a TP sequence-parallel all-gather block to `DeepseekV2Model.forward`, gated on `hidden_states.shape[0] != positions.shape[0]`. That guard assumes the GPU shape contract (flat 2D hidden_states, 1D positions). On HPU `positions` is 2D `[bs, seq]` while `DeepseekV2MoE.forward` returns flattened `[bs*seq, H]`, so the guard fires for any prompt and crashes cat'ing 2D hidden_states against a 3D residual (`RuntimeError: Tensors must have same number of dimensions: got 2 and 3`). The block is a GPU-TP-SP optimization, dead on HPU (MoE parallelism runs in HPU's own kernels).

**Fix (`vllm_gaudi/models/deepseek_v2.py`):** Override `DeepseekV2Model.forward` with the pre-#46635 plain decoder loop. Covers DeepseekV2/V3/Deepseek/GlmMoeDsa (shared `model_cls`).

### 4. FP8 KV-scale: adapt to upstream cache-scale pre-mapping (vllm#44589)

**Problem:** vllm#44589 activated `QuantizationConfig.get_cache_scale_mapper` (returned `None` at the old pinned SHA). `AutoWeightsLoader` now applies it to the weight stream before the model's `load_weights`, rewriting `...self_attn.{q,k,v}_scale` -> `...self_attn.attn.{q,k,v}_scale`. The HPU fork's `oot_maybe_remap_kv_scale_name` only knew the raw forms, so a static-FP8 QKV DeepSeek-V2 checkpoint (`kv_cache_dtype=fp8_inc`, `HPUAttentionMLA`) crashed at load: `q_scale` matched no pattern -> `KeyError 'layers.0.self_attn.attn.q_scale'` (real MLA param is `...self_attn.mla_attn.mla_attn.q_scale`); k/v_scale mapped to a non-existent `.attn.attn.*` name and were silently dropped to 1.0.

**Fix (`vllm_gaudi/ops/hpu_compressed_tensors.py`):** Re-sync to the pre-mapped contract —
- add upstream guard `if name in params_dict: return name` so pre-mapped names that already match a param (regular Attention) short-circuit;
- add highest-precedence pattern for the pre-mapped `.self_attn.attn.{q,k,v}` form, redirecting to the real HPU MLA path (`.mla_attn.mla_attn.`);
- widen the default pattern from `[kv]` to `[qkv]` for upstream parity.

### 5. AWQ/GPTQ HPU configs: call `super().__init__()` (vllm#44589)

**Problem:** vllm#44589 added `SupportsQuant` to `LlamaForCausalLM`; its `__new__` now runs `packed_modules_mapping.update()`, which the base `QuantizationConfig.__init__` populates. `AWQHPUConfig`/`GPTQHPUConfig` skipped `super().__init__()`, so the attr was missing -> `AttributeError` at model load.

**Fix (`vllm_gaudi/ops/hpu_awq.py`, `vllm_gaudi/ops/hpu_gptq.py`):** Call `super().__init__()` in both HPU quant configs.

### 6. Drop older-vLLM back-compat cruft (target ae6170f8)

**Problem:** Two paths were dead against the current target and only added confusion:
- `kv_offload/worker/cpu_hpu.py` carried a dual `hasattr()` patch block for both `get_worker` and `get_handlers`. The target `CPUOffloadingSpec` exposes only `get_worker` (with the CUDA/XPU guard) — there is no `get_handlers`.
- `multi_model_api_server.py` still built `state.online_derenderer`, but after fix #1 `ServingRender.__init__` (scale_out) no longer takes a derenderer, so it was constructed and never consumed.

**Fix (`vllm_gaudi/v1/kv_offload/worker/cpu_hpu.py`, `vllm_gaudi/entrypoints/openai/multi_model_api_server.py`):**
- Drop `_hpu_get_handlers`, its lazy GPU/CPU `LoadStoreSpec` imports and the unused `Iterator` import; collapse the dual `hasattr()` block to an unconditional `CPUOffloadingSpec.get_worker` assignment.
- Drop the `OnlineDerenderer` construction and its import.

### 7. FP8/compressed-tensor MoE: accept keyword-only `loaded_weight` (vllm#47197)

**Problem:** vllm#47197 changed `FusedMoE` expert loading in `routed_experts.py` from `self.weight_loader(...)` to `param.weight_loader(param=..., loaded_weight=..., weight_name=..., shard_id=..., expert_id=..., return_success=True)` — keyword-only args, routed through the HPU-wrapped loader on the parameter. The HPU `gaudi_weight_wrapper` assumed `loaded_weight` was the positional `args[1]`; with the keyword-only call `args = (param,)`, so `args[1]` raised `IndexError: tuple index out of range` at model load. This broke `run_qwen3_moe_compressed_tensor_static_per_tensor_scaling_load_generate_test` (`Intel/Qwen3-30B-A3B-FP8-Test-Only`, `--enable-expert-parallel`). A latent secondary defect: the wrapper never `return`ed the loader result, so `return_success=True` would yield `None` → silent no-op weight load.

**Fix (`vllm_gaudi/extension/ops.py`):** In `gaudi_weight_wrapper`, read `loaded_weight` from `kwargs` when present (else positional `args[1]`), write the scale-adjusted value back to the same slot, and return the wrapped `weight_loader` result so `return_success` is honoured.

### 8. HPU InputBatch: pass max_num_blocks to MultiGroupBlockTable (vllm#40996)

**Problem:** vllm#40996 (95ed0feaa5, "DCP supports hybrid attention") changed `MultiGroupBlockTable.__init__` in `vllm/v1/worker/block_table.py`: it dropped the `max_model_len` parameter and made `max_num_blocks: list[int]` a required argument. The per-group block count, previously computed inside the class as `cdiv(max_model_len, block_size * cp_world_size)`, must now be supplied by the caller. The HPU `InputBatch` still passed the removed `max_model_len` kwarg → `TypeError: MultiGroupBlockTable.__init__() got an unexpected keyword argument 'max_model_len'` (54 failed + 20 errors across sampler / worker / prefix-cache unit tests and HPU engine startup).

**Fix (`vllm_gaudi/v1/worker/hpu_input_batch.py`):** Compute `max_num_blocks` in the caller and pass it instead. HPU does not use DCP (`cp_world_size == 1`), so it reduces to `cdiv(max_model_len, block_size)` per KV cache group.

### 9. Qwen3.5 / Qwen3-Next: adapt GDN + full-attn to return-based forward (vllm#46998)

**Problem:** vllm#46998 (300e33797f) converted Qwen3.5/Qwen3-Next attention from an in-place `output` buffer to a return-based signature:
- `QwenGatedDeltaNetAttention.forward(hidden_states, output)` -> `forward(hidden_states) -> Tensor`
- `Qwen3NextAttention.forward(positions, output, hidden_states)` -> `forward(positions, hidden_states) -> Tensor`

The decoder-layer caller now does `hidden_states = self.linear_attn(hidden_states=...)` / `self.self_attn(...)` with no `output` kwarg, so the two HPU overrides raised `TypeError: forward() missing 1 required positional argument: 'output'` (GDN path first, in `run_gsm8k_qwen36_35b_a3b_test`).

**Fix (`vllm_gaudi/models/qwen3_5.py`, `vllm_gaudi/models/qwen3_next.py`):** Convert both HPU overrides to the return-based contract: drop the `output` parameter and return the projected output restored to the caller's original 2-D flat or 3-D `[B, L, H]` layout, keeping the residual add shape-consistent.

### 10. multi-model server: pass reuse_port=False to setup_server (vllm#47529)

**Problem:** vllm#47529 (ab3b6d97aa, "[Frontend] Limit `SO_REUSEPORT` to multi-worker serving") made `reuse_port` a required keyword-only argument of `setup_server()`; `SO_REUSEPORT` is now opt-in and enabled only for multi-worker serving. All upstream callers pass it explicitly (single-server paths use `reuse_port=False`). The HPU multi-model server still called `setup_server(args)` → `TypeError: setup_server() missing 1 required keyword-only argument: 'reuse_port'` before the socket bound, failing `run_online_model_swap_test`.

**Fix (`vllm_gaudi/entrypoints/openai/multi_model_api_server.py`):** `multi_model_api_server` runs a single API server (one socket/port), matching upstream single-server semantics — pass `reuse_port=False`.

---
