### PR TITLE
NIXL examples: port disagg accuracy test script fixes to v0.26.0

### DIFF
--- a/examples/nixl/run_hpu_disagg_accuracy_test.sh
+++ b/examples/nixl/run_hpu_disagg_accuracy_test.sh
@@ -95,8 +95,8 @@ run_tests_for_model() {
     BASE_CMD="CUDA_VISIBLE_DEVICES=$GPU_ID VLLM_NIXL_SIDE_CHANNEL_PORT=$SIDE_CHANNEL_PORT vllm serve $model_name \
     --port $PORT \
     --enforce-eager \
-    --disable-log-requests \
     --gpu-memory-utilization 0.3 \
+    --served-model-name meta-llama/Llama-3.1-8B \
     --tensor-parallel-size $PREFILLER_TP_SIZE \
     --kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\",\"kv_buffer_device\":\"cpu\"}'"
 
@@ -129,8 +129,8 @@ run_tests_for_model() {
     BASE_CMD="CUDA_VISIBLE_DEVICES=$GPU_ID VLLM_NIXL_SIDE_CHANNEL_PORT=$SIDE_CHANNEL_PORT vllm serve $model_name \
     --port $PORT \
     --enforce-eager \
-    --disable-log-requests \
     --gpu-memory-utilization 0.3 \
+    --served-model-name meta-llama/Llama-3.1-8B \
     --tensor-parallel-size $DECODER_TP_SIZE \
     --kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\",\"kv_buffer_device\":\"cpu\"}'"
 
@@ -159,7 +159,7 @@ run_tests_for_model() {
   done
 
   # Build the command for the proxy server with all the hosts and ports
-  PROXY_CMD="python toy_proxy_server.py --port 9192"
+  PROXY_CMD="python toy_proxy_server.py --port 9195"
 
   # Add all prefill hosts and ports
   PROXY_CMD+=" --prefiller-hosts ${PREFILL_HOSTS[@]}"
@@ -176,7 +176,7 @@ run_tests_for_model() {
   # Wait for the proxy to start
   sleep 10
   
-# curl -X POST -s http://localhost:9192/v1/completions \
+# curl -X POST -s http://localhost:9195/v1/completions \
 #	-H "Content-Type: application/json" \
 #	-d '{
 #	"model": "meta-llama/Llama-3.1-8B",
@@ -186,7 +186,7 @@ run_tests_for_model() {
 #	}'
 	sleep 5
 	echo "--------------------===================-------------"
-curl -X POST -s http://localhost:9192/v1/completions \
+curl -X POST -s http://localhost:9195/v1/completions \
         -H "Content-Type: application/json" \
         -d '{
         "model": "meta-llama/Llama-3.1-8B",
@@ -194,7 +194,7 @@ curl -X POST -s http://localhost:9192/v1/completions \
         "max_tokens": 5,
         "temperature": 0
         }'
- curl -X POST -s http://localhost:9192/v1/completions \
+ curl -X POST -s http://localhost:9195/v1/completions \
        -H "Content-Type: application/json" \
        -d '{
        "model": "meta-llama/Llama-3.1-8B",
@@ -206,7 +206,7 @@ curl -X POST -s http://localhost:9192/v1/completions \
   #sleep 10000
   # Run lm eval for this model
   echo "Running tests for $model_name"
-  TEST_MODEL=$model_name python -m pytest -s -x test_accuracy.py
+  TEST_MODEL=meta-llama/Llama-3.1-8B python -m pytest -s -x test_accuracy.py
 
   # Clean up before running next model
   cleanup_instances

--- a/examples/nixl/run_hpu_disagg_accuracy_test_hpubuf.sh
+++ b/examples/nixl/run_hpu_disagg_accuracy_test_hpubuf.sh
@@ -117,6 +117,7 @@ run_tests_for_model() {
     --enforce-eager \
     --gpu-memory-utilization 0.3 \
     --tensor-parallel-size $PREFILLER_TP_SIZE \
+    --served-model-name meta-llama/Llama-3.1-8B \
     --block-size 128 \
     --max-model-len 8192 \
     --max-num-batched-tokens 99999 \
@@ -154,6 +155,7 @@ run_tests_for_model() {
     --enforce-eager \
     --gpu-memory-utilization 0.3 \
     --tensor-parallel-size $DECODER_TP_SIZE \
+    --served-model-name meta-llama/Llama-3.1-8B \
     --block-size 128 \
     --max-model-len 8192 \
     --max-num-batched-tokens 99999 \
@@ -232,7 +234,7 @@ curl -X POST -s http://localhost:9195/v1/completions \
   #sleep 10000
   # Run lm eval for this model
   echo "Running tests for $model_name"
-  TEST_MODEL=$model_name python -m pytest -s -x test_accuracy.py
+  TEST_MODEL=meta-llama/Llama-3.1-8B python -m pytest -s -x test_accuracy.py
 
   # Clean up before running next model
   cleanup_instances

--- a/examples/nixl/run_hpu_disagg_hetero_combined.sh
+++ b/examples/nixl/run_hpu_disagg_hetero_combined.sh
@@ -129,6 +129,7 @@ run_tests_for_model() {
     --enforce-eager \
     --gpu-memory-utilization 0.3 \
     --tensor-parallel-size $PREFILLER_TP_SIZE \
+    --served-model-name meta-llama/Llama-3.1-8B \
     --block-size $PREFILL_BLOCK_SIZE \
     --max-model-len 8192 \
     --max-num-batched-tokens 99999 \
@@ -167,6 +168,7 @@ run_tests_for_model() {
     --enforce-eager \
     --gpu-memory-utilization 0.3 \
     --tensor-parallel-size $DECODER_TP_SIZE \
+    --served-model-name meta-llama/Llama-3.1-8B \
     --block-size $DECODE_BLOCK_SIZE \
     --max-model-len 8192 \
     --max-num-batched-tokens 99999 \
@@ -245,7 +247,7 @@ curl -X POST -s http://localhost:9195/v1/completions \
   #sleep 10000
   # Run lm eval for this model
   echo "Running tests for $model_name"
-  TEST_MODEL=$model_name python -m pytest -s -x test_accuracy.py
+  TEST_MODEL=meta-llama/Llama-3.1-8B python -m pytest -s -x test_accuracy.py
 
   # Clean up before running next model
   cleanup_instances


### PR DESCRIPTION
Cherry-pick the example-script changes from PR #1591 (hetero fixes for vLLM 0.24.0). Only the example scripts are carried over: the connector and hpu_fp8 changes from that PR already landed in releases/v0.26.0 (and were developed further there), so they are intentionally omitted to avoid regressing v0.26.0.

- hardcode --served-model-name / TEST_MODEL to meta-llama/Llama-3.1-8B
- bump toy_proxy_server port 9192 -> 9195
- drop removed --disable-log-requests flag

## Depends on #1653 

This PR is scripts-only and **cannot pass on `releases/v0.26.0` by itself.**
Two of the three scripts it touches need the connector and test fixes in #1653
("restore HPU NIXL K/V split and hetero connector attrs after vLLM #44455"):

- **`run_hpu_disagg_hetero_combined.sh`** — hard dependency. Upstream vLLM
  #44455 packed K/V into the content dim and deleted
  `TransferTopology.split_k_and_v` / `.is_kv_layout_blocks_first`, which the
  hetero connector still reads. Without #1653 this script dies at startup with
  `AttributeError: 'TransferTopology' object has no attribute 'split_k_and_v'`,
  and then on the decode side with `AttributeError: 'TensorTuple' object has no
  attribute 'index_select'`. The failure is in the connector, not in these
  scripts.
- **`run_hpu_disagg_accuracy_test.sh`** — depends on the `test_accuracy.py`
  sample-size fix in #1653. All three scripts here invoke `test_accuracy.py`,
  which asserted against a 128-question gsm8k subset that is harder than the
  task average, so a healthy run scored ~0.42–0.43 against a 0.47 expectation
  and failed regardless of these script changes. #1653 raises the subset to 512.

`run_hpu_disagg_accuracy_test_hpubuf.sh` passes on `releases/v0.26.0` without
#1653.

Please merge #1653 first, or merge the two together. Reviewing these scripts
against a plain `releases/v0.26.0` checkout will show failures that this PR does
not cause and cannot fix.
