### PR TITLE
[FIX_FOR_VLLM_CUSTOM=8def3cdde2a0acf0019447d8fcfc57e4df6bcfc2] Restore HPU MLA dcp_q_replicate attr (vllm#45964) and fix offloading_connector test lambda arity (vllm#48679)

### DIFF
--- a/tests/unit_tests/kv_offload/offloading_connector/test_scheduler.py
+++ b/tests/unit_tests/kv_offload/offloading_connector/test_scheduler.py
@@ -93,13 +93,13 @@ def test_offloading_connector(request_runner, async_scheduling: bool):
     runner.scheduler.reset_prefix_cache()
     runner.new_request(token_ids=[0] * offloaded_block_size)
     runner.manager.prepare_store.side_effect = (lambda block_hashes, req_context: generate_store_output([]))
-    runner.connector_scheduler._maximal_prefix_lookup = lambda key, req_context: 1
+    runner.connector_scheduler._maximal_prefix_lookup = lambda key, req_context, *_: 1
     runner.run(decoded_tokens=[EOS_TOKEN_ID], expected_loaded_gpu_block_indexes=(0, 1, 2))
 
     # single block lookup with a hit in a middle block
     runner.new_request(token_ids=[0] * offloaded_block_size * 2 + [1] * offloaded_block_size)
     runner.manager.prepare_store.side_effect = (lambda block_hashes, req_context: generate_store_output([]))
-    runner.connector_scheduler._maximal_prefix_lookup = lambda key, req_context: 1
+    runner.connector_scheduler._maximal_prefix_lookup = lambda key, req_context, *_: 1
     runner.run(decoded_tokens=[EOS_TOKEN_ID], expected_loaded_gpu_block_indexes=(3, 4, 5))
 
 
@@ -152,7 +152,7 @@ def test_request_preemption(request_runner, async_scheduling: bool):
 
     # request should now return from preemption
     # re-load [0, ..., 8] from the CPU and store [9, 10, 11]
-    runner.connector_scheduler._maximal_prefix_lookup = lambda key, req_context: 3
+    runner.connector_scheduler._maximal_prefix_lookup = lambda key, req_context, *_: 3
     runner.manager.prepare_store.side_effect = (lambda block_hashes, req_context: generate_store_output(block_hashes))
     runner.run(
         decoded_tokens=[0] * gpu_block_size,
@@ -192,7 +192,7 @@ def test_concurrent_lookups_of_the_same_prefix(request_runner, async_scheduling:
     # start a request to load the first block, but don't complete
     runner.scheduler.reset_prefix_cache()
     runner.new_request(token_ids=[0] * offloaded_block_size)
-    runner.connector_scheduler._maximal_prefix_lookup = lambda key, req_context: 1
+    runner.connector_scheduler._maximal_prefix_lookup = lambda key, req_context, *_: 1
     runner.run(
         decoded_tokens=[],
         complete_transfers=False,
@@ -204,7 +204,7 @@ def test_concurrent_lookups_of_the_same_prefix(request_runner, async_scheduling:
 
     # start a new request to load the same first block
     runner.new_request(token_ids=[0] * offloaded_block_size)
-    runner.connector_scheduler._maximal_prefix_lookup = lambda key, req_context: 1
+    runner.connector_scheduler._maximal_prefix_lookup = lambda key, req_context, *_: 1
     runner.run(
         decoded_tokens=[],
         complete_transfers=False,
@@ -254,7 +254,7 @@ def test_abort_loading_requests(request_runner, async_scheduling: bool):
     # start a request to load the first block, but don't complete
     runner.scheduler.reset_prefix_cache()
     runner.new_request(token_ids=[0] * offloaded_block_size)
-    runner.connector_scheduler._maximal_prefix_lookup = lambda key, req_context: 1
+    runner.connector_scheduler._maximal_prefix_lookup = lambda key, req_context, *_: 1
     runner.run(
         decoded_tokens=[],
         complete_transfers=False,

--- a/vllm_gaudi/attention/oot_mla.py
+++ b/vllm_gaudi/attention/oot_mla.py
@@ -61,7 +61,14 @@ class HPUMLAAttention(MLAAttention):
         kv_c_normed: torch.Tensor,
         k_pe: torch.Tensor,
         output_shape: torch.Size | None = None,
+        q_dcp_replicated: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        # `q_dcp_replicated` was added to the base MLAAttention.forward signature
+        # by vllm#45964 (DCP query replication for MLA decode). Decode-context
+        # parallelism is not enabled on HPU, so the inherited wrapper forward
+        # always passes this as None; accept and ignore it to keep the HPU path
+        # behaviourally identical to pre-#45964.
+        del q_dcp_replicated
         if self.calculate_kv_scales:
             torch.ops.vllm.maybe_calc_kv_scales(q, kv_c_normed, k_pe, self.layer_name)
 
@@ -268,6 +275,13 @@ class HPUMultiHeadLatentAttentionWrapper(MultiHeadLatentAttentionWrapper):
         self.is_sparse = mla_modules.is_sparse
 
         self.skip_topk = skip_topk
+        # vllm#45964 (DCP query replication) added `self.dcp_q_replicate`, which
+        # the base MultiHeadLatentAttentionWrapper.forward (inherited here, since
+        # we do not override forward) reads and forwards to mla_attn. Because we
+        # bypass super().__init__(), replicate the upstream assignment. DCP is
+        # not enabled on HPU, so `qrep_active` is absent and this stays False.
+        q_proj_layer = self.q_b_proj if self.q_lora_rank is not None else self.q_proj
+        self.dcp_q_replicate = getattr(q_proj_layer, "qrep_active", False)
         if self.indexer is not None:
             assert hasattr(self.indexer, "topk_tokens")
             self.topk_tokens = self.indexer.topk_tokens


### PR DESCRIPTION
## Summary

Two independent hourly-CI fixes pinned to vLLM `8def3cdde2a0acf0019447d8fcfc57e4df6bcfc2`.

### 1. `fix(mla): set dcp_q_replicate on HPU MLA wrapper` (d20dd313)
- **Root cause:** `HPUMultiHeadLatentAttentionWrapper` bypasses `super().__init__()` and omitted the `dcp_q_replicate` attribute that upstream vllm-project/vllm#45964 added; the inherited base forward reads it and passes `q_dcp_replicated` to `mla_attn`.
- **Fix:** replicate `self.dcp_q_replicate = getattr(q_proj_layer, "qrep_active", False)` in `__init__` and accept/ignore `q_dcp_replicated` in `HPUMLAAttention.forward`.
- **Symptom:** `AttributeError: 'HPUMultiHeadLatentAttentionWrapper' object has no attribute 'dcp_q_replicate'` crashing EngineCore/Worker init across 6 DeepSeek/MLA e2e jobs.

### 2. `fix(test): match _maximal_prefix_lookup 5-arg arity after vllm #48679` (7912d549)
- **Root cause:** upstream vllm-project/vllm#48679 widened `OffloadingScheduler._maximal_prefix_lookup` to `(keys, req_context, req, group_config, start_chunk_idx)`; the scheduler now calls it with 5 positional args but the test monkeypatch lambda accepted only 2.
- **Fix:** absorb the 3 extra positional args with `*_` in the `_maximal_prefix_lookup` monkeypatch lambdas, mirroring upstream's own test fix.
- **Symptom:** `TypeError: test_offloading_connector.<locals>.<lambda>() takes 2 positional arguments but 5 were given` in run_unit_tests.
