### PR TITLE
[FIX_FOR_VLLM_CUSTOM=439f336212227833e126526d3c5f3ef3968dfbf5] Restore is_interleaved helper removed upstream

### DIFF
--- a/vllm_gaudi/ops/hpu_mamba_mixer2.py
+++ b/vllm_gaudi/ops/hpu_mamba_mixer2.py
@@ -4,6 +4,8 @@
 # Added by the IBM Team, 2024
 # Adapted from https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/layers/mamba/mamba_mixer2.py
 
+import logging
+
 import torch
 import torch.nn.functional as F
 from torch import nn
@@ -42,6 +44,8 @@ from vllm_gaudi.ops.granite_causal_conv1d import (
 )
 from vllm_gaudi.ops.ssd_combined import hpu_mamba_chunk_scan_combined_varlen
 from vllm_gaudi.ops.ops_selector import get_selective_state_update_impl
+
+logger = logging.getLogger(__name__)
 
 
 # Adapted from vllm.model_executor.layers.mamba.mamba_mixer2.Mixer2RMSNormGated
@@ -256,6 +260,19 @@ class HPUMambaMixer2(MambaMixer2):
         self.model_config = model_config
         self.cache_config = cache_config
         self.prefix = prefix
+
+        # ReplaySSM (upstream vLLM #48018) caches SSM decode inputs in extra
+        # KV-cache tensors. The HPU conv+SSM path (conv_ssm_forward) and the
+        # hardcoded 2-tuple self.kv_cache above implement only the non-replay
+        # layout, so the feature is forced off on HPU. The base
+        # MambaMixer2.__init__ sets these attributes and the inherited
+        # get_state_shape()/get_state_dtype() read them during EngineCore
+        # init; since HPUMambaMixer2 overrides __init__ entirely, set them
+        # explicitly to avoid AttributeError.
+        if cache_config is not None and getattr(cache_config, "use_replayssm", False):
+            logger.warning("ReplaySSM is not supported on HPU; forcing use_replayssm=False for layer %s", prefix)
+        self.use_replayssm = False
+        self.replayssm_buffer_len = None
 
         # Pre-compute sizes for forward pass
         self.tped_intermediate_size = self.intermediate_size // self.tp_size

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -91,7 +91,6 @@ from vllm.distributed.parallel_state import get_pp_group, get_dp_group
 from vllm.model_executor.models.interfaces import (supports_eagle3, supports_transcription)
 from vllm.model_executor.models.interfaces_base import (VllmModelForPooling, is_pooling_model, is_text_generation_model)
 from vllm.tasks import GenerationTask, PoolingTask, SupportedTask
-from vllm.transformers_utils.config import is_interleaved
 from vllm.v1.worker.utils import (AttentionGroup, prepare_kernel_block_sizes, sanity_check_mm_encoder_outputs)
 from vllm.v1.sample.rejection_sampler import RejectionSampler
 from vllm.v1.spec_decode.eagle import EagleProposer
@@ -131,6 +130,27 @@ from vllm_gaudi.extension.logger import logger as init_logger
 from vllm.model_executor.models.bert import _encode_token_type_ids
 
 logger = init_logger()
+
+
+def is_interleaved(config: Any) -> bool:
+    """Detect if the model with this config uses interleaved attention.
+
+    Restores the helper removed from ``vllm.transformers_utils.config`` by
+    upstream vLLM PR #49803 (commit ``26d725c334``), which inlined the check
+    at its former call sites. vllm-gaudi still relies on it in three places.
+
+    Args:
+        config: A ``PretrainedConfig`` (or any config exposing
+            ``get_text_config``).
+
+    Returns:
+        True if the text config declares more than one distinct layer type.
+    """
+    text_config = config.get_text_config()
+    if layer_types := getattr(text_config, "layer_types", None):
+        return len(set(layer_types)) > 1
+    return False
+
 
 try:
     from lmcache.integration.vllm.vllm_v1_adapter import LMCacheConnectorMetadata


### PR DESCRIPTION
## Root cause
Upstream vLLM PR #49803 (commit 26d725c334) removed the `is_interleaved`
helper from `vllm.transformers_utils.config`, inlining the check at its former
call sites. The HPU model runner still imported that symbol at module load, so
`EngineCore` / worker init crashed with
`ImportError: cannot import name 'is_interleaved' from 'vllm.transformers_utils.config'`
across run_unit_tests, data_parallel, pd_disaggregate and ~50 e2e
load/generate jobs.

## Upstream PR
https://github.com/vllm-project/vllm/pull/49803
Removed `is_interleaved` from `vllm.transformers_utils.config` and inlined the
layer-type check at its call sites.

## Fix
Define a local `is_interleaved(config)` helper in
`vllm_gaudi/v1/worker/hpu_model_runner.py` (identical behaviour to the removed
upstream helper: True when the text config declares more than one distinct
layer type) and drop the now-dead top-level import.

## Bug 2: set use_replayssm on HPUMambaMixer2

- **State machine id**: granite_4_h_hpumambamixer2_use_replayssm_missing
- **Commit**: c219434891d11dfdeb4760c3ea0eda8b8364a21d
- **vllm pin (this fix)**: 439f336212227833e126526d3c5f3ef3968dfbf5
- **Root cause**: Upstream vLLM PR #48018 (ReplaySSM) added `self.use_replayssm` / `self.replayssm_buffer_len` to `MambaMixer2.__init__`, read by the inherited `get_state_shape()` / `get_state_dtype()` during EngineCore init. `HPUMambaMixer2` overrides `__init__` and never set them, so Granite-4-H crashed with `AttributeError: 'HPUMambaMixer2' object has no attribute 'use_replayssm'`.
- **Upstream**: https://github.com/vllm-project/vllm/pull/48018
- **Fix**: Set `use_replayssm=False` and `replayssm_buffer_len=None` in the HPU `__init__` (HPU has no replay decode kernel; conv+SSM path is non-replay).
- **Verification**: HPU re-verify of full stack PASS against vllm@439f336212227833e126526d3c5f3ef3968dfbf5 (granite-4.0-h-small e2e load/generate; both fixes exercised, EngineCore init clean, coherent generations).
