### PR TITLE
Cherry pick from v0.24.0 to main

### DIFF
--- a/.cd/Dockerfile.rhel.ubi.vllm
+++ b/.cd/Dockerfile.rhel.ubi.vllm
@@ -3,14 +3,14 @@
 
 # Global build arguments - declared before first FROM to be available in all stages
 ARG ARTIFACTORY_URL="vault.habana.ai"
-ARG SYNAPSE_VERSION=1.24.0
+ARG SYNAPSE_VERSION=1.24.1
 # Use an exact revision (e.g. 695) or "latest" to auto-detect the newest available revision.
 # If you do not want metadata to show "latest", pass an exact SYNAPSE_REVISION.
-ARG SYNAPSE_REVISION=1007
+ARG SYNAPSE_REVISION=482
 ARG BASE_NAME=rhel9.6
 ARG OS_VERSION=9.6
 ARG OS_STRING=rhel96
-ARG PT_VERSION=2.10.0
+ARG PT_VERSION=2.11.0
 ARG PT_MODULES_REPO_NAME=gaudi-pt-modules
 # for internal use - to support a different package name for RHEL 9.4 with Python 3.12
 ARG PT_PACKAGE_NAME_NON_DEFAULT_PYTHON_SUBSTRING=

--- a/.cd/Dockerfile.rhel.ubi.vllm.no-torchaudio
+++ b/.cd/Dockerfile.rhel.ubi.vllm.no-torchaudio
@@ -7,14 +7,14 @@
 
 # Global build arguments - declared before first FROM to be available in all stages
 ARG ARTIFACTORY_URL="vault.habana.ai"
-ARG SYNAPSE_VERSION=1.24.0
+ARG SYNAPSE_VERSION=1.24.1
 # Use an exact revision (e.g. 695) or "latest" to auto-detect the newest available revision.
 # If you do not want metadata to show "latest", pass an exact SYNAPSE_REVISION.
-ARG SYNAPSE_REVISION=1007
+ARG SYNAPSE_REVISION=482
 ARG BASE_NAME=rhel9.6
 ARG OS_VERSION=9.6
 ARG OS_STRING=rhel96
-ARG PT_VERSION=2.10.0
+ARG PT_VERSION=2.11.0
 ARG PT_MODULES_REPO_NAME=gaudi-pt-modules
 # for internal use - to support a different package name for RHEL 9.4 with Python 3.12
 ARG PT_PACKAGE_NAME_NON_DEFAULT_PYTHON_SUBSTRING=

--- a/.cd/Dockerfile.ubuntu.pytorch.vllm
+++ b/.cd/Dockerfile.ubuntu.pytorch.vllm
@@ -3,9 +3,9 @@
 
 # Parameterize base image components
 ARG DOCKER_URL=vault.habana.ai/gaudi-docker
-ARG VERSION=1.24.0
+ARG VERSION=1.24.1
 ARG BASE_NAME=ubuntu24.04
-ARG PT_VERSION=2.10.0
+ARG PT_VERSION=2.11.0
 ARG REVISION=latest
 ARG REPO_TYPE=habanalabs
 ARG TORCH_TYPE_SUFFIX

--- a/.cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest
+++ b/.cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest
@@ -3,9 +3,9 @@
 
 # Parameterize base image components
 ARG DOCKER_URL=vault.habana.ai/gaudi-docker
-ARG VERSION=1.24.0
+ARG VERSION=1.24.1
 ARG BASE_NAME=ubuntu24.04
-ARG PT_VERSION=2.10.0
+ARG PT_VERSION=2.11.0
 ARG REVISION=latest
 ARG REPO_TYPE=habanalabs
 ARG TORCH_TYPE_SUFFIX
@@ -67,7 +67,7 @@ RUN \
 # Install torchaudio (CPU wheel, matching PyTorch version in base image)
 RUN pip install --no-cache-dir --no-deps --extra-index-url https://download.pytorch.org/whl/cpu torchaudio==${PT_VERSION}
 
-# Workaround: Gaudi base image bundles HPU-patched PyTorch (e.g. 2.10.0a0+git...)
+# Workaround: Gaudi base image bundles HPU-patched PyTorch (e.g. 2.11.0a0+git...)
 # which doesn't satisfy torchvision/torchaudio's strict torch==X.Y.Z pin.
 # Relax the requirement in installed package metadata so pip check passes.
 RUN SITE=$(python3 -c "import site; print(site.getsitepackages()[0])") && \

--- a/.cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest.no-torchaudio
+++ b/.cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest.no-torchaudio
@@ -7,9 +7,9 @@
 
 # Parameterize base image components
 ARG DOCKER_URL=vault.habana.ai/gaudi-docker
-ARG VERSION=1.24.0
+ARG VERSION=1.24.1
 ARG BASE_NAME=ubuntu24.04
-ARG PT_VERSION=2.10.0
+ARG PT_VERSION=2.11.0
 ARG REVISION=latest
 ARG REPO_TYPE=habanalabs
 ARG TORCH_TYPE_SUFFIX
@@ -70,7 +70,7 @@ RUN \
 
 # torchaudio install removed.
 
-# Workaround: Gaudi base image bundles HPU-patched PyTorch (e.g. 2.10.0a0+git...)
+# Workaround: Gaudi base image bundles HPU-patched PyTorch (e.g. 2.11.0a0+git...)
 # which doesn't satisfy torchvision's strict torch==X.Y.Z pin.
 # Relax the requirement in installed package metadata so pip check passes.
 # (torchaudio metadata patch removed together with torchaudio install.)

--- a/.cd/Dockerfile.ubuntu.pytorch.vllm.no-torchaudio
+++ b/.cd/Dockerfile.ubuntu.pytorch.vllm.no-torchaudio
@@ -7,9 +7,9 @@
 
 # Parameterize base image components
 ARG DOCKER_URL=vault.habana.ai/gaudi-docker
-ARG VERSION=1.24.0
+ARG VERSION=1.24.1
 ARG BASE_NAME=ubuntu24.04
-ARG PT_VERSION=2.10.0
+ARG PT_VERSION=2.11.0
 ARG REVISION=latest
 ARG REPO_TYPE=habanalabs
 ARG TORCH_TYPE_SUFFIX

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ vLLM Hardware Plugin for Intel® Gaudi®
 
 ---
 *Latest News* 🔥
+- [2026/07] Version 0.24.0 is now available, built on [vLLM 0.24.0](https://github.com/vllm-project/vllm/releases/tag/v0.24.0) and fully compatible with [Intel® Gaudi® v1.24.1](https://docs.habana.ai/en/v1.24.1/Release_Notes/GAUDI_Release_Notes.html) with PyTorch 2.11.
+
+  This release enables the plugin on upstream vLLM 0.24.0 and adapts the Intel® Gaudi® platform to upstream changes, including the FusedMoE/MoERunner inversion, KV-connector and offloading refactors, and the Mamba/GDN rewrite. It also adds Qwen3-Next architecture support, improves FP8/INC quantization memory usage and stability, switches hybrid models to a TPC-native `causal_conv1d` update path, extends single-card model swapping to hybrid models, and strengthens security.
+
 - [2026/04] Version 0.19.0 is now available, built on [vLLM 0.19.0](https://github.com/vllm-project/vllm/releases/tag/v0.19.0) and fully compatible with [Intel® Gaudi® v1.24.0](https://docs.habana.ai/en/v1.24.0/Release_Notes/GAUDI_Release_Notes.html) with PyTorch 2.10.
 
   This release upgrades the platform to Intel® Gaudi® Software v1.24.0 with PyTorch 2.10. It introduces Qwen 3.5 model support, Mamba prefix caching for hybrid models, MxFP4 weight dequantization, LMCache integration, and a custom depthwise conv1d TPC kernel for MambaMixer2. Performance improvements include torch.compile-compatible online defragmentation, improved warmup time, and optimized hybrid KV cache visibility.
@@ -21,10 +25,6 @@ vLLM Hardware Plugin for Intel® Gaudi®
 - [2026/04] Version 0.17.1 is now available, built on [vLLM 0.17.1](https://github.com/vllm-project/vllm/releases/tag/v0.17.1) and fully compatible with [Intel® Gaudi® v1.23.0](https://docs.habana.ai/en/v1.23.0/Release_Notes/GAUDI_Release_Notes.html).
 
   This patch release backports critical fixes and improvements including MxFP4 weight loading, Granite 4.0-h calibration, prefix caching for HPUMambaMixer2, OOM crash fixes, and SDL secure error handling improvements.
-
-- [2026/03] Version 0.16.0 is now available, built on [vLLM 0.16.0](https://github.com/vllm-project/vllm/releases/tag/v0.16.0) and fully compatible with [Intel® Gaudi® v1.23.0](https://docs.habana.ai/en/v1.23.0/Release_Notes/GAUDI_Release_Notes.html).
-
-  This release introduces validated support and critical stability fixes for Qwen3-VL models leveraging HPUMMEncoderAttention. Performance and stability were improved through backported Mamba architecture optimizations, Docker and UBI infrastructure enhancements, and a forced CPU loading mechanism for INC quantization to prevent OOM errors.
 
 ---
 

--- a/docs/getting_started/compatibility_matrix.md
+++ b/docs/getting_started/compatibility_matrix.md
@@ -3,46 +3,56 @@ title: Compatibility Matrix
 ---
 [](){ #compatibility-matrix }
 
-The following table details the supported vLLM versions for Intel® Gaudi® 2 and Intel® Gaudi® 3 AI accelerators. The versions marked as unsupported may still work, but they have not been thoroughly tested.
+The following table details the supported vLLM versions for Intel® Gaudi® 2 and Intel® Gaudi® 3 AI accelerators. The versions marked as unsupported may still work, but they have not been thoroughly tested. The latest validated release is **vLLM v0.24.0** on Intel® Gaudi® software version 1.24.1.
 
 <div class="compatibility-matrix">
 <table>
   <thead>
     <tr>
       <th rowspan="2">vLLM<br>version</th>
-      <th colspan="4">Intel Gaudi software version</th>
+      <th colspan="5">Intel® Gaudi® software version</th>
     </tr>
     <tr>
       <th>1.22.1</th>
       <th>1.22.2</th>
       <th>1.23.0</th>
       <th>1.24.0</th>
+      <th>1.24.1</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td>0.10.1</td><td>✅ Beta</td><td>❌</td><td>❌</td><td>❌</td>
+      <td>0.10.1</td><td>✅ Beta</td><td>❌</td><td>❌</td><td>❌</td><td>❌</td>
     </tr>
     <tr>
-      <td>0.11.2</td><td>❌</td><td>✅</td><td>✅</td><td>❌</td>
+      <td>0.11.2</td><td>❌</td><td>✅</td><td>✅</td><td>❌</td><td>❌</td>
     </tr>
     <tr>
-      <td>0.13.0</td><td>❌</td><td>❌</td><td>✅</td><td>❌</td>
+      <td>0.13.0</td><td>❌</td><td>❌</td><td>✅</td><td>❌</td><td>❌</td>
     </tr>
     <tr>
-      <td>0.14.1</td><td>❌</td><td>❌</td><td>✅</td><td>❌</td>
+      <td>0.14.1</td><td>❌</td><td>❌</td><td>✅</td><td>❌</td><td>❌</td>
     </tr>
     <tr>
-      <td>0.15.1</td><td>❌</td><td>❌</td><td>✅</td><td>❌</td>
+      <td>0.15.1</td><td>❌</td><td>❌</td><td>✅</td><td>❌</td><td>❌</td>
     </tr>
     <tr>
-      <td>0.16.0</td><td>❌</td><td>❌</td><td>✅</td><td>❌</td>
+      <td>0.16.0</td><td>❌</td><td>❌</td><td>✅</td><td>❌</td><td>❌</td>
     </tr>
     <tr>
-      <td>0.17.1</td><td>❌</td><td>❌</td><td>✅</td><td>✅</td>
+      <td>0.17.1</td><td>❌</td><td>❌</td><td>✅</td><td>✅</td><td>❌</td>
     </tr>
     <tr>
-      <td>0.19.0</td><td>❌</td><td>❌</td><td>❌</td><td>✅</td>
+      <td>0.19.0</td><td>❌</td><td>❌</td><td>❌</td><td>✅</td><td>❌</td>
+    </tr>
+    <tr>
+      <td>0.19.1</td><td>❌</td><td>❌</td><td>❌</td><td>✅</td><td>❌</td>
+    </tr>
+    <tr>
+      <td>0.21.0</td><td>❌</td><td>❌</td><td>❌</td><td>✅</td><td>❌</td>
+    </tr>
+    <tr>
+      <td>0.24.0</td><td>❌</td><td>❌</td><td>❌</td><td>❌</td><td>✅</td>
     </tr>
   </tbody>
 </table>

--- a/docs/getting_started/validated_models.md
+++ b/docs/getting_started/validated_models.md
@@ -54,6 +54,8 @@ The following configurations have been validated to function with IntelÂ® GaudiÂ
 | [Qwen/Qwen3-VL-235B-A22B-Instruct-FP8](https://huggingface.co/Qwen/Qwen3-VL-235B-A22B-Instruct-FP8)     | 4    |  FP8    | Gaudi 3|
 | [Qwen/Qwen3-VL-235B-A22B-Thinking](https://huggingface.co/Qwen/Qwen3-VL-235B-A22B-Thinking)     | 8    |  BF16    | Gaudi 3|
 | [Qwen/Qwen3-VL-235B-A22B-Thinking-FP8](https://huggingface.co/Qwen/Qwen3-VL-235B-A22B-Thinking-FP8)     | 4    |  FP8    | Gaudi 3|
+| [Qwen/Qwen3.5-35B-A3B](https://huggingface.co/Qwen/Qwen3.5-35B-A3B)     | 1    | BF16    | Gaudi 3|
+| [Qwen/Qwen3.6-35B-A3B](https://huggingface.co/Qwen/Qwen3.6-35B-A3B)     | 1    | BF16    | Gaudi 3|
 | [ibm-granite/granite-4.0-h-small](https://huggingface.co/ibm-granite/granite-4.0-h-small)     | 1    |  BF16    | Gaudi 3|
 | [tencent/Hunyuan-7B-Instruct](https://huggingface.co/tencent/Hunyuan-7B-Instruct)     | 1    | BF16, FP8    | Gaudi 3|
 | [tencent/Hunyuan-A13B-Instruct](https://huggingface.co/tencent/Hunyuan-A13B-Instruct)     | 1    | BF16, FP8    | Gaudi 3|

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -2,6 +2,30 @@
 
 This document provides an overview of the features, changes, and fixes introduced in each release of the vLLM Hardware Plugin for Intel® Gaudi®.
 
+## 0.24.0
+
+This version is based on [vLLM 0.24.0](https://github.com/vllm-project/vllm/releases/tag/v0.24.0) and supports [Intel® Gaudi® Software v1.24.1](https://docs.habana.ai/en/v1.24.1/Release_Notes/GAUDI_Release_Notes.html) with PyTorch 2.11.
+
+This release enables the plugin on upstream vLLM 0.24.0 and adapts the Intel® Gaudi® platform to upstream changes, including the FusedMoE/MoERunner inversion, KV-connector and offloading refactors, the Mamba/GDN rewrite, and serving tokenization changes. It also adds Qwen3-Next architecture support, improves FP8/INC quantization memory usage and stability, switches hybrid models to a TPC-native `causal_conv1d` update path, extends single-card model swapping to hybrid SSM-Transformer models, and strengthens security.
+
+For a full list of changes, see the [Detailed Release Notes](release_notes_v0.24.0.md).
+
+## 0.21.0
+
+This version is based on [vLLM 0.21.0](https://github.com/vllm-project/vllm/releases/tag/v0.21.0) and supports [Intel® Gaudi® Software v1.24.0](https://docs.habana.ai/en/v1.24.0/Release_Notes/GAUDI_Release_Notes.html) with PyTorch 2.10.
+
+This release introduces a new padding-aware bucketing strategy for improved memory utilization, W8A8 INT8 quantization with BF16 fallback, and FusedSDPA slicing for better attention performance. It adds an OpenAI-compatible `/v1/models/switch` entrypoint with per-model tool-calling and FP8 configs for online model swap, HPU-specific KV-offload and async speculative decoding fixes, and NIXL connector fixes for heterogeneous and homogeneous deployments. Eager execution mode is now the default in CI, with lazy mode still supported at runtime.
+
+For a full list of changes, see the [Detailed Release Notes](release_notes_v0.21.0.md).
+
+## 0.19.1
+
+This version is a minor patch release on top of [0.19.0](release_notes_v0.19.0.md) and continues to support [Intel® Gaudi® Software v1.24.0](https://docs.habana.ai/en/v1.24.0/Release_Notes/GAUDI_Release_Notes.html) with PyTorch 2.10.
+
+This release lifts the `transformers < 5` upper-bound constraint, allowing users to install Hugging Face Transformers v5 alongside the plugin, and refreshes the pinned upstream vLLM stable commit used by build scripts and CI.
+
+For a full list of changes, see the [Detailed Release Notes](release_notes_v0.19.1.md).
+
 ## 0.19.0
 
 This version is based on [vLLM 0.19.0](https://github.com/vllm-project/vllm/releases/tag/v0.19.0) and supports the latest [Intel® Gaudi® Software v1.24.0](https://docs.habana.ai/en/v1.24.0/Release_Notes/GAUDI_Release_Notes.html) with PyTorch 2.10.

--- a/docs/release_notes_v0.19.1.md
+++ b/docs/release_notes_v0.19.1.md
@@ -1,0 +1,30 @@
+# vLLM Gaudi Plugin v0.19.1 Release Notes
+
+## Overview
+
+This is a minor patch release on top of [v0.19.0](release_notes_v0.19.0.md) and continues to support [Intel® Gaudi® Software v1.24.0](https://docs.habana.ai/en/v1.24.0/Release_Notes/GAUDI_Release_Notes.html) with PyTorch 2.10.
+
+The release lifts the **`transformers < 5` upper-bound constraint**, allowing users to install Hugging Face Transformers v5 alongside the plugin.
+
+For the full set of features delivered in the v0.19.x line, see the [v0.19.0 release notes](release_notes_v0.19.0.md).
+
+---
+
+## Highlights
+
+- Removed the **`transformers >= 4.56.0, <5`** dependency constraint from `requirements.txt`, enabling installation of Hugging Face Transformers v5.
+- Refreshed the pinned **upstream vLLM stable commit** used by build scripts and CI.
+
+---
+
+## Plugin Core
+
+- Removed the `transformers >= 4.56.0, <5` dependency entry entirely from `requirements.txt` (the plugin no longer pins a `transformers` version), and dropped the now-redundant `add_bos_token=True` test setting in `tests/models/language/generation/test_common.py`. ([#1420](https://github.com/vllm-project/vllm-gaudi/pull/1420))
+
+---
+
+## Full Changelog
+
+| PR | Title | Author |
+| --- | --- | --- |
+| [#1420](https://github.com/vllm-project/vllm-gaudi/pull/1420) | Transformers v5 upgrade | @iboiko-habana |

--- a/docs/release_notes_v0.21.0.md
+++ b/docs/release_notes_v0.21.0.md
@@ -1,0 +1,218 @@
+# vLLM Gaudi Plugin v0.21.0 Release Notes
+
+## Overview
+
+This release is based on [vLLM v0.21.0](https://github.com/vllm-project/vllm/releases/tag/v0.21.0) and supports [Intel® Gaudi® Software v1.24.0](https://docs.habana.ai/en/v1.24.0/Release_Notes/GAUDI_Release_Notes.html) with PyTorch 2.10.
+
+---
+
+## Highlights
+
+- **Removed lazy execution mode from CI** — eager mode is now the default in CI pipelines; lazy mode is still supported at runtime. ([#996](https://github.com/vllm-project/vllm-gaudi/pull/996))
+- Introduced **new padding-aware bucketing strategy** for improved memory utilization and reduced padding overhead. ([#762](https://github.com/vllm-project/vllm-gaudi/pull/762))
+- Added **W8A8 INT8 quantization with BF16 fallback** via `HPUCompressedTensorsW8A8Int8_BF16Fallback`. ([#1168](https://github.com/vllm-project/vllm-gaudi/pull/1168))
+- Enabled **FusedSDPA slicing** for better attention performance. ([#1155](https://github.com/vllm-project/vllm-gaudi/pull/1155))
+- Added **OpenAI-compatible `/v1/models/switch` entrypoint** and per-model tool-calling and FP8 configs for online model swap. ([#1258](https://github.com/vllm-project/vllm-gaudi/pull/1258))
+- Introduced **HPU-specific KV-offload and async speculative decoding** fixes. ([#1264](https://github.com/vllm-project/vllm-gaudi/pull/1264))
+- Fixed **NIXL connector heterogeneous and homogeneous** deployment scenarios. ([#1511](https://github.com/vllm-project/vllm-gaudi/pull/1511), [#1503](https://github.com/vllm-project/vllm-gaudi/pull/1503))
+
+---
+
+## Performance
+
+- Introduced a new padding-aware bucketing strategy. ([#762](https://github.com/vllm-project/vllm-gaudi/pull/762))
+- Enabled slicing for the FusedSDPA attention path. ([#1155](https://github.com/vllm-project/vllm-gaudi/pull/1155))
+- Skipped HPU graphs for long (query + context) prefills. ([#1346](https://github.com/vllm-project/vllm-gaudi/pull/1346))
+- Fixed guard breaks and improved warmup time for Qwen3 MoE. ([#1329](https://github.com/vllm-project/vllm-gaudi/pull/1329))
+- Improved `selective_state_update` performance. ([#1291](https://github.com/vllm-project/vllm-gaudi/pull/1291))
+- Removed splitting MoE decode layer compilation function. ([#1313](https://github.com/vllm-project/vllm-gaudi/pull/1313))
+- Optimized visible block number for hybrid KV cache. ([#1317](https://github.com/vllm-project/vllm-gaudi/pull/1317))
+- Fine-tuned bucketing edge cases for longer contexts. ([#1362](https://github.com/vllm-project/vllm-gaudi/pull/1362))
+- Raised the default `max_cudagraph_capture_size` floor to 16384. ([#1507](https://github.com/vllm-project/vllm-gaudi/pull/1507))
+
+---
+
+## Attention & KV Cache
+
+- Added prefix caching support for HPUMambaMixer2. ([#1366](https://github.com/vllm-project/vllm-gaudi/pull/1366))
+- Fixed condition for materialised causal `attn_bias`. ([#1433](https://github.com/vllm-project/vllm-gaudi/pull/1433))
+- Fixed proper KV cache slot addressing for hybrid models. ([#1327](https://github.com/vllm-project/vllm-gaudi/pull/1327))
+- Fixed `mamba_type` comparison for GDN hybrid cache allocation. ([#1449](https://github.com/vllm-project/vllm-gaudi/pull/1449))
+- Fixed extra masking for batched prefill in GDN layers. ([#1440](https://github.com/vllm-project/vllm-gaudi/pull/1440))
+- Fixed HPU-specific bugs for KV-offload and async speculative decoding. ([#1264](https://github.com/vllm-project/vllm-gaudi/pull/1264))
+
+---
+
+## Quantization
+
+- Implemented `HPUCompressedTensorsW8A8Int8_BF16Fallback` for W8A8 INT8 quantization with BF16 fallback. ([#1168](https://github.com/vllm-project/vllm-gaudi/pull/1168))
+- Fixed Synapse GC compile failure for FP8-quantized models. ([#1324](https://github.com/vllm-project/vllm-gaudi/pull/1324))
+- Enabled Llama4 Maverick FP8 torch.compile without breaking DeepSeek. ([#1396](https://github.com/vllm-project/vllm-gaudi/pull/1396))
+- Fixed GPT-OSS MxFP4 TP partitioning and `quant_method` matching. ([#1498](https://github.com/vllm-project/vllm-gaudi/pull/1498))
+- Added Granite-4.0-h calibration config. ([#1270](https://github.com/vllm-project/vllm-gaudi/pull/1270))
+- Fixed load failure of MxFP4 GPT-OSS-120B with expert parallel. ([#1411](https://github.com/vllm-project/vllm-gaudi/pull/1411))
+- Added `hf_config` parameter to HPU quantization config overrides. ([#1349](https://github.com/vllm-project/vllm-gaudi/pull/1349))
+
+---
+
+## Plugin Core
+
+- Removed lazy execution mode from CI — eager is now the default in CI pipelines. ([#996](https://github.com/vllm-project/vllm-gaudi/pull/996))
+- Accepted PEP 440 versions in build detection. ([#1351](https://github.com/vllm-project/vllm-gaudi/pull/1351))
+- Patched `torch.accelerator.empty_cache` for HPU to fix import-order dependent cleanup failures. ([#1430](https://github.com/vllm-project/vllm-gaudi/pull/1430))
+- Removed `matmul_qk` output-tensor compatibility gate after 1.24.0. ([#1409](https://github.com/vllm-project/vllm-gaudi/pull/1409))
+- Removed `transformers` installation from vllm-gaudi. ([#1494](https://github.com/vllm-project/vllm-gaudi/pull/1494))
+- Prevented eager-mode env vars from leaking to lazy-mode subprocesses. ([#1510](https://github.com/vllm-project/vllm-gaudi/pull/1510))
+- Fixed multiple upstream regressions across MoE, MLA, NIXL, attention, FP8, offloading, and platform modules. ([#1279](https://github.com/vllm-project/vllm-gaudi/pull/1279), [#1311](https://github.com/vllm-project/vllm-gaudi/pull/1311), [#1338](https://github.com/vllm-project/vllm-gaudi/pull/1338), [#1342](https://github.com/vllm-project/vllm-gaudi/pull/1342), [#1354](https://github.com/vllm-project/vllm-gaudi/pull/1354), [#1375](https://github.com/vllm-project/vllm-gaudi/pull/1375), [#1377](https://github.com/vllm-project/vllm-gaudi/pull/1377), [#1403](https://github.com/vllm-project/vllm-gaudi/pull/1403), [#1421](https://github.com/vllm-project/vllm-gaudi/pull/1421), [#1428](https://github.com/vllm-project/vllm-gaudi/pull/1428), [#1442](https://github.com/vllm-project/vllm-gaudi/pull/1442))
+- Ported fixes for MoE fast path, dynamic shape, kernel block size, and batched count operations. ([#1453](https://github.com/vllm-project/vllm-gaudi/pull/1453), [#1458](https://github.com/vllm-project/vllm-gaudi/pull/1458), [#1459](https://github.com/vllm-project/vllm-gaudi/pull/1459), [#1460](https://github.com/vllm-project/vllm-gaudi/pull/1460), [#1469](https://github.com/vllm-project/vllm-gaudi/pull/1469))
+
+---
+
+## Serving & Infrastructure
+
+- Added torchaudio-free copies of CD Dockerfiles. ([#1446](https://github.com/vllm-project/vllm-gaudi/pull/1446))
+- Set Docker `PT_HPU_LAZY_MODE=0` as the default auto-calculated value. ([#1378](https://github.com/vllm-project/vllm-gaudi/pull/1378))
+- Added OpenAI-compatible `/v1/models/switch` entrypoint integration. ([#1258](https://github.com/vllm-project/vllm-gaudi/pull/1258))
+- Added per-model tool-calling and FP8 configs. ([#1258](https://github.com/vllm-project/vllm-gaudi/pull/1258))
+- Enhanced process management for online model swap example. ([#1414](https://github.com/vllm-project/vllm-gaudi/pull/1414))
+- Fixed NIXL connector V1 API signature mismatches for heterogeneous HPU. ([#1503](https://github.com/vllm-project/vllm-gaudi/pull/1503))
+- Fixed heterogeneous and homogeneous NIXL deployment issues for v0.21.0. ([#1511](https://github.com/vllm-project/vllm-gaudi/pull/1511))
+- Enabled defragmentation when contiguous PA is enabled. ([#1400](https://github.com/vllm-project/vllm-gaudi/pull/1400))
+- Clarified `VLLM_PROMPT_BS_BUCKET_MAX` runtime behavior in docs. ([#1410](https://github.com/vllm-project/vllm-gaudi/pull/1410))
+
+---
+
+## Fixes
+
+- Fixed occasional Qwen3.5 segfault. ([#1500](https://github.com/vllm-project/vllm-gaudi/pull/1500))
+- Fixed decode bucket generation for hybrid models with mismatched block sizes. ([#1486](https://github.com/vllm-project/vllm-gaudi/pull/1486))
+- Fixed HPU `prompt_token_ids` device placement for penalty sampling. ([#1466](https://github.com/vllm-project/vllm-gaudi/pull/1466))
+- Fixed decode bucket filter issues. ([#1447](https://github.com/vllm-project/vllm-gaudi/pull/1447))
+- Fixed decode bucketing in non-contiguous PA scenario. ([#1122](https://github.com/vllm-project/vllm-gaudi/pull/1122))
+- Fixed MRoPE accuracy for Qwen models. ([#1437](https://github.com/vllm-project/vllm-gaudi/pull/1437))
+- Fixed warmup failure and multimodal graph warmup in PT compile-only mode. ([#1392](https://github.com/vllm-project/vllm-gaudi/pull/1392))
+- Flattened 3D `inputs_embeds` in `HpuModelAdapter.forward`. ([#1381](https://github.com/vllm-project/vllm-gaudi/pull/1381))
+- Fixed prompt logprobs gathering on Gaudi HPU. ([#1405](https://github.com/vllm-project/vllm-gaudi/pull/1405))
+- Fixed regression in Mistral-Large-3-675B. ([#1304](https://github.com/vllm-project/vllm-gaudi/pull/1304))
+- Fixed Granite 4h block size calculations. ([#1332](https://github.com/vllm-project/vllm-gaudi/pull/1332))
+- Separated conv1d for Granite 4.0. ([#1322](https://github.com/vllm-project/vllm-gaudi/pull/1322))
+- Corrected `get_supported_kernel_block_sizes`. ([#1384](https://github.com/vllm-project/vllm-gaudi/pull/1384))
+- Fixed MoE graph breaks from ForwardContext lookups. ([#1357](https://github.com/vllm-project/vllm-gaudi/pull/1357))
+- Reset hybrid `block_size` to 128 for tool calling. ([#1303](https://github.com/vllm-project/vllm-gaudi/pull/1303))
+- Fixed hybrid model warmup `block_size` mismatch (Qwen3.5-35B-A3B). ([#1462](https://github.com/vllm-project/vllm-gaudi/pull/1462))
+- Fixed stale gate ref overriding caller `router_logits` in dp_size==1 MoE fast path. ([#1469](https://github.com/vllm-project/vllm-gaudi/pull/1469))
+- Fixed Ernie4.5-VL test. ([#1105](https://github.com/vllm-project/vllm-gaudi/pull/1105))
+- Eliminated Llama4 torch.compile recompilations on HPU. ([#1360](https://github.com/vllm-project/vllm-gaudi/pull/1360))
+
+---
+
+## Deprecation & Breaking Changes
+
+- Removed `transformers` installation from vllm-gaudi — it is now expected to be provided by the base environment. ([#1494](https://github.com/vllm-project/vllm-gaudi/pull/1494))
+
+---
+
+## Full Changelog
+
+| PR | Title | Author |
+| --- | --- | --- |
+| [#1511](https://github.com/vllm-project/vllm-gaudi/pull/1511) | Heterogeneous and Homogeneous fixes for v0.21.0 | @hsubramony |
+| [#1510](https://github.com/vllm-project/vllm-gaudi/pull/1510) | fix: prevent eager-mode env vars leaking to lazy-mode subprocesses | @adobrzyn |
+| [#1507](https://github.com/vllm-project/vllm-gaudi/pull/1507) | fix: raise default max_cudagraph_capture_size floor to 16384 | @adobrzyn |
+| [#1503](https://github.com/vllm-project/vllm-gaudi/pull/1503) | Fix NIXL connector V1 API signature mismatches for hetero HPU | @hsubramony |
+| [#1500](https://github.com/vllm-project/vllm-gaudi/pull/1500) | QWN35: fix occasional segfault | @libinta |
+| [#1498](https://github.com/vllm-project/vllm-gaudi/pull/1498) | Fix gpt-oss mxfp4 TP partitioning and quant_method matching | @mkrze |
+| [#1494](https://github.com/vllm-project/vllm-gaudi/pull/1494) | Remove transformers installation from vllm-gaudi | @iboiko-habana |
+| [#1491](https://github.com/vllm-project/vllm-gaudi/pull/1491) | ci: route HF_TOKEN-using jobs through approved-workflow environment | @adobrzyn |
+| [#1489](https://github.com/vllm-project/vllm-gaudi/pull/1489) | Port of: Update lora tests | @iboiko-habana |
+| [#1486](https://github.com/vllm-project/vllm-gaudi/pull/1486) | Fix decode bucket generation for hybrid models with mismatched block sizes | @yangulei |
+| [#1471](https://github.com/vllm-project/vllm-gaudi/pull/1471) | Add pre-merge-approval for execute_pre_merge | @bmyrcha |
+| [#1469](https://github.com/vllm-project/vllm-gaudi/pull/1469) | Port of: Fix stale gate ref overriding caller router_logits in dp_size==1 MoE fast path | @iboiko-habana |
+| [#1466](https://github.com/vllm-project/vllm-gaudi/pull/1466) | Fix HPU prompt_token_ids device placement for penalty sampling | @yeonsily |
+| [#1462](https://github.com/vllm-project/vllm-gaudi/pull/1462) | Port of: fix: hybrid model warmup block_size mismatch (Qwen3.5-35B-A3B) | @iboiko-habana |
+| [#1460](https://github.com/vllm-project/vllm-gaudi/pull/1460) | Port of: Remove num_ctx_tokens_less_or_equal_batched_max_model_len filter | @iboiko-habana |
+| [#1459](https://github.com/vllm-project/vllm-gaudi/pull/1459) | Port of: fix: bypass _forward_impl for dp_size==1 to fix DeepSeek R1 FP8 crash | @iboiko-habana |
+| [#1458](https://github.com/vllm-project/vllm-gaudi/pull/1458) | Port of: fix: replace batched_count_greater_than to avoid dynamic shape TypeError on HPU | @iboiko-habana |
+| [#1453](https://github.com/vllm-project/vllm-gaudi/pull/1453) | Port of: fix kernel block size | @iboiko-habana |
+| [#1449](https://github.com/vllm-project/vllm-gaudi/pull/1449) | Fix mamba_type comparison for GDN hybrid cache allocation | @shepark |
+| [#1447](https://github.com/vllm-project/vllm-gaudi/pull/1447) | Fix decode bucket filter issues | @yangulei |
+| [#1446](https://github.com/vllm-project/vllm-gaudi/pull/1446) | Add torchaudio-free copies of CD Dockerfiles | @PatrykWo |
+| [#1444](https://github.com/vllm-project/vllm-gaudi/pull/1444) | [MiniMax-M2] Remove reduce_results kwarg from FusedMoE init | @mounikamandava |
+| [#1443](https://github.com/vllm-project/vllm-gaudi/pull/1443) | Harden Qwen3.5 CI test to detect regressions | @shepark |
+| [#1442](https://github.com/vllm-project/vllm-gaudi/pull/1442) | Fix for MoE refactor | @iboiko-habana |
+| [#1440](https://github.com/vllm-project/vllm-gaudi/pull/1440) | fix extra masking for batched prefill in GDN layers | @osavchenkox |
+| [#1437](https://github.com/vllm-project/vllm-gaudi/pull/1437) | MRoPE accuracy fix for Qwen | @hsubramony |
+| [#1435](https://github.com/vllm-project/vllm-gaudi/pull/1435) | fix: guard CUDA sync in hf3fs mock client for HPU compatibility | @kamil-kaczor |
+| [#1433](https://github.com/vllm-project/vllm-gaudi/pull/1433) | Fixing condition for materialised causal attn_bias | @ksmusz |
+| [#1430](https://github.com/vllm-project/vllm-gaudi/pull/1430) | fix: patch torch.accelerator.empty_cache for HPU to fix import-order dependent cleanup failures | @kamil-kaczor |
+| [#1428](https://github.com/vllm-project/vllm-gaudi/pull/1428) | Fix moe_forward hidden_dim_unpadded parameter | @pawel-olejniczak |
+| [#1425](https://github.com/vllm-project/vllm-gaudi/pull/1425) | [DOC] Fix torchaudio version | @yangulei |
+| [#1424](https://github.com/vllm-project/vllm-gaudi/pull/1424) | fix: lower eagle3 spec_decode accuracy threshold to 0.60 | @kamil-kaczor |
+| [#1422](https://github.com/vllm-project/vllm-gaudi/pull/1422) | CI cleanup v0.20.0 | @iboiko-habana |
+| [#1421](https://github.com/vllm-project/vllm-gaudi/pull/1421) | Fix upstream regressions: MoE PluggableLayer recursion, MLA attention init crashes, KV offload module consolidation | @pawel-olejniczak |
+| [#1414](https://github.com/vllm-project/vllm-gaudi/pull/1414) | Enhance process management for online model swap example | @12010486 |
+| [#1411](https://github.com/vllm-project/vllm-gaudi/pull/1411) | Fix load failure of mxfp4 gpt-oss-120b with expert parallel | @malsbat |
+| [#1410](https://github.com/vllm-project/vllm-gaudi/pull/1410) | Clarify VLLM_PROMPT_BS_BUCKET_MAX runtime behavior in docs | @iboiko-habana |
+| [#1409](https://github.com/vllm-project/vllm-gaudi/pull/1409) | Remove matmul_qk output-tensor compatibility gate after 1.24.0 | @iboiko-habana |
+| [#1405](https://github.com/vllm-project/vllm-gaudi/pull/1405) | Fix prompt logprobs gathering on Gaudi HPU | @iboiko-habana |
+| [#1403](https://github.com/vllm-project/vllm-gaudi/pull/1403) | Fix upstream regressions: MoE refactor, DeepSeek V4 router, KV offload HMA | @pawel-olejniczak |
+| [#1400](https://github.com/vllm-project/vllm-gaudi/pull/1400) | Enable defrag when contig_pa is enabled | @iboiko-habana |
+| [#1399](https://github.com/vllm-project/vllm-gaudi/pull/1399) | QA test fixes for ValueError: No common block size for 16 | @hsubramony |
+| [#1396](https://github.com/vllm-project/vllm-gaudi/pull/1396) | fix: enable Llama4 Maverick FP8 torch.compile without breaking DeepSeek | @adobrzyn |
+| [#1392](https://github.com/vllm-project/vllm-gaudi/pull/1392) | Fix warmup failure and run mm graph warmup pt compile only mode | @shepark |
+| [#1385](https://github.com/vllm-project/vllm-gaudi/pull/1385) | Update CODEOWNERS | @jbyczkow |
+| [#1384](https://github.com/vllm-project/vllm-gaudi/pull/1384) | Correct get_supported_kernel_block_sizes | @jbyczkow |
+| [#1383](https://github.com/vllm-project/vllm-gaudi/pull/1383) | fix: monkey-patch cleanup_dist_env_and_memory for HPU allocator | @kamil-kaczor |
+| [#1381](https://github.com/vllm-project/vllm-gaudi/pull/1381) | flatten 3D inputs_embeds in HpuModelAdapter.forward | @shepark |
+| [#1378](https://github.com/vllm-project/vllm-gaudi/pull/1378) | Set Docker auto calc PT_HPU_LAZY_MODE=0 as default | @nngokhale |
+| [#1377](https://github.com/vllm-project/vllm-gaudi/pull/1377) | Fix upstream breakages: NIXL connector, TpKVTopology rename, MoE refactor, transformers v5 | @pawel-olejniczak |
+| [#1375](https://github.com/vllm-project/vllm-gaudi/pull/1375) | Fix offloading test lambdas for upstream req_context parameter | @pawel-olejniczak |
+| [#1366](https://github.com/vllm-project/vllm-gaudi/pull/1366) | Prefix caching support for HPUMambaMixer2 | @jbyczkow |
+| [#1364](https://github.com/vllm-project/vllm-gaudi/pull/1364) | Logging omitted buckets when bucketing from file is enabled | @ksmusz |
+| [#1363](https://github.com/vllm-project/vllm-gaudi/pull/1363) | Set GaudiSW version in CI to 1.24.0 | @afierka-intel |
+| [#1362](https://github.com/vllm-project/vllm-gaudi/pull/1362) | Bucketing edge cases finetune for longer ctx | @ksmusz |
+| [#1360](https://github.com/vllm-project/vllm-gaudi/pull/1360) | Eliminate Llama4 torch.compile recompilations on HPU | @adobrzyn |
+| [#1357](https://github.com/vllm-project/vllm-gaudi/pull/1357) | Fix MoE graph breaks from ForwardContext lookups | @jbyczkow |
+| [#1354](https://github.com/vllm-project/vllm-gaudi/pull/1354) | Fix upstream regressions in HPU worker, MoE router, and offloading tests | @pawel-olejniczak |
+| [#1352](https://github.com/vllm-project/vllm-gaudi/pull/1352) | Add pre-merge-trigger.yaml | @bmyrcha |
+| [#1351](https://github.com/vllm-project/vllm-gaudi/pull/1351) | Accept PEP 440 versions in build detection | @wjhrdy |
+| [#1349](https://github.com/vllm-project/vllm-gaudi/pull/1349) | Add hf_config parameter to HPU quantization config overrides | @pawel-olejniczak |
+| [#1342](https://github.com/vllm-project/vllm-gaudi/pull/1342) | Fix requirements paths and nixl_connector imports after upstream restructuring | @pawel-olejniczak |
+| [#1339](https://github.com/vllm-project/vllm-gaudi/pull/1339) | Qwen3.5 changes cherry-picked from release 0.19.0 | @yeonsily |
+| [#1338](https://github.com/vllm-project/vllm-gaudi/pull/1338) | Fix upstream regressions in attention, FP8, offloading and platform | @pawel-olejniczak |
+| [#1332](https://github.com/vllm-project/vllm-gaudi/pull/1332) | Fix granite 4h block size calculations | @jkaniecki |
+| [#1329](https://github.com/vllm-project/vllm-gaudi/pull/1329) | feat: fix guard breaks and improve warmup time for Qwen3 MoE | @kamil-kaczor |
+| [#1327](https://github.com/vllm-project/vllm-gaudi/pull/1327) | Fix for proper KV cache slot addressing for Hybrid models | @ksmusz |
+| [#1324](https://github.com/vllm-project/vllm-gaudi/pull/1324) | Fix Synapse GC compile failure for FP8-quantized models | @slokesha |
+| [#1322](https://github.com/vllm-project/vllm-gaudi/pull/1322) | Separate conv1d for Granite 4.0 | @jbyczkow |
+| [#1317](https://github.com/vllm-project/vllm-gaudi/pull/1317) | Optimizing visible block number for Hybrid kv_cache | @ksmusz |
+| [#1313](https://github.com/vllm-project/vllm-gaudi/pull/1313) | Remove splitting moe decode layer compilation func | @shepark |
+| [#1311](https://github.com/vllm-project/vllm-gaudi/pull/1311) | Fix Pixtral, MoE and Granite regressions | @pawel-olejniczak |
+| [#1304](https://github.com/vllm-project/vllm-gaudi/pull/1304) | Fix regression in Mistral-Large-3-675B | @skavulya |
+| [#1303](https://github.com/vllm-project/vllm-gaudi/pull/1303) | reset hybrid block_size to 128 for tool calling | @shepark |
+| [#1291](https://github.com/vllm-project/vllm-gaudi/pull/1291) | improve selective_state_update | @osavchenkox |
+| [#1279](https://github.com/vllm-project/vllm-gaudi/pull/1279) | Upstream vLLM compatibility fix | @iboiko-habana |
+| [#1270](https://github.com/vllm-project/vllm-gaudi/pull/1270) | Granite-4.0-h Calibration config | @mfylcek |
+| [#1264](https://github.com/vllm-project/vllm-gaudi/pull/1264) | fix: HPU-specific bug fixes for KV-offload + async spec-decode | @hsubramony |
+| [#1258](https://github.com/vllm-project/vllm-gaudi/pull/1258) | Add per-model toolcalling and fp8 configs; OpenAI /v1/models/switch entrypoint | @12010486 |
+| [#1242](https://github.com/vllm-project/vllm-gaudi/pull/1242) | avoid using pip show to get habana-torch-plugin version | @dtrifiro |
+| [#1168](https://github.com/vllm-project/vllm-gaudi/pull/1168) | HPUCompressedTensorsW8A8Int8_BF16Fallback impl | @rsmyrek |
+| [#1160](https://github.com/vllm-project/vllm-gaudi/pull/1160) | Revert "Cap decode block bucket limit to reduce warmup time" | @adobrzyn |
+| [#1155](https://github.com/vllm-project/vllm-gaudi/pull/1155) | Enable slicing for the FusedSDPA | @yangulei |
+| [#1122](https://github.com/vllm-project/vllm-gaudi/pull/1122) | Fixes for the decode bucketing in non-contiguous pa scenario | @yangulei |
+| [#1105](https://github.com/vllm-project/vllm-gaudi/pull/1105) | fix ernie45-vl test | @jinyouzhi |
+| [#996](https://github.com/vllm-project/vllm-gaudi/pull/996) | Remove all lazy execution mode from the codebase | @afierka-intel |
+| [#762](https://github.com/vllm-project/vllm-gaudi/pull/762) | Add the padding-aware bucketing strategy | @yangulei |
+
+---
+
+## New Contributors
+
+Welcome to the following first-time contributors to vLLM Gaudi Plugin!
+
+- **@dtrifiro** — avoid using pip show to get habana-torch-plugin version ([#1242](https://github.com/vllm-project/vllm-gaudi/pull/1242))
+- **@malsbat** — Fix load failure of mxfp4 gpt-oss-120b with expert parallel ([#1411](https://github.com/vllm-project/vllm-gaudi/pull/1411))
+- **@mkrze** — Fix gpt-oss mxfp4 TP partitioning and quant_method matching ([#1498](https://github.com/vllm-project/vllm-gaudi/pull/1498))
+- **@mounikamandava** — [MiniMax-M2] Remove reduce_results kwarg from FusedMoE init ([#1444](https://github.com/vllm-project/vllm-gaudi/pull/1444))
+- **@osavchenkox** — fix extra masking for batched prefill in GDN layers ([#1440](https://github.com/vllm-project/vllm-gaudi/pull/1440))
+- **@wjhrdy** — Accept PEP 440 versions in build detection ([#1351](https://github.com/vllm-project/vllm-gaudi/pull/1351))

--- a/docs/release_notes_v0.24.0.md
+++ b/docs/release_notes_v0.24.0.md
@@ -1,0 +1,208 @@
+# vLLM Gaudi Plugin v0.24.0 Release Notes
+
+## Overview
+
+This release is based on [vLLM v0.24.0](https://github.com/vllm-project/vllm/releases/tag/v0.24.0) and supports [Intel® Gaudi® Software v1.24.1](https://docs.habana.ai/en/v1.24.1/Release_Notes/GAUDI_Release_Notes.html) with PyTorch 2.11.
+
+## Highlights
+
+- Upgraded platform compatibility to [Intel® Gaudi® Software v1.24.1](https://docs.habana.ai/en/v1.24.1/Release_Notes/GAUDI_Release_Notes.html) and [PyTorch 2.11](https://github.com/pytorch/pytorch/releases#release-v2.11.0).
+- Enabled upstream [vLLM v0.24.0](https://github.com/vllm-project/vllm/releases#release-v0.24.0) by adapting the HPU platform to the FusedMoE/MoERunner inversion ([vLLM #41184](https://github.com/vllm-project/vllm/pull/41184)), HPU scheduler and ngram-proposer updates, KV-connector and offloading-connector refactors, `ServingTokenization`, and the Mamba/GDN rewrite.
+- Added [Qwen3-Next](https://huggingface.co/collections/Qwen/qwen3-next) model support by registering `Qwen3NextForCausalLM` in the Mamba-like architecture set and adding `Qwen3.6-35B` CI coverage.
+- Improved FP8/INC quantization memory efficiency by freeing dead INC-quantized FP8 MoE weight copies to roughly halve device memory and resolving multiple FP8/INC calibration OOM and graph-compile regressions.
+- Switched hybrid/Mamba decode to TPC-native `causal_conv1d` operations, removing the custom conv1d update kernel.
+- Extended single-card model swapping to hybrid SSM-Transformer models, including [granite-4.0-h-small](https://huggingface.co/ibm-granite/granite-4.0-h-small).
+- Strengthened project security by adding a [SECURITY.md](https://github.com/vllm-project/vllm-gaudi/blob/main/SECURITY.md) vulnerability disclosure policy, removing the outdated and insecure `decord` dependency, and isolating `HF_TOKEN` CI jobs behind an approved-workflow environment.
+
+---
+
+## New Model Support
+
+- Validated [Qwen3.5-35B-A3B](https://huggingface.co/Qwen/Qwen3.5-35B-A3B) and [Qwen3.6-35B-A3B](https://huggingface.co/Qwen/Qwen3.6-35B-A3B) (BF16, single-card Gaudi 3) with GSM8K accuracy coverage. ([#1554](https://github.com/vllm-project/vllm-gaudi/pull/1554), [#1443](https://github.com/vllm-project/vllm-gaudi/pull/1443), [#1434](https://github.com/vllm-project/vllm-gaudi/pull/1434))
+- Added `Qwen3-Next` architecture support via `Qwen3NextForCausalLM` in the Mamba-like architecture set. ([#1450](https://github.com/vllm-project/vllm-gaudi/pull/1450))
+- Added hybrid-model support for single-card model swapping. ([#1415](https://github.com/vllm-project/vllm-gaudi/pull/1415))
+
+---
+
+## Performance
+
+- Switched to TPC-native operations for the `causal_conv1d` update. ([#1527](https://github.com/vllm-project/vllm-gaudi/pull/1527))
+- Removed the custom conv1d update TPC kernel in favor of the native path. ([#1585](https://github.com/vllm-project/vllm-gaudi/pull/1585))
+- Fixed a decode throughput regression introduced by upstream vLLM. ([#1609](https://github.com/vllm-project/vllm-gaudi/pull/1609))
+- Fixed decode bucket sparsity for long prompts. ([#1584](https://github.com/vllm-project/vllm-gaudi/pull/1584))
+- Replaced `Sampler.gather_logprobs` to remove `mark_unbacked` calls. ([#1548](https://github.com/vllm-project/vllm-gaudi/pull/1548))
+- Reduced graph (re)compilation warnings during single-process model swap. ([#1478](https://github.com/vllm-project/vllm-gaudi/pull/1478))
+- Removed the `num_ctx_tokens_less_or_equal_batched_max_model_len` filter. ([#1454](https://github.com/vllm-project/vllm-gaudi/pull/1454))
+- Fixed decode bucket filter issues. ([#1447](https://github.com/vllm-project/vllm-gaudi/pull/1447))
+
+---
+
+## Attention and KV Cache
+
+- Fixed contiguous PA wrong-rows on prefill context (perf-preserving). ([#1546](https://github.com/vllm-project/vllm-gaudi/pull/1546))
+- Fixed hetero HPU NIXL connector compatibility with upstream vLLM. ([#1534](https://github.com/vllm-project/vllm-gaudi/pull/1534))
+- Fixed HPU-specific bugs in KV-offload with async spec-decode. ([#1401](https://github.com/vllm-project/vllm-gaudi/pull/1401))
+- Fixed decode bucket generation for hybrid models with mismatched block sizes. ([#1485](https://github.com/vllm-project/vllm-gaudi/pull/1485))
+- Fixed `conv_state` corruption in compact GDN batched decode. ([#1431](https://github.com/vllm-project/vllm-gaudi/pull/1431))
+- Fixed `mamba_type` comparison for GDN hybrid cache allocation. ([#1449](https://github.com/vllm-project/vllm-gaudi/pull/1449))
+- Reverted materialised causal `attn_bias` on FSDPA for non-GDN hybrid models. ([#1482](https://github.com/vllm-project/vllm-gaudi/pull/1482))
+
+---
+
+## Quantization
+
+- Freed dead INC-quantized FP8 MoE weight copies to roughly halve device memory. ([#1583](https://github.com/vllm-project/vllm-gaudi/pull/1583))
+- Fixed Maverick FP8 INC calibration OOM after the upstream MoE refactor. ([#1590](https://github.com/vllm-project/vllm-gaudi/pull/1590))
+- Fixed DeepSeek-R1 FP8 grouped-topk MoE graph-compile failure. ([#1586](https://github.com/vllm-project/vllm-gaudi/pull/1586))
+- Fixed a dense-model INC quantization OOM regression. ([#1605](https://github.com/vllm-project/vllm-gaudi/pull/1605))
+- Fixed an FP8 dequant device mismatch. ([#1597](https://github.com/vllm-project/vllm-gaudi/pull/1597))
+- Fixed gpt-oss MxFP4 bias handling. ([#1578](https://github.com/vllm-project/vllm-gaudi/pull/1578))
+- Fixed gpt-oss MxFP4 TP partitioning and `quant_method` matching. ([#1499](https://github.com/vllm-project/vllm-gaudi/pull/1499))
+- Skipped the WNA16 MoE backend oracle on Gaudi. ([#1513](https://github.com/vllm-project/vllm-gaudi/pull/1513))
+- Bypassed `_forward_impl` for `dp_size==1` to fix a DeepSeek R1 FP8 crash. ([#1441](https://github.com/vllm-project/vllm-gaudi/pull/1441))
+- Warned when `calibrate_model.sh -u` is used on TP>1 without `-r`. ([#1607](https://github.com/vllm-project/vllm-gaudi/pull/1607))
+
+---
+
+## Plugin Core
+
+- Applied hetero fixes for upstream vLLM v0.24.0. ([#1592](https://github.com/vllm-project/vllm-gaudi/pull/1592))
+- Adapted HPU MoE to the FusedMoE/MoERunner inversion and fixed KV-connector and sampler drift. ([#1536](https://github.com/vllm-project/vllm-gaudi/pull/1536))
+- Detached the shared MoE gate when experts is the `MoERunner`. ([#1566](https://github.com/vllm-project/vllm-gaudi/pull/1566))
+- Fixed a stale MoE refactor path. ([#1442](https://github.com/vllm-project/vllm-gaudi/pull/1442))
+- Adapted HPU scheduler, ngram proposer, and offloading-connector tests to upstream API drift. ([#1556](https://github.com/vllm-project/vllm-gaudi/pull/1556))
+- Adapted `multi_model_api_server` to the vLLM `ServingTokenization` refactor. ([#1558](https://github.com/vllm-project/vllm-gaudi/pull/1558))
+- Overrode the HPU offloading handler `get_finished`/`shutdown`. ([#1525](https://github.com/vllm-project/vllm-gaudi/pull/1525))
+- Fixed the `online_model_swap` generate import after upstream resettlement. ([#1522](https://github.com/vllm-project/vllm-gaudi/pull/1522))
+- Fixed the `gdn_linear_attn` import path after the upstream Mamba refactor. ([#1496](https://github.com/vllm-project/vllm-gaudi/pull/1496))
+- Fixed `DynamicNTKScalingRotaryEmbedding` and `HPUCompressedTensorsConfig`. ([#1479](https://github.com/vllm-project/vllm-gaudi/pull/1479))
+- Fixed `MultiModelEngineClient`, Qwen3.5 compilation, and EPLB refactoring. ([#1436](https://github.com/vllm-project/vllm-gaudi/pull/1436))
+- Made `granite-4.0-h-small` compatible with single-process model swap. ([#1595](https://github.com/vllm-project/vllm-gaudi/pull/1595))
+
+---
+
+## Serving and Infrastructure
+
+- Capped `fastapi<0.137` to unbreak the Prometheus instrumentator. ([#1551](https://github.com/vllm-project/vllm-gaudi/pull/1551))
+- Pinned `transformers==5.9.0` temporarily for compatibility. ([#1530](https://github.com/vllm-project/vllm-gaudi/pull/1530))
+- Enhanced process management for the online model-swap example. ([#1414](https://github.com/vllm-project/vllm-gaudi/pull/1414))
+- Documented `--distributed-executor-backend` and `VLLM_WORKER_MULTIPROC_METHOD` in the README. ([#1448](https://github.com/vllm-project/vllm-gaudi/pull/1448))
+- Updated the LoRA tests. ([#1488](https://github.com/vllm-project/vllm-gaudi/pull/1488))
+- Hardened the Qwen3.5 CI test to detect regressions. ([#1443](https://github.com/vllm-project/vllm-gaudi/pull/1443))
+- Fixed the documented `torchaudio` version. ([#1425](https://github.com/vllm-project/vllm-gaudi/pull/1425))
+
+---
+
+## Fixes
+
+- Fixed an eager-only env var leaking into lazy subprocesses; respect user input. ([#1524](https://github.com/vllm-project/vllm-gaudi/pull/1524))
+- Fixed HPU `prompt_token_ids` device placement for penalty sampling. ([#1465](https://github.com/vllm-project/vllm-gaudi/pull/1465))
+- Fixed a stale gate ref overriding caller `router_logits` in the `dp_size==1` MoE fast path. ([#1469](https://github.com/vllm-project/vllm-gaudi/pull/1469))
+- Fixed `patch_hf3fs_mock_client_for_cpu_only`. ([#1439](https://github.com/vllm-project/vllm-gaudi/pull/1439))
+- Fixed the kernel block size. ([#1453](https://github.com/vllm-project/vllm-gaudi/pull/1453))
+- Replaced `batched_count_greater_than` to avoid a dynamic-shape `TypeError` on HPU. ([#1412](https://github.com/vllm-project/vllm-gaudi/pull/1412))
+- Fixed a hybrid-model warmup block_size mismatch (Qwen3.5-35B-A3B). ([#1434](https://github.com/vllm-project/vllm-gaudi/pull/1434))
+- Fixed M-RoPE accuracy for Qwen. ([#1437](https://github.com/vllm-project/vllm-gaudi/pull/1437))
+- Fixed an accuracy issue in `minimax_m2` with TP>1. ([#1451](https://github.com/vllm-project/vllm-gaudi/pull/1451))
+- Fixed `granite-4.0-h-small` tool-calling accuracy. ([#1561](https://github.com/vllm-project/vllm-gaudi/pull/1561))
+- Removed the `granite-4.0-h-small` OOM workaround. ([#1579](https://github.com/vllm-project/vllm-gaudi/pull/1579))
+
+---
+
+## Security
+
+- Added a [SECURITY.md](https://github.com/vllm-project/vllm-gaudi/blob/main/SECURITY.md) vulnerability disclosure policy. ([#1509](https://github.com/vllm-project/vllm-gaudi/pull/1509))
+- Removed the outdated and insecure `decord` dependency. ([#1520](https://github.com/vllm-project/vllm-gaudi/pull/1520))
+- Routed `HF_TOKEN`-using CI jobs through an approved-workflow environment. ([#1473](https://github.com/vllm-project/vllm-gaudi/pull/1473))
+- Added pre-merge approval for `execute_pre_merge`. ([#1471](https://github.com/vllm-project/vllm-gaudi/pull/1471))
+
+---
+
+## Deprecation and Breaking Changes
+
+- Upgraded to Intel® Gaudi® Software v1.24.1 and PyTorch 2.11, which requires users to update their Intel® Gaudi® software stack to [v1.24.1](https://docs.habana.ai/en/v1.24.1/Release_Notes/GAUDI_Release_Notes.html).
+- Removed `ray` and redundant `transformers` packages from the Gaudi requirements. ([#1445](https://github.com/vllm-project/vllm-gaudi/pull/1445))
+- Removed the `decord` dependency; environments relying on it must migrate to a supported decoder. ([#1520](https://github.com/vllm-project/vllm-gaudi/pull/1520))
+- Temporarily pinned `transformers==5.9.0`; expect this constraint to be relaxed in a later release. ([#1530](https://github.com/vllm-project/vllm-gaudi/pull/1530))
+
+---
+
+## Full Changelog
+
+| PR | Title | Author |
+| --- | --- | --- |
+| [#1609](https://github.com/vllm-project/vllm-gaudi/pull/1609) | [v0.24.0] Fix decode throughput regression from vLLM #42656 | @adobrzyn |
+| [#1605](https://github.com/vllm-project/vllm-gaudi/pull/1605) | [v0.24.0] Fix dense-model INC quant OOM regression from #1590 | @adobrzyn |
+| [#1607](https://github.com/vllm-project/vllm-gaudi/pull/1607) | Warn when calibrate_model.sh -u is used on TP>1 without -r | @adobrzyn |
+| [#1597](https://github.com/vllm-project/vllm-gaudi/pull/1597) | Fix FP8 dequant device mismatch | @mkrze |
+| [#1595](https://github.com/vllm-project/vllm-gaudi/pull/1595) | granite-4.0-h-small made compatible with single process models swap | @12010486 |
+| [#1592](https://github.com/vllm-project/vllm-gaudi/pull/1592) | hetero fixes for vllm v0.24.0 | @adobrzyn |
+| [#1590](https://github.com/vllm-project/vllm-gaudi/pull/1590) | Fix Maverick FP8 INC calibration OOM after #41184 MoE refactor | @iboiko-habana |
+| [#1586](https://github.com/vllm-project/vllm-gaudi/pull/1586) | Fix DeepSeek-R1 FP8 grouped-topk MoE graph compile failure | @iboiko-habana |
+| [#1585](https://github.com/vllm-project/vllm-gaudi/pull/1585) | Remove conv1d update TPC kernel | @slokesha |
+| [#1584](https://github.com/vllm-project/vllm-gaudi/pull/1584) | Fix decode bucket sparsity for longprompt | @shepark |
+| [#1583](https://github.com/vllm-project/vllm-gaudi/pull/1583) | Free dead INC-quantized FP8 MoE weight copy to halve device memory | @iboiko-habana |
+| [#1579](https://github.com/vllm-project/vllm-gaudi/pull/1579) | granite-4.0-h-small - remove OOM workaround | @rsmyrek |
+| [#1578](https://github.com/vllm-project/vllm-gaudi/pull/1578) | Gptoss mxfp4 bias v0.24.0 | @SKRohit |
+| [#1566](https://github.com/vllm-project/vllm-gaudi/pull/1566) | Detach shared MoE gate when experts is the MoERunner (vLLM #41184) | @iboiko-habana |
+| [#1561](https://github.com/vllm-project/vllm-gaudi/pull/1561) | granite-4.0-h-small - toolcalling accuracy fix | @rsmyrek |
+| [#1558](https://github.com/vllm-project/vllm-gaudi/pull/1558) | Adapt multi_model_api_server to vLLM ServingTokenization refactor | @pawel-olejniczak |
+| [#1557](https://github.com/vllm-project/vllm-gaudi/pull/1557) | 3 hourly-CI fixes | @pawel-olejniczak |
+| [#1556](https://github.com/vllm-project/vllm-gaudi/pull/1556) | Adapt HPU scheduler, ngram proposer and offloading connector tests to upstream API drift | @pawel-olejniczak |
+| [#1554](https://github.com/vllm-project/vllm-gaudi/pull/1554) | Add Qwen3.6-35B CI test | @iboiko-habana |
+| [#1548](https://github.com/vllm-project/vllm-gaudi/pull/1548) | Replace Sampler.gather_logprobs to remove mark_unbacked calls | @shepark |
+| [#1546](https://github.com/vllm-project/vllm-gaudi/pull/1546) | [HPU] Fix contiguous PA wrong-rows on prefill context (perf-preserving) | @adobrzyn |
+| [#1536](https://github.com/vllm-project/vllm-gaudi/pull/1536) | Adapt HPU MoE to the FusedMoE/MoERunner inversion and fix KV-connector and sampler drift | @pawel-olejniczak |
+| [#1534](https://github.com/vllm-project/vllm-gaudi/pull/1534) | Fix hetero HPU NIXL connector compatibility with vLLM v0.22.1rc1 | @hsubramony |
+| [#1530](https://github.com/vllm-project/vllm-gaudi/pull/1530) | Temporary fixed version transformers==5.9.0 | @iboiko-habana |
+| [#1527](https://github.com/vllm-project/vllm-gaudi/pull/1527) | [HPU] Use TPC native ops for causal_conv1d update | @slokesha |
+| [#1525](https://github.com/vllm-project/vllm-gaudi/pull/1525) | Override HPU offloading handler get_finished/shutdown | @pawel-olejniczak |
+| [#1524](https://github.com/vllm-project/vllm-gaudi/pull/1524) | Fix eager-only env var leak into lazy subprocesses; respect user input | @adobrzyn |
+| [#1522](https://github.com/vllm-project/vllm-gaudi/pull/1522) | Fix online_model_swap generate import after upstream resettlement | @pawel-olejniczak |
+| [#1520](https://github.com/vllm-project/vllm-gaudi/pull/1520) | fix: remove outdated and insecure decord dependency | @adobrzyn |
+| [#1513](https://github.com/vllm-project/vllm-gaudi/pull/1513) | Skip WNA16 MoE backend oracle on Gaudi | @pawel-olejniczak |
+| [#1509](https://github.com/vllm-project/vllm-gaudi/pull/1509) | Create SECURITY.md | @sfblackl-intel |
+| [#1508](https://github.com/vllm-project/vllm-gaudi/pull/1508) | Fix offloading connector prepare_store test | @pawel-olejniczak |
+| [#1499](https://github.com/vllm-project/vllm-gaudi/pull/1499) | Fix gpt-oss mxfp4 TP partitioning and quant_method matching | @mkrze |
+| [#1496](https://github.com/vllm-project/vllm-gaudi/pull/1496) | Fix gdn_linear_attn import path after upstream mamba refactor | @pawel-olejniczak |
+| [#1488](https://github.com/vllm-project/vllm-gaudi/pull/1488) | Update lora tests | @iboiko-habana |
+| [#1485](https://github.com/vllm-project/vllm-gaudi/pull/1485) | Fix decode bucket generation for hybrid models with mismatched block sizes | @yangulei |
+| [#1482](https://github.com/vllm-project/vllm-gaudi/pull/1482) | Revert "Skip materialised causal attn_bias on FSDPA for non-GDN hybrid models" | @rsmyrek |
+| [#1479](https://github.com/vllm-project/vllm-gaudi/pull/1479) | Fix DynamicNTKScalingRotaryEmbedding and HPUCompressedTensorsConfig | @pawel-olejniczak |
+| [#1478](https://github.com/vllm-project/vllm-gaudi/pull/1478) | Fix graph (re)compilation warnings for single process models swap | @12010486 |
+| [#1473](https://github.com/vllm-project/vllm-gaudi/pull/1473) | ci: route HF_TOKEN-using jobs through approved-workflow environment | @adobrzyn |
+| [#1471](https://github.com/vllm-project/vllm-gaudi/pull/1471) | Add pre-merge-approval for execute_pre_merge | @bmyrcha |
+| [#1469](https://github.com/vllm-project/vllm-gaudi/pull/1469) | Fix stale gate ref overriding caller router_logits in dp_size==1 MoE fast path | @iboiko-habana |
+| [#1468](https://github.com/vllm-project/vllm-gaudi/pull/1468) | Fix offloading_connector test flush assertion for load transfers | @pawel-olejniczak |
+| [#1465](https://github.com/vllm-project/vllm-gaudi/pull/1465) | Fix HPU prompt_token_ids device placement for penalty sampling | @yeonsily |
+| [#1464](https://github.com/vllm-project/vllm-gaudi/pull/1464) | Increase timeout from default 6h to 12h | @bmyrcha |
+| [#1454](https://github.com/vllm-project/vllm-gaudi/pull/1454) | Remove num_ctx_tokens_less_or_equal_batched_max_model_len filter | @yangulei |
+| [#1453](https://github.com/vllm-project/vllm-gaudi/pull/1453) | fix kernel block size | @iboiko-habana |
+| [#1451](https://github.com/vllm-project/vllm-gaudi/pull/1451) | Fix accuracy issue in minimax_m2 with TP > 1 | @skavulya |
+| [#1450](https://github.com/vllm-project/vllm-gaudi/pull/1450) | Add Qwen3NextForCausalLM to mamba_like_arch | @rsmyrek |
+| [#1449](https://github.com/vllm-project/vllm-gaudi/pull/1449) | Fix mamba_type comparison for GDN hybrid cache allocation | @shepark |
+| [#1448](https://github.com/vllm-project/vllm-gaudi/pull/1448) | README update for --distributed-executor-backend and VLLM_WORKER_MULTIPROC_METHOD | @iboiko-habana |
+| [#1447](https://github.com/vllm-project/vllm-gaudi/pull/1447) | Fix decode bucket filter issues | @yangulei |
+| [#1445](https://github.com/vllm-project/vllm-gaudi/pull/1445) | Removal of ray and redundant transformers packages from gaudi requirements | @iboiko-habana |
+| [#1443](https://github.com/vllm-project/vllm-gaudi/pull/1443) | Harden Qwen3.5 CI test to detect regressions | @shepark |
+| [#1442](https://github.com/vllm-project/vllm-gaudi/pull/1442) | Fix for MoE refactor #35178 | @iboiko-habana |
+| [#1441](https://github.com/vllm-project/vllm-gaudi/pull/1441) | fix: bypass _forward_impl for dp_size==1 to fix DeepSeek R1 FP8 crash | @kamil-kaczor |
+| [#1439](https://github.com/vllm-project/vllm-gaudi/pull/1439) | Fix patch_hf3fs_mock_client_for_cpu_only | @hsubramony |
+| [#1437](https://github.com/vllm-project/vllm-gaudi/pull/1437) | Mrope accuracy fix for qwen | @hsubramony |
+| [#1436](https://github.com/vllm-project/vllm-gaudi/pull/1436) | Fix MultiModelEngineClient, Qwen3.5 compilation, and EPLB refactoring | @pawel-olejniczak |
+| [#1434](https://github.com/vllm-project/vllm-gaudi/pull/1434) | fix: hybrid model warmup block_size mismatch (Qwen3.5-35B-A3B) | @adobrzyn |
+| [#1431](https://github.com/vllm-project/vllm-gaudi/pull/1431) | Fix conv_state corruption in compact GDN batched decode | @osavchenkox |
+| [#1415](https://github.com/vllm-project/vllm-gaudi/pull/1415) | Add hybrid models support for single card models swap | @12010486 |
+| [#1414](https://github.com/vllm-project/vllm-gaudi/pull/1414) | Enhance process management for online model swap example | @12010486 |
+| [#1412](https://github.com/vllm-project/vllm-gaudi/pull/1412) | fix: replace batched_count_greater_than to avoid dynamic shape TypeError on HPU | @kamil-kaczor |
+| [#1401](https://github.com/vllm-project/vllm-gaudi/pull/1401) | fix: HPU-specific bug fixes for KV-offload + async spec-decode | @hsubramony |
+| [#1425](https://github.com/vllm-project/vllm-gaudi/pull/1425) | [DOC] Fix torchaudio version | @yangulei |
+| [#1551](https://github.com/vllm-project/vllm-gaudi/pull/1551) | fix: cap fastapi<0.137 to unbreak prometheus instrumentator | @pawel-olejniczak |
+
+---
+
+## New Contributors
+
+Welcome to the following first-time contributor to vLLM Gaudi Plugin!
+
+- **@sfblackl-intel** — Create SECURITY.md ([#1509](https://github.com/vllm-project/vllm-gaudi/pull/1509))

--- a/docs/release_notes_v0.24.0.md
+++ b/docs/release_notes_v0.24.0.md
@@ -6,8 +6,8 @@ This release is based on [vLLM v0.24.0](https://github.com/vllm-project/vllm/rel
 
 ## Highlights
 
-- Upgraded platform compatibility to [Intel® Gaudi® Software v1.24.1](https://docs.habana.ai/en/v1.24.1/Release_Notes/GAUDI_Release_Notes.html) and [PyTorch 2.11](https://github.com/pytorch/pytorch/releases#release-v2.11.0).
-- Enabled upstream [vLLM v0.24.0](https://github.com/vllm-project/vllm/releases#release-v0.24.0) by adapting the HPU platform to the FusedMoE/MoERunner inversion ([vLLM #41184](https://github.com/vllm-project/vllm/pull/41184)), HPU scheduler and ngram-proposer updates, KV-connector and offloading-connector refactors, `ServingTokenization`, and the Mamba/GDN rewrite.
+- Upgraded platform compatibility to [Intel® Gaudi® Software v1.24.1](https://docs.habana.ai/en/v1.24.1/Release_Notes/GAUDI_Release_Notes.html) and [PyTorch 2.11](https://github.com/pytorch/pytorch/releases/tag/v2.11.0).
+- Enabled upstream [vLLM v0.24.0](https://github.com/vllm-project/vllm/releases/tag/v0.24.0) by adapting the HPU platform to the FusedMoE/MoERunner inversion ([vLLM #41184](https://github.com/vllm-project/vllm/pull/41184)), HPU scheduler and ngram-proposer updates, KV-connector and offloading-connector refactors, `ServingTokenization`, and the Mamba/GDN rewrite.
 - Added [Qwen3-Next](https://huggingface.co/collections/Qwen/qwen3-next) model support by registering `Qwen3NextForCausalLM` in the Mamba-like architecture set and adding `Qwen3.6-35B` CI coverage.
 - Improved FP8/INC quantization memory efficiency by freeing dead INC-quantized FP8 MoE weight copies to roughly halve device memory and resolving multiple FP8/INC calibration OOM and graph-compile regressions.
 - Switched hybrid/Mamba decode to TPC-native `causal_conv1d` operations, removing the custom conv1d update kernel.

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -125,6 +125,6 @@ extra_javascript:
 use_directory_urls: false
 
 extra:
-  PT_VERSION: "2.10.0"
-  VERSION: "1.24.0"
+  PT_VERSION: "2.11.0"
+  VERSION: "1.24.1"
   # VLLM_VERSION is set automatically by main.py from the latest git tag


### PR DESCRIPTION
## Summary

Cherry-picks the **v0.24.0 release documentation** from the release branch to `main`, and moves main's build baseline to **Intel® Gaudi® Software 1.24.1 / PyTorch 2.11**.

Only the changes that belong on `main` are included — the release-tag pins (`VLLM_GAUDI_COMMIT` / `VLLM_PROJECT_COMMIT=v0.24.0`) are intentionally **not** cherry-picked. Main's Dockerfiles keep `VLLM_GAUDI_COMMIT=main` and an empty `VLLM_PROJECT_COMMIT`.

## Documentation

- **README.md** — add the v0.24.0 "Latest News" entry.
- **docs/release_notes.md** — add `0.24.0`, `0.21.0`, and `0.19.1` summary sections.
- **docs/release_notes_v0.24.0.md**, **docs/release_notes_v0.21.0.md**, **docs/release_notes_v0.19.1.md** — new detailed release-notes pages (the 0.21.0 and 0.19.1 pages previously existed only on their release branches).
- **docs/getting_started/compatibility_matrix.md** — add the Gaudi 1.24.1 column and the 0.19.1 / 0.21.0 / 0.24.0 rows.
- **docs/getting_started/validated_models.md** — add validated `Qwen3.5-35B-A3B` and `Qwen3.6-35B-A3B` (BF16, Gaudi 3).

## Build baseline (main → Gaudi 1.24.1 / PyTorch 2.11)

- **mkdocs.yaml** — `VERSION` 1.24.0 → 1.24.1, `PT_VERSION` 2.10.0 → 2.11.0.
- **.cd/Dockerfile.*** (all six) — bump the base image to Gaudi 1.24.1 / PyTorch 2.11 (`SYNAPSE_REVISION` → 482). `VLLM_GAUDI_COMMIT` stays `main`, `VLLM_PROJECT_COMMIT` stays empty.

## Intentionally excluded (release-branch only)

- The `VLLM_GAUDI_COMMIT` / `VLLM_PROJECT_COMMIT=v0.24.0` release-tag pins — `main` continues to build from `main`.
