### PR TITLE
[FIX_FOR_VLLM_CUSTOM=038ec293b17d8d1018b5494a97187597b10c5182] fix: skip GPU-only blocks-first KV asserts in HPU NIXL TransferTopology

### DIFF
--- a/vllm_gaudi/distributed/kv_transfer/kv_connector/v1/hpu_nixl_connector.py
+++ b/vllm_gaudi/distributed/kv_transfer/kv_connector/v1/hpu_nixl_connector.py
@@ -3,6 +3,7 @@
 import torch
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl import NixlConnectorWorker
 from vllm.distributed.kv_transfer.kv_connector.utils import TransferTopology
+from vllm.v1.kv_cache_interface import MambaSpec
 from vllm_gaudi.platform import logger
 import habana_frameworks.torch.utils.experimental as htexp
 
@@ -136,3 +137,72 @@ def _hpu_transfer_topo_post_init(self):
 
 
 TransferTopology.__post_init__ = _hpu_transfer_topo_post_init
+
+# ── HPU TransferTopology.get_transfer_cache_regions K/V-split override ──────── #
+# Upstream vLLM PR #44455 ("Pack K/V into the content dim across attention
+# backends") rewrote get_transfer_cache_regions to always return a single
+# packed region ([cache]) and dropped the old split_k_and_v / blocks-first
+# handling.  This assumes the GPU layout where K and V are interleaved inside
+# each block, so the registered tensor is blocks-first (shape[0] == num_blocks).
+#
+# HPU allocates K and V as two *separate* per-layer tensors, surfaced to NIXL
+# as a TensorTuple((K, V)) whose leading dim is the K/V split (2), not
+# num_blocks.  With the upstream single-region path, register_kv_caches sees
+# cache.shape == (2, num_blocks, block_size, num_kv_heads, head_size) and its
+# `cache.shape[0] != num_blocks` guard raises:
+#
+#   AssertionError: All kv cache tensors must have the same number of blocks;
+#   ... cache_shape=(2, <N>, ...) ... kv_cache_layout=HND
+#
+# crashing every NIXL PD-disaggregation run right after the connector logs
+# "setting KV cache layout to HND".
+#
+# Restore the pre-#44455 behaviour for HPU: register K and V as two separate
+# blocks-first regions so each registered tensor is blocks-first
+# (shape[0] == num_blocks) again.  Mirror upstream exactly for the Mamba and
+# hybrid-SSM branches (they are backend-agnostic and already blocks-first), and
+# only iterate the tuple for the regular attention path.  MLA layers surface a
+# single tensor (not a TensorTuple), so they naturally fall through to the
+# single-region return.
+
+
+def _hpu_get_transfer_cache_regions(self, cache, layer_spec):
+    """Return the NIXL memory regions for an HPU KV cache tensor.
+
+    HPU packs K and V as two separate per-layer tensors (a K/V-split
+    ``TensorTuple``) rather than a single blocks-first tensor, so this
+    override registers each K/V half as its own blocks-first region. This
+    reverses vLLM PR #44455's single-region packing, which would otherwise
+    make ``register_kv_caches`` see a leading K/V dim of 2 and fail its
+    ``cache.shape[0] == num_blocks`` contract.
+
+    Args:
+        cache: The per-layer KV cache tensor (or ``(conv, ssm)`` for Mamba,
+            or a K/V-split ``TensorTuple`` for regular attention).
+        layer_spec: The ``KVCacheSpec`` for this layer.
+
+    Returns:
+        The tensor(s) to register as NIXL memory regions.
+    """
+    if isinstance(layer_spec, MambaSpec):
+        # Register the whole shared conv/ssm tensor (mirror upstream).
+        conv, _ssm = cache
+        return [conv]
+
+    # Mirror upstream's hybrid-SSM blocks-first transpose.
+    if self.is_mamba and cache.shape[0] == 2:
+        return [cache.transpose(0, 1)]
+
+    # HPU regular attention: K and V surface with a leading K/V-split dim of 2,
+    # either as a TensorTuple((K, V)) (no host buffer) or as a single 5-D tensor
+    # (host-buffer path).  Register each half as its own blocks-first region so
+    # `shape[0] == num_blocks` holds again.  Indexing ([0]/[1]) yields the K and
+    # V halves for both the tuple and the tensor form.
+    if not self.is_mla and len(cache) == 2:
+        return [cache[0], cache[1]]
+
+    # MLA (single tensor) and any already-blocks-first layout: single region.
+    return [cache]
+
+
+TransferTopology.get_transfer_cache_regions = _hpu_get_transfer_cache_regions

--- a/vllm_gaudi/distributed/kv_transfer/kv_connector/v1/hpu_nixl_connector.py
+++ b/vllm_gaudi/distributed/kv_transfer/kv_connector/v1/hpu_nixl_connector.py
@@ -7,7 +7,7 @@ from vllm_gaudi.platform import logger
 import habana_frameworks.torch.utils.experimental as htexp
 
 original_data_ptr = torch.Tensor.data_ptr
-#NOTE(Chendi): Temp solution for HPU htexp._data_ptr
+# NOTE(Chendi): Temp solution for HPU htexp._data_ptr
 # If same tensor assigned with two Views, the htexp._data_ptr() fails on non-in-place view.
 # So we record the mapping from original data_ptr to htexp._data_ptr
 global_data_ptr_record = {}
@@ -16,15 +16,15 @@ global_data_ptr_record = {}
 def _hpu_data_ptr(tensor_self) -> int:
     """
     A temporary replacement for tensor.data_ptr().
-    
+
     Checks if the tensor is on an HPU device and if host buffers are not
     in use, then calls the htexp._data_ptr utility. Otherwise, it falls
     back to the original method.
     """
     # The first `self` refers to the class instance (from the outer scope)
     # The `tensor_self` is the tensor instance on which .data_ptr() is called
-    if tensor_self.device.type == 'hpu':
-        #return htexp._data_ptr(tensor_self)
+    if tensor_self.device.type == "hpu":
+        # return htexp._data_ptr(tensor_self)
         v_dataptr = original_data_ptr(tensor_self)
         if v_dataptr not in global_data_ptr_record:
             p_dataptr = htexp._data_ptr(tensor_self)
@@ -67,24 +67,71 @@ def initialize_host_xfer_buffer(self, kv_caches: dict[str, torch.Tensor]) -> Non
 torch.Tensor.data_ptr = _hpu_data_ptr
 NixlConnectorWorker.initialize_host_xfer_buffer = initialize_host_xfer_buffer
 
-# ── HPU cross-layer-block false-positive fix ───────────────────────────────── #
-# TransferTopology.__post_init__ infers _cross_layers_blocks from tensor shape:
-#   _cross_layers_blocks = (len(tensor_shape) == len(kv_cache_shape) + 1)
-# On HPU, get_kv_cache_shape() returns a 3-D shape instead of the 5-D shape
-# expected by CUDA FlashAttn.  For DeepSeek MLA, the host buffer is 4-D, so
-# 4 == 3 + 1 triggers a false positive → physical_page_size gets multiplied
-# by the number of attention layers (~27× for DeepSeek-V2-Lite-Chat),
-# producing out-of-bounds NIXL transfers and KV cache corruption.
-# MLA models never use cross-layer layout, so guard the heuristic with is_mla.
-_original_transfer_topo_post_init = TransferTopology.__post_init__
+# ── HPU TransferTopology.__post_init__ layout-contract override ─────────────── #
+# Upstream vLLM PR #44455 ("Pack K/V into the content dim across attention
+# backends") added two GPU-centric layout asserts to
+# TransferTopology.__post_init__:
+#
+#   kv_cache_shape = attn_backend.get_kv_cache_shape(num_blocks=1, block_size=16,
+#                                                    num_kv_heads=1, head_size=1)
+#   assert kv_cache_shape[0] == 1, "KV cache layout must be blocks-first ..."
+#   assert len(kv_cache_shape) == 4, "[num_blocks, num_kv_heads, block_size, ...]"
+#
+# HPU's get_kv_cache_shape() fuses blocks and tokens into the leading dim
+# (num_blocks * block_size, num_kv_heads, head_size) — 3-D, block_size-first —
+# so the mocked probe returns (16, 1, 1).  Both asserts therefore fire on HPU
+# with "got shape (16, 1, 1)", crashing every NIXL PD-disaggregation run before
+# any transfer topology is built.
+#
+# The HPU layout is intentional and never blocks-first, so the GPU-only asserts
+# do not apply.  Reimplement __post_init__ for HPU: mirror upstream exactly but
+# drop the two layout asserts, preserving every persistent side effect
+# (local_physical_heads, _engines, _cross_layers_blocks + cross-layer stride
+# reordering).  The final MLA guard keeps the pre-existing HPU fix: the
+# _cross_layers_blocks dim-count heuristic (len(tensor_shape) == len(
+# kv_cache_shape) + 1) can misfire for MLA host buffers, and MLA models never
+# use cross-layer layout, so force it False.
 
 
 def _hpu_transfer_topo_post_init(self):
-    _original_transfer_topo_post_init(self)
+    self.local_physical_heads = max(1, self.total_num_kv_heads // self.tp_size)
+
+    self._engines = {}
+
+    # HPU get_kv_cache_shape() is block_size-first, not blocks-first, so the
+    # upstream blocks-first / 4-D layout asserts are intentionally skipped here.
+    attn_backend = self.attn_backends[0]
+    kv_cache_shape: tuple[int, ...] = ()
+    if not self.is_mamba:
+        _MOCK_BLOCK_SIZE = 16
+        kv_cache_shape = attn_backend.get_kv_cache_shape(
+            num_blocks=1,
+            block_size=_MOCK_BLOCK_SIZE,
+            num_kv_heads=1,
+            head_size=1,
+        )
+        logger.debug("[HPU] Test kv_cache_shape: %s", kv_cache_shape)
+
+    self._cross_layers_blocks = False
+    if self.tensor_shape is not None:
+        self._cross_layers_blocks = len(self.tensor_shape) == len(kv_cache_shape) + 1
+
+    if self._cross_layers_blocks:
+        logger.debug("[HPU] Using cross-layer KV cache")
+        _MOCK_NUM_LAYERS = 80
+        kv_cache_shape = (_MOCK_NUM_LAYERS, ) + tuple(kv_cache_shape)
+        try:
+            kv_cache_stride_order = attn_backend.get_kv_cache_stride_order(
+                include_num_layers_dimension=self._cross_layers_blocks)
+        except (AttributeError, NotImplementedError):
+            assert self.tensor_shape is not None
+            kv_cache_stride_order = tuple(range(len(self.tensor_shape)))
+        kv_cache_shape = tuple(kv_cache_shape[i] for i in kv_cache_stride_order)
+
     if self.is_mla and self._cross_layers_blocks:
         logger.warning("[HPU] TransferTopology: overriding false-positive _cross_layers_blocks=True "
-                       "for MLA model. HPU get_kv_cache_shape() returns 3-D tensors, causing "
-                       "the dim-count heuristic to misfire.  Forcing _cross_layers_blocks=False.")
+                       "for MLA model. HPU get_kv_cache_shape() fuses blocks into the leading dim, "
+                       "causing the dim-count heuristic to misfire.  Forcing _cross_layers_blocks=False.")
         self._cross_layers_blocks = False
 
 


### PR DESCRIPTION
## Root cause
Upstream vLLM PR #44455 added blocks-first / 4-D layout assertions to
`TransferTopology.__post_init__` in `kv_connector/utils.py`. These assertions
assume the GPU KV cache layout. The HPU `get_kv_cache_shape()` returns a
block_size-first 3-D shape `(16, 1, 1)`, so both assertions trip on every NIXL
PD (prefill/decode disaggregation) run:
`AssertionError: KV cache layout must be blocks-first`.

## Upstream PR
https://github.com/vllm-project/vllm/pull/44455
Introduced blocks-first / 4-D layout invariants on the NIXL TransferTopology.

## Fix
Reimplement `_hpu_transfer_topo_post_init` in the HPU NIXL connector to mirror
upstream's `__post_init__` minus the two GPU-only blocks-first assertions, which
are invalid for HPU's block_size-first 3-D KV cache shape. All other side
effects (topology construction) and the MLA cross-layer guard are preserved.

## HPU verification
- Pod: Gaudi 3
- Tests: NIXL PD (prefill/decode) connector path (FAIL before fix -> PASS after fix);
  baseline reproduces the AssertionError, patched build passes.
- Status: PASS

## Related PRs
None
