### PR TITLE
[FIX_FOR_VLLM_CUSTOM=9b2be4e9a55033a410a6f9e7c18eda5ce9105162] fix: pair SP-MoE dispatch/combine at dp_size==1 for Qwen3-30B EP (BF16 + FP8/compressed-tensors)

### DIFF
--- a/vllm_gaudi/ops/hpu_compressed_tensors.py
+++ b/vllm_gaudi/ops/hpu_compressed_tensors.py
@@ -53,6 +53,7 @@ from vllm_gaudi.extension.ops import (VllmMixtureOfExpertsOpFP8, VllmMixtureOfEx
                                       VllmMixtureOfExpertsOpWNA16)
 from vllm_gaudi.extension.runtime import get_config
 from vllm_gaudi.ops.hpu_fused_moe import _normalize_moe_activation, select_experts_from_routed
+from vllm_gaudi.v1.worker.hpu_dp_utils import dispatch_tensor
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizeMethodBase, )
 import vllm.model_executor.model_loader.weight_utils as vllm_weight_utils
@@ -538,6 +539,25 @@ class HPUCompressedTensorsW8A8Fp8MoEMethod(CompressedTensorsW8A8Fp8MoEMethod):
             topk_weights, topk_ids = torch.topk(topk_weights, layer.top_k, dim=-1)
             topk_weights /= topk_weights.sum(dim=-1, keepdim=True)
             topk_weights = topk_weights.to(x.dtype)
+
+        if layer.moe_config.is_sequence_parallel:
+            # Sequence-parallel MoE without data parallelism (TP>1 + EP with the
+            # allgather_reducescatter backend => use_sequence_parallel_moe). The
+            # model block chunks tokens by tp_size before the experts and
+            # all-gathers afterwards, expecting `self.experts` to be
+            # token-neutral. Upstream MoERunner._maybe_combine (mirrored in
+            # patched_fused_moe_forward) reduce-scatters the expert output over
+            # the EP group whenever is_sequence_parallel is set, regardless of
+            # dp_size. The paired dispatch all-gather is set up via dispatch_fn
+            # only for dp_size > 1, so at dp_size == 1 the combine is unpaired
+            # and halves the token count -> the block's final reshape fails.
+            # All-gather x / topk over the EP group here to restore the
+            # dispatch/combine symmetry (dp_metadata is None at dp_size == 1, so
+            # dispatch_tensor allocates its own EP-sized output).
+            x = dispatch_tensor(x, None, is_sequence_parallel=True)
+            topk_ids = dispatch_tensor(topk_ids, None, is_sequence_parallel=True)
+            topk_weights = dispatch_tensor(topk_weights, None, is_sequence_parallel=True)
+
         topk_ids = topk_ids.view(*x.shape[:-1], -1)
         topk_weights = topk_weights.view(*x.shape[:-1], -1)
 
@@ -548,6 +568,8 @@ class HPUCompressedTensorsW8A8Fp8MoEMethod(CompressedTensorsW8A8Fp8MoEMethod):
             permuted_weights=True,
             activation=_normalize_moe_activation(layer.activation),
         )
+        if layer.moe_config.is_sequence_parallel:
+            return output.view(*(output.size(0), *input_shape[1:]))
         return output.view(*input_shape)
 
 

--- a/vllm_gaudi/ops/hpu_fp8.py
+++ b/vllm_gaudi/ops/hpu_fp8.py
@@ -245,6 +245,17 @@ class HPUFp8MoEMethod(Fp8MoEMethod):
 
             topk_weights_across_dp = dp_metadata.topk_weights_across_dp if dp_metadata is not None else None
             topk_weights = dispatch_tensor(topk_weights, topk_weights_across_dp, is_sequence_parallel)
+        elif is_sequence_parallel:
+            # See HPUCompressedTensorsW8A8Fp8MoEMethod.apply_monolithic: at
+            # dp_size == 1 with sequence-parallel MoE (TP>1 + EP),
+            # MoERunner._maybe_combine reduce-scatters the expert output over the
+            # EP group but no paired dispatch all-gather runs (dispatch_fn is
+            # wired only for dp_size > 1). Restore symmetry by all-gathering the
+            # inputs over the EP group so the combine leaves the token count
+            # unchanged for the block's post-experts reshape.
+            x = dispatch_tensor(x, None, is_sequence_parallel=True)
+            topk_ids = dispatch_tensor(topk_ids, None, is_sequence_parallel=True)
+            topk_weights = dispatch_tensor(topk_weights, None, is_sequence_parallel=True)
 
         topk_ids = topk_ids.view(-1, topk_ids.shape[-1])
         topk_weights = topk_weights.view(-1, topk_weights.shape[-1])

--- a/vllm_gaudi/ops/hpu_fused_moe.py
+++ b/vllm_gaudi/ops/hpu_fused_moe.py
@@ -201,6 +201,23 @@ class HPUUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
 
             topk_weights_across_dp = dp_metadata.topk_weights_across_dp if dp_metadata is not None else None
             topk_weights = dispatch_tensor(topk_weights, topk_weights_across_dp, layer.moe_config.is_sequence_parallel)
+        elif layer.moe_config.is_sequence_parallel:
+            # Sequence-parallel MoE without data parallelism (TP>1 + EP with the
+            # allgather_reducescatter backend => use_sequence_parallel_moe). The
+            # model block chunks tokens by tp_size before the experts and
+            # all-gathers afterwards, expecting `self.experts` to be
+            # token-neutral. Upstream MoERunner._maybe_combine (mirrored in
+            # patched_fused_moe_forward) reduce-scatters the expert output over
+            # the EP group whenever is_sequence_parallel is set, regardless of
+            # dp_size. The paired dispatch all-gather is set up via dispatch_fn
+            # only for dp_size > 1, so at dp_size == 1 the combine is unpaired
+            # and halves the token count -> the block's final reshape fails.
+            # All-gather x / topk over the EP group here to restore the
+            # dispatch/combine symmetry (dp_metadata is None at dp_size == 1, so
+            # dispatch_tensor allocates its own EP-sized output).
+            x = dispatch_tensor(x, None, is_sequence_parallel=True)
+            topk_ids = dispatch_tensor(topk_ids, None, is_sequence_parallel=True)
+            topk_weights = dispatch_tensor(topk_weights, None, is_sequence_parallel=True)
 
         topk_ids = topk_ids.view(-1, topk_ids.shape[-1])
         topk_weights = topk_weights.view(-1, topk_weights.shape[-1])
@@ -212,7 +229,7 @@ class HPUUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
             permuted_weights=True,
             activation=_normalize_moe_activation(layer.activation),
         )
-        if layer.moe_config.dp_size > 1:
+        if layer.moe_config.dp_size > 1 or layer.moe_config.is_sequence_parallel:
             return output.view(*(output.size(0), *input_shape[1:]))
         else:
             return output.view(*input_shape)
@@ -258,18 +275,31 @@ class HPUUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
 
             topk_weights_across_dp = dp_metadata.topk_weights_across_dp if dp_metadata is not None else None
             topk_weights = dispatch_tensor(topk_weights, topk_weights_across_dp, layer.moe_config.is_sequence_parallel)
+        elif layer.moe_config.is_sequence_parallel:
+            # See apply_monolithic: at dp_size == 1 with sequence-parallel MoE
+            # (TP>1 + EP), MoERunner._maybe_combine reduce-scatters the expert
+            # output over the EP group but no paired dispatch all-gather runs
+            # (dispatch_fn is wired only for dp_size > 1). Restore symmetry by
+            # all-gathering the inputs over the EP group so the combine leaves
+            # the token count unchanged for the block's post-experts reshape.
+            x = dispatch_tensor(x, None, is_sequence_parallel=True)
+            topk_ids = dispatch_tensor(topk_ids, None, is_sequence_parallel=True)
+            topk_weights = dispatch_tensor(topk_weights, None, is_sequence_parallel=True)
 
         topk_ids = topk_ids.view(-1, topk_ids.shape[-1])
         topk_weights = topk_weights.view(-1, topk_weights.shape[-1])
 
         if self.model_type in ["gpt_oss"]:
-            return layer.moe_op(
+            gpt_oss_out = layer.moe_op(
                 x,
                 topk_ids.to(torch.int64),
                 topk_weights.to(x.dtype),
                 permuted_weights=True,
                 activation=_normalize_moe_activation(layer.activation),
-            ).view(*input_shape)
+            )
+            if layer.moe_config.dp_size > 1 or layer.moe_config.is_sequence_parallel:
+                return gpt_oss_out.view(*(gpt_oss_out.size(0), *input_shape[1:]))
+            return gpt_oss_out.view(*input_shape)
 
         output = layer.moe_op(
             x,
@@ -278,7 +308,7 @@ class HPUUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
             permuted_weights=True,
             activation=_normalize_moe_activation(layer.activation),
         )
-        if layer.moe_config.dp_size > 1:
+        if layer.moe_config.dp_size > 1 or layer.moe_config.is_sequence_parallel:
             return output.view(*(output.size(0), *input_shape[1:]))
         else:
             return output.view(*input_shape)


### PR DESCRIPTION
## Root cause
At `dp_size == 1` with sequence-parallel MoE (TP>1 + EP, i.e.
`use_sequence_parallel_moe`), the HPU expert method reduce-scatters its output
via `MoERunner._maybe_combine` but skips the paired dispatch all-gather
(previously wired only for `dp_size > 1`). This halves the token count on the
combine path, so the block's post-experts reshape is invalid for the smaller
tensor and crashes in the Dynamo fake-tensor trace with
`shape '[8192, 2048]' is invalid for input of size 8388608` (tokens 8192 -> 4096,
at `vllm_gaudi/models/qwen3_moe.py` `reshape(*orig_shape[:-1], hidden_dim)`).

## Upstream PR
https://github.com/vllm-project/vllm/pull/41184
Reworked the fused-MoE sequence-parallel dispatch/combine wiring (FusedMoE ->
MoERunner inversion), which exposed the unpaired combine on the HPU path at
`dp_size == 1`, independent of `dp_size`.

## Fix
Restore dispatch/combine symmetry across **every** HPU MoE method the Qwen3-30B
TP2+EP config can hit. When `is_sequence_parallel` and `dp_size == 1`,
all-gather `x` / `topk_ids` / `topk_weights` over the EP group and return the
gathered token count, so `self.experts(...)` stays token-neutral and the block
reshape invariant holds.

Two commits, one per MoE code path (they are separate implementations, so the
first commit alone left the FP8-static path crashing):
- **BF16 / unquantized** — `HPUUnquantizedFusedMoEMethod` (`apply_monolithic`
  and `forward_oot`) in `vllm_gaudi/ops/hpu_fused_moe.py`.
- **FP8-static / plain-fp8** — `HPUCompressedTensorsW8A8Fp8MoEMethod`
  (`hpu_compressed_tensors.py`, the live path for `quantization=compressed-tensors`,
  which had no dispatch at all) and `HPUFp8MoEMethod` (`hpu_fp8.py`, which
  dispatched only for `dp_size > 1`).

`HPUCompressedTensorsWNA16MoEMethod` (w4a16) is left untouched — not exercised
by these jobs.