### PR TITLE
[warmup][multimodal] Enable Gemma4 vision-tower warmup resolution on HPU

### DIFF
--- a/vllm_gaudi/extension/bucketing/vision.py
+++ b/vllm_gaudi/extension/bucketing/vision.py
@@ -57,6 +57,16 @@ MULTIMODAL_CONFIG = {
         # patches per image (<= in_patch_limit=16384)
         'buckets': [256, 576, 1024, 1600, 3136, 4096, 6400, 9216, 12544, 16384]
     },
+    'gemma4': {
+        # Gemma4's vision tower rescales each image to <= max_soft_tokens and
+        # buckets by patch count (like qwen/kimi), not fixed-resolution like
+        # gemma3. Without this entry it falls back to the batch-based default
+        # [1, 2, 4, 8], never compiling the real production resolution.
+        'is_batch_based': False,
+        # patches per image (864x480 at patch_size=16 rescales toward
+        # max_soft_tokens=280 => ~2376 patches; buckets span the workload).
+        'buckets': [196, 256, 441, 480, 576, 900, 1156]
+    },
 }
 
 

--- a/vllm_gaudi/models/__init__.py
+++ b/vllm_gaudi/models/__init__.py
@@ -69,3 +69,4 @@ def register_model():
     import vllm_gaudi.models.qwen3_next  # noqa: F401
     import vllm_gaudi.models.qwen3_5  # noqa: F401
     import vllm_gaudi.models.kimi_k25_vit  # noqa: F401
+    import vllm_gaudi.models.gemma4_mm  # noqa: F401

--- a/vllm_gaudi/models/gemma4_mm.py
+++ b/vllm_gaudi/models/gemma4_mm.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+"""HPU override for the Gemma4 multimodal dummy-inputs builder.
+
+Warmup needs to compile the vision graph at the *production* image resolution
+(e.g. 864x480), but upstream ``Gemma4DummyInputsBuilder`` inherits
+``_get_dummy_images`` from ``BaseDummyInputsBuilder``, which clamps any
+``ImageDummyOptions`` width/height override down to the model's default
+(224, since the Gemma4 image processor exposes ``size=None``). That makes
+warmup build a 224x224 dummy and compile the wrong vision-tower shape.
+
+The clamp is removed for Gemma4 by swapping ``_get_dummy_images`` at import
+time (the same approach ``kimi_k25_vit.py`` / ``qwen3_5.py`` use). Guarded so
+an upstream rename makes this a no-op rather than an error.
+"""
+
+from PIL import Image
+
+import vllm.model_executor.models.gemma4_mm as _gemma4
+
+
+def _get_dummy_images(self, *, width, height, num_images, overrides=None):
+    """Honor width/height overrides instead of clamping to the model default.
+
+    Mirrors ``BaseDummyInputsBuilder._get_dummy_images`` but, when an override
+    is larger than the default, uses the override so warmup compiles the real
+    production resolution.
+    """
+    if num_images == 0:
+        return []
+    if overrides is not None:
+        if getattr(overrides, "width", None):
+            width = overrides.width
+        if getattr(overrides, "height", None):
+            height = overrides.height
+    image = Image.new("RGB", (width, height), color=255)
+    return [image] * num_images
+
+
+_builder_cls = getattr(_gemma4, "Gemma4DummyInputsBuilder", None)
+if _builder_cls is not None and hasattr(_builder_cls, "_get_dummy_images"):
+    _builder_cls._get_dummy_images = _get_dummy_images


### PR DESCRIPTION
## Summary

  Enables correct vision-tower warmup for Gemma4 multimodal models on HPU.
  Gemma4 uses a native-resolution (patch-count) vision tower that rescales
  images toward `max_soft_tokens` — like the Qwen/Kimi towers — rather than
  a fixed-resolution tower like Gemma3. Two HPU-side gaps caused warmup to
  compile the wrong shapes:

  - **Bucketing fell back to batch-based defaults.** Without a
    `MULTIMODAL_CONFIG` entry, gemma4 used the batch-based default
    `[1, 2, 4, 8]`, mis-bucketing the variable patch count and never
    compiling the real production resolution.
  - **Dummy inputs were clamped to 224x224.** Upstream
    `Gemma4DummyInputsBuilder` inherits `_get_dummy_images` from
    `BaseDummyInputsBuilder`, which clamps width/height overrides down to
    the model default (224, because the image processor exposes
    `size=None`). Warmup then compiled a 224x224 vision-tower shape instead
    of the production resolution.

  ## Changes

  - `vllm_gaudi/extension/bucketing/vision.py`: add a patch-count
    (`is_batch_based=False`) bucket config for `gemma4`.
  - `vllm_gaudi/models/gemma4_mm.py`: HPU override of `_get_dummy_images`
    that honors the width/height override so warmup compiles the production
    resolution. Applied at import time and guarded so an upstream rename
    becomes a no-op instead of an error (same pattern as `kimi_k25_vit.py` /
    `qwen3_5.py`).
  - `vllm_gaudi/models/__init__.py`: register `gemma4_mm`.
  - `tests/unit_tests/`: unit tests for the dummy-inputs override and the
    bucketing config.