### PR TITLE
Improve MiniMax-M3 MoE decode performance after upstream merge

### DIFF
--- a/docs/configuration/env_variables.md
+++ b/docs/configuration/env_variables.md
@@ -26,6 +26,9 @@ This document lists the supported diagnostic and profiling, as well as performan
 | `VLLM_ROW_PARALLEL_CHUNKS`   | Number of chunks to split input into for pipelining matmul with all-reduce in RowParallelLinear layers. Setting to a value greater than 1 enables chunking. See [Row-Parallel Chunking](../features/row_parallel_chunking.md). | `1` (disabled) |
 | `VLLM_ROW_PARALLEL_CHUNK_THRESHOLD` | Minimum number of tokens required to activate row-parallel chunking. Inputs below this threshold use the standard non-chunked path. | `8192` |
 | `VLLM_PROMPT_BS_BUCKET_MAX`  | Sets prefill batch size | `1` |
+| `VLLM_MINIMAX_M3_MOE_TOKEN_TILE` | Maximum number of tokens processed per tile by the MiniMax-M3 dense SwiGLU-OAI expert path. Non-positive values disable tiling. | `512` |
+| `VLLM_MINIMAX_M3_MOE_DECODE_GATHER` | Enables the MiniMax-M3 routed-expert gather path for low-token decode. Set to `0` or `false` to use the dense expert path. | `true` |
+| `VLLM_MINIMAX_M3_MOE_GATHER_MAX_TOKENS` | Maximum token count for the MiniMax-M3 routed-expert gather path. Larger batches use the dense expert path. | `16` |
 
 Use `VLLM_BUCKETING_STRATEGY=exp` for the default exponential warm-up, `VLLM_BUCKETING_STRATEGY=lin` for explicitly configured linear ranges, or `VLLM_BUCKETING_STRATEGY=pad` for padding-aware ranges with absolute and relative padding limits.
 

--- a/tests/unit_tests/ops/test_hpu_fused_moe.py
+++ b/tests/unit_tests/ops/test_hpu_fused_moe.py
@@ -1,10 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
+
+import pytest
 import torch
 import habana_frameworks.torch as htorch
 from utils import get_data_path, create_fused_moe
-from vllm_gaudi.ops.hpu_fused_moe import HPUUnquantizedFusedMoEMethod
+import vllm_gaudi.ops.hpu_fused_moe as hpu_fused_moe
+from vllm_gaudi.ops.hpu_fused_moe import (
+    HPUUnquantizedFusedMoEMethod,
+    _gather_swigluoai_moe,
+    _unfused_swigluoai_moe,
+)
 from vllm_gaudi.utils import HPUCompileConfig
 from vllm.forward_context import ForwardContext, override_forward_context
 from safetensors import safe_open
@@ -47,3 +55,106 @@ def test_unquantized_fused_moe_method(default_vllm_config: None, dist_init):
 
     # Check correctness
     torch.testing.assert_close(ref_output, out, atol=1e-4, rtol=1e-4)
+
+
+@pytest.mark.parametrize(("tokens", "ep_rank"), [(1, 0), (2, 1), (8, 0)])
+def test_gather_swigluoai_moe_matches_dense(tokens: int, ep_rank: int):
+    num_experts = 64
+    top_k = 8
+    hidden_size = 16
+    intermediate_size = 12
+    experts_min = ep_rank * num_experts
+
+    layer = SimpleNamespace(
+        w13_weight=torch.randn(
+            num_experts,
+            2 * intermediate_size,
+            hidden_size,
+            dtype=torch.bfloat16,
+            device="hpu",
+        ),
+        w2_weight=torch.randn(
+            num_experts,
+            hidden_size,
+            intermediate_size,
+            dtype=torch.bfloat16,
+            device="hpu",
+        ),
+        moe_config=SimpleNamespace(ep_rank=ep_rank),
+        local_num_experts=num_experts,
+    )
+    x = torch.randn(tokens, hidden_size, dtype=torch.bfloat16, device="hpu")
+    local_ids = (torch.arange(tokens * top_k, device="hpu").view(tokens, top_k) + 3) % num_experts
+    topk_ids = local_ids + experts_min
+    if ep_rank > 0:
+        topk_ids[:, 0] = 0  # Expert owned by another EP rank.
+    topk_weights = torch.softmax(
+        torch.randn(tokens, top_k, dtype=torch.float32, device="hpu"),
+        dim=-1,
+    ).to(torch.bfloat16)
+
+    dense = _unfused_swigluoai_moe(
+        layer,
+        x,
+        topk_ids,
+        topk_weights,
+        alpha=1.702,
+        beta=1.0,
+        limit=7.0,
+    )
+    gathered = _gather_swigluoai_moe(
+        layer,
+        x,
+        topk_ids,
+        topk_weights,
+        alpha=1.702,
+        beta=1.0,
+        limit=7.0,
+    )
+
+    torch.testing.assert_close(gathered, dense, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize(
+    ("enabled", "tokens", "top_k", "expected_path"),
+    [
+        (True, 1, 8, "gather"),
+        (True, 16, 2, "gather"),
+        (True, 17, 2, "dense"),
+        (True, 16, 4, "dense"),
+        (False, 1, 8, "dense"),
+    ],
+)
+def test_swigluoai_moe_dispatch(monkeypatch, enabled: bool, tokens: int, top_k: int, expected_path: str):
+    calls: list[str] = []
+
+    def gather(*args, **kwargs):
+        calls.append("gather")
+        return args[1]
+
+    def dense(*args, **kwargs):
+        calls.append("dense")
+        return args[1]
+
+    monkeypatch.setattr(hpu_fused_moe, "_MOE_DECODE_GATHER", enabled)
+    monkeypatch.setattr(hpu_fused_moe, "_MOE_GATHER_MAX_TOKENS", 16)
+    monkeypatch.setattr(hpu_fused_moe, "_gather_swigluoai_moe", gather)
+    monkeypatch.setattr(hpu_fused_moe, "_unfused_swigluoai_moe", dense)
+
+    layer = SimpleNamespace(w13_weight=torch.empty(64, 1, 1))
+    x = torch.empty(tokens, 1)
+    topk_ids = torch.empty(tokens, top_k, dtype=torch.int64)
+    topk_weights = torch.empty(tokens, top_k)
+
+    result = hpu_fused_moe._swigluoai_moe(
+        layer,
+        x,
+        topk_ids,
+        topk_weights,
+        alpha=1.702,
+        beta=1.0,
+        limit=7.0,
+    )
+
+    assert result is x
+    assert calls == [expected_path]

--- a/vllm_gaudi/envs.py
+++ b/vllm_gaudi/envs.py
@@ -13,6 +13,9 @@ if TYPE_CHECKING:
     VLLM_NIXL_SIDE_CHANNEL_PORT: int = 5600
     VLLM_HPU_NIXL_JOINT_KV: bool = False
     VLLM_HPU_NIXL_STAGING_SLOTS: int = 0
+    VLLM_MINIMAX_M3_MOE_TOKEN_TILE: int = 512
+    VLLM_MINIMAX_M3_MOE_DECODE_GATHER: bool = True
+    VLLM_MINIMAX_M3_MOE_GATHER_MAX_TOKENS: int = 16
 
 # The begin-* and end* here are used by the documentation generator
 # to extract the used env vars.
@@ -70,6 +73,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # value if you are certain peak concurrent transfer demand stays under it.
     "VLLM_HPU_NIXL_STAGING_SLOTS":
     lambda: int(os.environ.get("VLLM_HPU_NIXL_STAGING_SLOTS", "0")),
+
+    # MiniMax-M3 SwiGLU-OAI expert execution tuning.
+    "VLLM_MINIMAX_M3_MOE_TOKEN_TILE":
+    lambda: int(os.environ.get("VLLM_MINIMAX_M3_MOE_TOKEN_TILE", "512")),
+    "VLLM_MINIMAX_M3_MOE_DECODE_GATHER":
+    lambda: os.environ.get("VLLM_MINIMAX_M3_MOE_DECODE_GATHER", "1").lower() in ("1", "true"),
+    "VLLM_MINIMAX_M3_MOE_GATHER_MAX_TOKENS":
+    lambda: int(os.environ.get("VLLM_MINIMAX_M3_MOE_GATHER_MAX_TOKENS", "16")),
 }
 
 # end-env-vars-definition

--- a/vllm_gaudi/ops/hpu_fused_moe.py
+++ b/vllm_gaudi/ops/hpu_fused_moe.py
@@ -27,6 +27,7 @@ from vllm.model_executor.layers.fused_moe.router.routing_simulator_router import
     RoutingSimulatorRouter, )
 from vllm.model_executor.layers.fused_moe.router.zero_expert_router import (
     ZeroExpertRouter, )
+import vllm_gaudi.envs as gaudi_envs
 from vllm_gaudi.extension.ops import VllmMixtureOfExpertsOp
 from vllm_gaudi.extension.runtime import get_config
 from vllm_gaudi.utils import has_quant_config
@@ -63,7 +64,7 @@ _SWIGLU_OAI_ACTIVATION = "swigluoai_uninterleave"
 # with ``synStatus 26 [Generic failure]``. Tiling the token dimension bounds the
 # size of every fused graph/op while keeping the math and per-tile shapes static,
 # which the HPU graph compiler requires. Tunable via env for large-prompt tuning.
-_SWIGLU_OAI_TOKEN_TILE = int(os.environ.get("VLLM_MINIMAX_M3_MOE_TOKEN_TILE", "512"))
+_SWIGLU_OAI_TOKEN_TILE = gaudi_envs.VLLM_MINIMAX_M3_MOE_TOKEN_TILE
 
 
 def _unfused_swigluoai_moe(
@@ -185,11 +186,10 @@ def _unfused_swigluoai_moe(
 #
 # Enabled by default for MiniMax-M3 low-concurrency decode. Set
 # VLLM_MINIMAX_M3_MOE_DECODE_GATHER=0 to use the dense expert pass instead.
-_MOE_DECODE_GATHER = os.environ.get("VLLM_MINIMAX_M3_MOE_DECODE_GATHER", "1") == "1"
+_MOE_DECODE_GATHER = gaudi_envs.VLLM_MINIMAX_M3_MOE_DECODE_GATHER
 # Only gather when the batch is at most this many tokens (bounds gather to the
 # low-concurrency decode regime where it wins; above it the dense pass is used).
-_MOE_GATHER_MAX_TOKENS = int(
-    os.environ.get("VLLM_MINIMAX_M3_MOE_GATHER_MAX_TOKENS", "16"))
+_MOE_GATHER_MAX_TOKENS = gaudi_envs.VLLM_MINIMAX_M3_MOE_GATHER_MAX_TOKENS
 
 
 def _gather_swigluoai_moe(
@@ -211,7 +211,7 @@ def _gather_swigluoai_moe(
     static-shape / no-drop / bit-exactness argument.
     """
     w13 = layer.w13_weight  # [E_local, 2*I, H]
-    w2 = layer.w2_weight    # [E_local, H, I]
+    w2 = layer.w2_weight  # [E_local, H, I]
     experts_min = int(layer.moe_config.ep_rank * layer.local_num_experts)
 
     e_local = w13.shape[0]
@@ -224,7 +224,7 @@ def _gather_swigluoai_moe(
     g = min(e_local, tokens * k)
 
     # Per-(token, local-expert) combine weight, identical to the dense pass.
-    local_ids = topk_ids - experts_min                        # [T, K]
+    local_ids = topk_ids - experts_min  # [T, K]
     in_range = (local_ids >= 0) & (local_ids < e_local)
     safe_ids = torch.where(in_range, local_ids, torch.zeros_like(local_ids))
     gate_w = x.new_zeros(tokens, e_local, dtype=torch.float32)
@@ -236,24 +236,24 @@ def _gather_swigluoai_moe(
 
     # Pick the G local experts to compute (sorted ascending so the per-token
     # accumulation order matches the dense index-order pass -> bit-exact).
-    hit = (gate_w > 0).to(torch.float32).sum(0)               # [E_local]
-    gather_ids = torch.topk(hit, g, sorted=False).indices     # [G]
-    gather_ids, _ = torch.sort(gather_ids)                    # ascending ids
+    hit = (gate_w > 0).to(torch.float32).sum(0)  # [E_local]
+    gather_ids = torch.topk(hit, g, sorted=False).indices  # [G]
+    gather_ids, _ = torch.sort(gather_ids)  # ascending ids
 
-    w13_g = w13.index_select(0, gather_ids)                   # [G, 2I, H]
-    w2_g = w2.index_select(0, gather_ids)                     # [G, H, I]
-    gate_wg = gate_w.index_select(1, gather_ids)              # [T, G]
+    w13_g = w13.index_select(0, gather_ids)  # [G, 2I, H]
+    w2_g = w2.index_select(0, gather_ids)  # [G, H, I]
+    gate_wg = gate_w.index_select(1, gather_ids)  # [T, G]
 
     # Expert MLP over the gathered experts (static shapes, no host sync).
-    xe = x.unsqueeze(0).expand(g, tokens, hidden)             # [G, T, H]
-    h = torch.bmm(xe, w13_g.transpose(1, 2))                  # [G, T, 2I]
+    xe = x.unsqueeze(0).expand(g, tokens, hidden)  # [G, T, H]
+    h = torch.bmm(xe, w13_g.transpose(1, 2))  # [G, T, 2I]
     gg = h[..., :d].float()
     uu = h[..., d:].float()
     if limit is not None:
         gg = gg.clamp(max=limit)
         uu = uu.clamp(min=-limit, max=limit)
     act = (gg * torch.sigmoid(alpha * gg) * (uu + beta)).to(x.dtype)  # [G, T, I]
-    y = torch.bmm(act, w2_g.transpose(1, 2))                  # [G, T, H] partial
+    y = torch.bmm(act, w2_g.transpose(1, 2))  # [G, T, H] partial
 
     # Match the dense pass's accumulation EXACTLY so the result is bit-identical:
     # _unfused_swigluoai_moe sums experts within each 32-expert index chunk in
@@ -261,13 +261,13 @@ def _gather_swigluoai_moe(
     # Reproduce the same chunk grouping + rounding here (gathered experts are
     # grouped by their original index // chunk; experts absent from a chunk
     # contribute exact +0.0, which never perturbs an fp sum).
-    cont = y.float() * gate_wg.t().unsqueeze(-1)              # [G, T, H] fp32
+    cont = y.float() * gate_wg.t().unsqueeze(-1)  # [G, T, H] fp32
     chunk = 32
     chunk_of = torch.div(gather_ids, chunk, rounding_mode="floor")  # [G]
-    acc = x.new_zeros(tokens, hidden)                         # [T, H] bf16
+    acc = x.new_zeros(tokens, hidden)  # [T, H] bf16
     n_chunks = (e_local + chunk - 1) // chunk
     for c in range(n_chunks):
-        m = (chunk_of == c).to(cont.dtype)                   # [G]
+        m = (chunk_of == c).to(cont.dtype)  # [G]
         acc = acc + (cont * m[:, None, None]).sum(0).to(x.dtype)
     return acc
 
@@ -289,14 +289,9 @@ def _swigluoai_moe(
     tokens = x.shape[0]
     k = topk_ids.shape[-1]
     e_local = layer.w13_weight.shape[0]
-    if (_MOE_DECODE_GATHER and tokens <= _MOE_GATHER_MAX_TOKENS
-            and tokens * k < e_local):
-        return _gather_swigluoai_moe(
-            layer, x, topk_ids, topk_weights,
-            alpha=alpha, beta=beta, limit=limit)
-    return _unfused_swigluoai_moe(
-        layer, x, topk_ids, topk_weights,
-        alpha=alpha, beta=beta, limit=limit)
+    if (_MOE_DECODE_GATHER and tokens <= _MOE_GATHER_MAX_TOKENS and tokens * k < e_local):
+        return _gather_swigluoai_moe(layer, x, topk_ids, topk_weights, alpha=alpha, beta=beta, limit=limit)
+    return _unfused_swigluoai_moe(layer, x, topk_ids, topk_weights, alpha=alpha, beta=beta, limit=limit)
 
 
 def model_has_quant_config() -> bool:

--- a/vllm_gaudi/ops/hpu_fused_moe.py
+++ b/vllm_gaudi/ops/hpu_fused_moe.py
@@ -183,10 +183,9 @@ def _unfused_swigluoai_moe(
 # (padding experts contribute exactly +0.0), so the result is numerically
 # identical to ``_unfused_swigluoai_moe`` (bit-exact; validated).
 #
-# Gated OFF by default (VLLM_MINIMAX_M3_MOE_DECODE_GATHER=1 to enable), so this
-# patch is a no-op until the flag is set -- existing behavior is unchanged.
-_MOE_DECODE_GATHER = os.environ.get(
-    "VLLM_MINIMAX_M3_MOE_DECODE_GATHER", "0") == "1"
+# Enabled by default for MiniMax-M3 low-concurrency decode. Set
+# VLLM_MINIMAX_M3_MOE_DECODE_GATHER=0 to use the dense expert pass instead.
+_MOE_DECODE_GATHER = os.environ.get("VLLM_MINIMAX_M3_MOE_DECODE_GATHER", "1") == "1"
 # Only gather when the batch is at most this many tokens (bounds gather to the
 # low-concurrency decode regime where it wins; above it the dense pass is used).
 _MOE_GATHER_MAX_TOKENS = int(

--- a/vllm_gaudi/ops/hpu_fused_moe.py
+++ b/vllm_gaudi/ops/hpu_fused_moe.py
@@ -163,6 +163,143 @@ def _unfused_swigluoai_moe(
     return out_tiles[0] if len(out_tiles) == 1 else torch.cat(out_tiles, dim=0)
 
 
+# --- Decode-time expert gather (bandwidth reduction) -------------------------
+# The dense pass above reads EVERY local expert's weights for every token
+# (E_local expert-weight reads) even though each token routes to only top_k
+# experts. At small token counts (single-stream / low-concurrency decode) the
+# number of DISTINCT local experts the batch touches is at most ``tokens * K``,
+# which can be far below E_local. This path gathers only those experts' weights
+# via ``index_select`` so only ``G = min(E_local, tokens * K)`` experts stream
+# from HBM instead of E_local -- up to ``E_local / G`` fewer expert-weight
+# bytes/token, the dominant single-stream decode cost.
+#
+# Static shapes (HPU graph-compiler requirement): ``G`` is a function of the
+# static (bucketed) token count, so every shape is fixed per warmup bucket and
+# the decode-bucket graphs compile once during warmup (no per-step recompile).
+# Because the number of distinct hit experts is provably ``<= tokens * K <= G``,
+# every routed expert is always included -- no token is ever dropped and there
+# is NO data-dependent overflow branch. Gathering ids sorted ascending makes the
+# per-token expert accumulation order identical to the dense index-order pass
+# (padding experts contribute exactly +0.0), so the result is numerically
+# identical to ``_unfused_swigluoai_moe`` (bit-exact; validated).
+#
+# Gated OFF by default (VLLM_MINIMAX_M3_MOE_DECODE_GATHER=1 to enable), so this
+# patch is a no-op until the flag is set -- existing behavior is unchanged.
+_MOE_DECODE_GATHER = os.environ.get(
+    "VLLM_MINIMAX_M3_MOE_DECODE_GATHER", "0") == "1"
+# Only gather when the batch is at most this many tokens (bounds gather to the
+# low-concurrency decode regime where it wins; above it the dense pass is used).
+_MOE_GATHER_MAX_TOKENS = int(
+    os.environ.get("VLLM_MINIMAX_M3_MOE_GATHER_MAX_TOKENS", "16"))
+
+
+def _gather_swigluoai_moe(
+    layer,
+    x: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    *,
+    alpha: float,
+    beta: float,
+    limit: float | None,
+) -> torch.Tensor:
+    """Expert-gather SwiGLU-OAI MLP: compute only the routed experts.
+
+    Numerically identical to :func:`_unfused_swigluoai_moe` (same per-rank,
+    pre-all-reduce partial; same fp32 SwiGLU-OAI math and expert accumulation
+    order) but reads only ``G = min(E_local, tokens * K)`` expert weights from
+    HBM instead of all ``E_local``. See the module comment above for the
+    static-shape / no-drop / bit-exactness argument.
+    """
+    w13 = layer.w13_weight  # [E_local, 2*I, H]
+    w2 = layer.w2_weight    # [E_local, H, I]
+    experts_min = int(layer.moe_config.ep_rank * layer.local_num_experts)
+
+    e_local = w13.shape[0]
+    d = w13.shape[1] // 2
+    hidden = x.shape[-1]
+    tokens = x.shape[0]
+    k = topk_ids.shape[-1]
+
+    # Static gathered-expert count (>= number of distinct hit experts).
+    g = min(e_local, tokens * k)
+
+    # Per-(token, local-expert) combine weight, identical to the dense pass.
+    local_ids = topk_ids - experts_min                        # [T, K]
+    in_range = (local_ids >= 0) & (local_ids < e_local)
+    safe_ids = torch.where(in_range, local_ids, torch.zeros_like(local_ids))
+    gate_w = x.new_zeros(tokens, e_local, dtype=torch.float32)
+    gate_w.scatter_add_(
+        1,
+        safe_ids,
+        torch.where(in_range, topk_weights, torch.zeros_like(topk_weights)).to(torch.float32),
+    )
+
+    # Pick the G local experts to compute (sorted ascending so the per-token
+    # accumulation order matches the dense index-order pass -> bit-exact).
+    hit = (gate_w > 0).to(torch.float32).sum(0)               # [E_local]
+    gather_ids = torch.topk(hit, g, sorted=False).indices     # [G]
+    gather_ids, _ = torch.sort(gather_ids)                    # ascending ids
+
+    w13_g = w13.index_select(0, gather_ids)                   # [G, 2I, H]
+    w2_g = w2.index_select(0, gather_ids)                     # [G, H, I]
+    gate_wg = gate_w.index_select(1, gather_ids)              # [T, G]
+
+    # Expert MLP over the gathered experts (static shapes, no host sync).
+    xe = x.unsqueeze(0).expand(g, tokens, hidden)             # [G, T, H]
+    h = torch.bmm(xe, w13_g.transpose(1, 2))                  # [G, T, 2I]
+    gg = h[..., :d].float()
+    uu = h[..., d:].float()
+    if limit is not None:
+        gg = gg.clamp(max=limit)
+        uu = uu.clamp(min=-limit, max=limit)
+    act = (gg * torch.sigmoid(alpha * gg) * (uu + beta)).to(x.dtype)  # [G, T, I]
+    y = torch.bmm(act, w2_g.transpose(1, 2))                  # [G, T, H] partial
+
+    # Match the dense pass's accumulation EXACTLY so the result is bit-identical:
+    # _unfused_swigluoai_moe sums experts within each 32-expert index chunk in
+    # fp32, rounds that partial to bf16, then accumulates across chunks in bf16.
+    # Reproduce the same chunk grouping + rounding here (gathered experts are
+    # grouped by their original index // chunk; experts absent from a chunk
+    # contribute exact +0.0, which never perturbs an fp sum).
+    cont = y.float() * gate_wg.t().unsqueeze(-1)              # [G, T, H] fp32
+    chunk = 32
+    chunk_of = torch.div(gather_ids, chunk, rounding_mode="floor")  # [G]
+    acc = x.new_zeros(tokens, hidden)                         # [T, H] bf16
+    n_chunks = (e_local + chunk - 1) // chunk
+    for c in range(n_chunks):
+        m = (chunk_of == c).to(cont.dtype)                   # [G]
+        acc = acc + (cont * m[:, None, None]).sum(0).to(x.dtype)
+    return acc
+
+
+def _swigluoai_moe(
+    layer,
+    x: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    *,
+    alpha: float,
+    beta: float,
+    limit: float | None,
+) -> torch.Tensor:
+    """Dispatch SwiGLU-OAI experts: gather only routed experts at small token
+    counts (low-concurrency decode), else the dense pass. Both return the
+    identical per-rank partial; the split is purely a bandwidth optimization.
+    """
+    tokens = x.shape[0]
+    k = topk_ids.shape[-1]
+    e_local = layer.w13_weight.shape[0]
+    if (_MOE_DECODE_GATHER and tokens <= _MOE_GATHER_MAX_TOKENS
+            and tokens * k < e_local):
+        return _gather_swigluoai_moe(
+            layer, x, topk_ids, topk_weights,
+            alpha=alpha, beta=beta, limit=limit)
+    return _unfused_swigluoai_moe(
+        layer, x, topk_ids, topk_weights,
+        alpha=alpha, beta=beta, limit=limit)
+
+
 def model_has_quant_config() -> bool:
     """Whether the active model runs with a MoE quantization config.
 
@@ -363,8 +500,9 @@ class HPUUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
 
         activation = _normalize_moe_activation(layer.activation)
         if activation == _SWIGLU_OAI_ACTIVATION:
-            # Habana fused MoE lacks SwiGLU-OAI; compute the experts unfused.
-            output = _unfused_swigluoai_moe(
+            # Habana fused MoE lacks SwiGLU-OAI; compute the experts unfused
+            # (dense), or gather-only routed experts at low-conc decode.
+            output = _swigluoai_moe(
                 layer,
                 x,
                 topk_ids,
@@ -455,8 +593,9 @@ class HPUUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
 
         activation = _normalize_moe_activation(layer.activation)
         if activation == _SWIGLU_OAI_ACTIVATION:
-            # Habana fused MoE lacks SwiGLU-OAI; compute the experts unfused.
-            output = _unfused_swigluoai_moe(
+            # Habana fused MoE lacks SwiGLU-OAI; compute the experts unfused
+            # (dense), or gather-only routed experts at low-conc decode.
+            output = _swigluoai_moe(
                 layer,
                 x,
                 topk_ids,


### PR DESCRIPTION
## Summary

Reduces HBM bandwidth for MiniMax-M3 SwiGLU-OAI MoE during low-concurrency decode by computing only the routed experts instead of every local expert. This is a follow-up optimization after the upstream MoE merge.

## Motivation

The existing dense SwiGLU-OAI path reads **every** local expert's weights for every token, even though each token routes to only `top_k` experts. At small token counts (single-stream / low-concurrency decode), the number of *distinct* experts the batch touches is at most `tokens * K`, which is often far below `E_local`. Reading all expert weights from HBM is the dominant single-stream decode cost.

## Changes

- **New expert-gather decode path** (`_gather_swigluoai_moe`): gathers only the `G = min(E_local, tokens * K)` routed experts via `index_select`, streaming up to `E_local / G` fewer expert-weight bytes per token. It is:
  - **Bit-exact** with the dense path — reproduces the same fp32 SwiGLU-OAI math and the same per-chunk accumulation/rounding order (ascending expert ids, absent experts contribute exact `+0.0`).
  - **Static-shaped** — `G` depends only on the bucketed token count, so decode-bucket graphs compile once during warmup with no per-step recompile and no data-dependent overflow branch (no token is ever dropped).
- **Dispatcher** (`_swigluoai_moe`): routes to the gather path at low token counts and falls back to the dense path otherwise; wired into both `HPUUnquantizedFusedMoEMethod` forward paths.
- **New env vars** (in `vllm_gaudi/envs.py`, documented in `docs/configuration/env_variables.md`):
  - `VLLM_MINIMAX_M3_MOE_DECODE_GATHER` (default `true`) — enable/disable the gather path.
  - `VLLM_MINIMAX_M3_MOE_GATHER_MAX_TOKENS` (default `16`) — max batch size for the gather path.
  - `VLLM_MINIMAX_M3_MOE_TOKEN_TILE` (default `512`) — now sourced through `vllm_gaudi.envs` instead of a raw `os.environ` read.
- **Tests**: extended `tests/unit_tests/ops/test_hpu_fused_moe.py` to cover the gather path, including bit-exactness against the dense path.