### PR TITLE
[FIX_FOR_VLLM_CUSTOM=c4dd6d78fd6485e103d71ba815b0a530e5c49439] fix: adapt HPU KV-offload + MLA to vLLM #48150/#48251 API drift

### DIFF
--- a/tests/unit_tests/kv_offload/offloading_connector/utils.py
+++ b/tests/unit_tests/kv_offload/offloading_connector/utils.py
@@ -15,7 +15,7 @@ from tests.unit_tests.kv_offload.utils import (
     create_vllm_config,
 )
 from vllm import SamplingParams
-from vllm.config import KVTransferConfig, VllmConfig, set_current_vllm_config
+from vllm.config import KVTransferConfig, set_current_vllm_config
 from vllm.distributed.kv_transfer.kv_connector.v1 import KVConnectorRole
 from vllm.distributed.kv_transfer.kv_connector.v1.offloading.common import (
     OffloadingConnectorMetadata,
@@ -51,6 +51,7 @@ from vllm.v1.kv_offload.base import (
     TransferResult,
     make_offload_key,
 )
+from vllm.v1.kv_offload.config import OffloadingConfig
 from vllm.v1.structured_output import StructuredOutputManager
 
 
@@ -119,8 +120,8 @@ class MockOffloadingWorker(OffloadingWorker):
 
 class MockOffloadingSpec(OffloadingSpec):
 
-    def __init__(self, vllm_config: VllmConfig, kv_cache_config: KVCacheConfig):
-        super().__init__(vllm_config, kv_cache_config)
+    def __init__(self, config: OffloadingConfig):
+        super().__init__(config)
 
         self.manager = MagicMock(spec=OffloadingManager)
         self.manager.prepare_load = lambda keys, req_context: MockLoadStoreSpec(keys)
@@ -236,8 +237,8 @@ class RequestRunner:
 
         assert len(self.connector_scheduler.config.kv_group_configs) == 1
         kv_group_config = self.connector_scheduler.config.kv_group_configs[0]
-        assert kv_group_config.gpu_block_size == gpu_block_size
-        assert kv_group_config.offloaded_block_size == offloaded_block_size
+        assert kv_group_config.tokens_per_block == gpu_block_size
+        assert kv_group_config.tokens_per_chunk == offloaded_block_size
 
         # extract OffloadingSpec of worker_connector
         connector_worker = self.worker_connector.connector_worker

--- a/vllm_gaudi/attention/backends/hpu_attn.py
+++ b/vllm_gaudi/attention/backends/hpu_attn.py
@@ -19,6 +19,7 @@ from vllm_gaudi.extension.utils import (FP8Matmul, Matmul, B2BMatmul, ModuleFuse
 from vllm.v1.attention.backend import (AttentionBackend, AttentionImpl, AttentionLayer, AttentionMetadata,
                                        AttentionType, MultipleOf)
 from vllm.model_executor.layers.attention.mla_attention import (MLACommonImpl)
+from vllm.model_executor.utils import replace_parameter
 from vllm_gaudi.attention.ops.hpu_paged_attn import (HPUPagedAttention, HPUPagedAttentionMetadata,
                                                      HPUPagedAttentionMetadataBuilder)
 
@@ -356,13 +357,15 @@ class HPUMLAImpl(MLACommonImpl[HPUAttentionMetadata], torch.nn.Module):
     # during each graph execution
     def process_weights_after_loading(self, act_dtype: torch.dtype):
         super().process_weights_after_loading(act_dtype)
-        # W_UV and W_UK_T are plain tensor attributes (not nn.Parameter or
-        # register_buffer), so model.to('hpu') won't move them.  When INC
-        # CPU-first loading is active the source weights live on CPU, making
-        # these derived tensors CPU-resident too — which then causes a device
-        # mismatch at the bmm calls in forward.  Explicitly place on HPU.
-        self.W_UV: torch.Tensor = self.W_UV.contiguous().to("hpu")
-        self.W_UK_T: torch.Tensor = self.W_UK_T.contiguous().to("hpu")
+        # Since vllm#48251 the base process_weights_after_loading registers
+        # W_UV and W_UK_T as nn.Parameter (via replace_parameter), so a plain
+        # tensor reassignment raises TypeError. Route the contiguous/.to("hpu")
+        # update back through replace_parameter to preserve the registration.
+        # When INC CPU-first loading is active the source weights live on CPU,
+        # making these derived tensors CPU-resident too — which then causes a
+        # device mismatch at the bmm calls in forward.  Explicitly place on HPU.
+        replace_parameter(self, "W_UV", self.W_UV.contiguous().to("hpu"))
+        replace_parameter(self, "W_UK_T", self.W_UK_T.contiguous().to("hpu"))
 
     # NOTE(Chendi): PR25184 using output buffer as default, which can't be used in HPU Graph,
     # so we override and always return a new tensor

--- a/vllm_gaudi/attention/oot_mla.py
+++ b/vllm_gaudi/attention/oot_mla.py
@@ -9,6 +9,7 @@ from vllm.config import get_current_vllm_config
 from vllm.model_executor.custom_op import PluggableLayer
 from vllm.model_executor.layers.attention import MLAAttention
 from vllm.model_executor.layers.mla import MultiHeadLatentAttentionWrapper
+from vllm.model_executor.utils import replace_parameter
 from vllm_gaudi.extension.utils import VLLMKVCache
 from vllm_gaudi.extension.utils import (FP8Matmul, Matmul, B2BMatmul, ModuleFusedSDPA, Softmax, VLLMFP8KVCache)
 from vllm_gaudi.attention.backends.hpu_attn import HPUMLAMetadata
@@ -203,8 +204,12 @@ class HPUMLAAttention(MLAAttention):
         else:
             # Non-FP8 kv_b_proj: use upstream logic as before.
             MLAAttention.process_weights_after_loading(self, act_dtype)
-            self.W_UV = self.W_UV.contiguous()
-            self.W_UK_T = self.W_UK_T.contiguous()
+            # Since vllm#48251 base registers W_UV/W_UK_T as nn.Parameter (via
+            # replace_parameter), so a plain tensor reassignment raises
+            # TypeError. Route the contiguous() update through replace_parameter
+            # to preserve the registration.
+            replace_parameter(self, "W_UV", self.W_UV.contiguous())
+            replace_parameter(self, "W_UK_T", self.W_UK_T.contiguous())
 
     # NOTE(Chendi): PR25184 using output buffer as default, which can't be used in HPU Graph,
     # so we override and always return a new tensor

--- a/vllm_gaudi/v1/kv_offload/worker/cpu_hpu.py
+++ b/vllm_gaudi/v1/kv_offload/worker/cpu_hpu.py
@@ -357,11 +357,16 @@ def register_kv_caches(
     instead of a single torch.Tensor for attention layers. This override
     handles that by treating each element of the tuple as a separate
     canonical tensor (similar to the FlashAttention unbind case).
+
+    The KV cache config is read from the connector worker instance
+    (``self.kv_cache_config``) to match upstream ``OffloadingConnectorWorker``
+    after vLLM PR #48150, which moved ``kv_cache_config`` off the offloading
+    spec and onto the worker.
     """
     tensors_per_block: dict[str, tuple[torch.Tensor, ...]] = {}
     page_size_bytes: dict[str, int] = {}
 
-    for kv_cache_group in self.spec.kv_cache_config.kv_cache_groups:
+    for kv_cache_group in self.kv_cache_config.kv_cache_groups:
         group_layer_names = kv_cache_group.layer_names
         group_kv_cache_spec = kv_cache_group.kv_cache_spec
         if isinstance(group_kv_cache_spec, UniformTypeKVCacheSpecs):
@@ -396,7 +401,7 @@ def register_kv_caches(
     # Build CanonicalKVCaches
     block_tensors: list[CanonicalKVCacheTensor] = []
     block_data_refs: dict[str, list[CanonicalKVCacheRef]] = defaultdict(list)
-    for kv_cache_tensor in self.spec.kv_cache_config.kv_cache_tensors:
+    for kv_cache_tensor in self.kv_cache_config.kv_cache_tensors:
         tensor_layer_names = kv_cache_tensor.shared_by
 
         first_layer_name = tensor_layer_names[0]
@@ -416,7 +421,7 @@ def register_kv_caches(
                     ))
 
     group_data_refs: list[list[CanonicalKVCacheRef]] = []
-    for kv_cache_group in self.spec.kv_cache_config.kv_cache_groups:
+    for kv_cache_group in self.kv_cache_config.kv_cache_groups:
         group_refs: list[CanonicalKVCacheRef] = []
         for layer_name in kv_cache_group.layer_names:
             group_refs += block_data_refs[layer_name]

--- a/vllm_gaudi/v1/kv_offload/worker/cpu_hpu.py
+++ b/vllm_gaudi/v1/kv_offload/worker/cpu_hpu.py
@@ -256,7 +256,7 @@ def shutdown(self) -> None:
 def CPUOffloadingWorker_init_(
     self,
     kv_caches: CanonicalKVCaches,
-    block_size_factor: int,
+    blocks_per_chunk: int,
     num_cpu_blocks: int,
     mmap_region=None,
 ):
@@ -269,7 +269,11 @@ def CPUOffloadingWorker_init_(
 
     Args:
         kv_caches: canonical GPU KV cache tensors to offload.
-        block_size_factor: ratio of CPU page size to GPU page size.
+        blocks_per_chunk: ratio of CPU page size to GPU page size. Renamed
+            from ``block_size_factor`` to match the upstream constructor
+            contract after vLLM PR #48150; the value is passed unchanged into
+            the HPU ``SingleDirectionOffloadingHandler`` as its
+            ``block_size_factor`` argument.
         num_cpu_blocks: number of CPU blocks to allocate.
         mmap_region: unused on HPU; accepted for upstream API parity.
     """
@@ -281,7 +285,7 @@ def CPUOffloadingWorker_init_(
     for kv_cache_tensor in kv_caches.tensors:
         gpu_page_size_bytes = kv_cache_tensor.page_size_bytes
         gpu_tensor = kv_cache_tensor.tensor.view(torch.int8).view((-1, gpu_page_size_bytes))
-        cpu_page_size_bytes = gpu_page_size_bytes * block_size_factor
+        cpu_page_size_bytes = gpu_page_size_bytes * blocks_per_chunk
         cpu_tensor = torch.zeros(
             (num_cpu_blocks, cpu_page_size_bytes),
             dtype=torch.int8,
@@ -295,7 +299,7 @@ def CPUOffloadingWorker_init_(
     self._store_handler = SingleDirectionOffloadingHandler(
         gpu_tensors=gpu_tensors,
         cpu_tensors=cpu_tensors,
-        block_size_factor=block_size_factor,
+        block_size_factor=blocks_per_chunk,
         kv_cache_groups_data_refs=kv_caches.group_data_refs,
         gpu_to_cpu=True,
     )
@@ -303,7 +307,7 @@ def CPUOffloadingWorker_init_(
     self._load_handler = SingleDirectionOffloadingHandler(
         gpu_tensors=gpu_tensors,
         cpu_tensors=cpu_tensors,
-        block_size_factor=block_size_factor,
+        block_size_factor=blocks_per_chunk,
         kv_cache_groups_data_refs=kv_caches.group_data_refs,
         gpu_to_cpu=False,
     )


### PR DESCRIPTION
## Root cause
Two independent upstream API changes broke the HPU fork:

**vLLM #48150** reworked the KV-offload spec/worker API:
- Collapsed `OffloadingSpec.__init__(vllm_config, kv_cache_config)` into a single `OffloadingConfig` argument; `create_spec` now calls `spec_cls(config)`.
- Moved `kv_cache_config` off `CPUOffloadingSpec` onto `OffloadingConnectorWorker` (`self.kv_cache_config`).
- Renamed the CPU/GPU page-size ratio kwarg on `CPUOffloadingWorker.__init__` from `block_size_factor` to `blocks_per_chunk`.
- Renamed `GroupOffloadConfig` fields (`gpu_block_size` -> `tokens_per_block`, `offloaded_block_size` -> `tokens_per_chunk`).

**vLLM #48251** changed base `MLAAttention.process_weights_after_loading` to register `W_UV` / `W_UK_T` as `nn.Parameter` via `replace_parameter`.

## Upstream PRs
- https://github.com/vllm-project/vllm/pull/48150
- https://github.com/vllm-project/vllm/pull/48251

## Fix
- **tests/.../offloading_connector/utils.py**: `MockOffloadingSpec.__init__` takes a single `OffloadingConfig` and forwards to `super().__init__(config)`; import `OffloadingConfig`, drop unused `VllmConfig`; rename `RequestRunner` asserts to `tokens_per_block` / `tokens_per_chunk`. Fixes `TypeError: MockOffloadingSpec.__init__() missing 1 required positional argument: 'kv_cache_config'` on every `test_scheduler.py` collection.
- **vllm_gaudi/v1/kv_offload/worker/cpu_hpu.py**: HPU `register_kv_caches` reads `self.kv_cache_config` instead of `self.spec.kv_cache_config`; rename worker override kwarg `block_size_factor` -> `blocks_per_chunk` (semantics unchanged — `gpu_page_size * blocks_per_chunk`), pass through to `SingleDirectionOffloadingHandler` as `block_size_factor`. Fixes `TypeError` at EngineCore startup.
- **vllm_gaudi/attention/backends/hpu_attn.py, vllm_gaudi/attention/oot_mla.py**: route the post-load `W_UV` / `W_UK_T` update through `replace_parameter` so the `nn.Parameter` registration survives; the plain `contiguous().to('hpu')` reassignment tripped `nn.Module.__setattr__` -> `TypeError`.