### PR TITLE
Fix Kimi-K2.5/K2.6 multimodal warmup corruption and dummy-input crash

### DIFF
--- a/vllm_gaudi/models/__init__.py
+++ b/vllm_gaudi/models/__init__.py
@@ -69,3 +69,4 @@ def register_model():
     import vllm_gaudi.models.qwen3_next  # noqa: F401
     import vllm_gaudi.models.qwen3_5  # noqa: F401
     import vllm_gaudi.models.kimi_k25_vit  # noqa: F401
+    import vllm_gaudi.models.kimi_k25  # noqa: F401

--- a/vllm_gaudi/models/kimi_k25.py
+++ b/vllm_gaudi/models/kimi_k25.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""HPU dummy-input fix + processor re-registration for Kimi-K2.5/K2.6.
+
+Upstream ``KimiK25DummyInputsBuilder`` has a count mismatch that only surfaces
+during warmup when ``limit_per_prompt['vision_chunk'] > 1``:
+
+* ``get_dummy_text`` emits ``num_media`` media tokens (one ``<|media_pad|>`` per
+  requested item), but
+* ``get_dummy_mm_data`` always returns a SINGLE dummy chunk.
+
+``KimiK25Processor`` expands each media token by popping a per-chunk token count
+from a list built from the provided chunks, so ``num_media`` tokens against 1
+chunk raises ``IndexError: pop from empty list`` →
+``ValueError: Failed to apply KimiK25Processor``. This crashes engine init for
+any run configured with a vision_chunk limit above 1 (e.g. the offline batch
+script uses ``limit_mm_per_prompt={"vision_chunk": 20}``); the OpenAI server did
+not hit it because it left the limit at the default.
+
+The fix replicates the dummy chunk to match ``num_media`` so token count and
+chunk count agree. Vision-tower HPU overrides live separately in
+``kimi_k25_vit.py``; this module only touches dummy-input building and
+re-registers the processor on the upstream model class.
+"""
+
+from collections.abc import Mapping
+
+from vllm.config.multimodal import BaseDummyOptions
+from vllm.inputs import MultiModalDataDict
+from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.model_executor.models.kimi_k25 import (
+    KimiK25DummyInputsBuilder,
+    KimiK25ForConditionalGeneration,
+    KimiK25MultiModalProcessor,
+    KimiK25ProcessingInfo,
+)
+
+
+class HpuKimiK25DummyInputsBuilder(KimiK25DummyInputsBuilder):
+    """Dummy-input builder that emits one chunk per requested media token.
+
+    Upstream ``get_dummy_mm_data`` returns a single chunk regardless of
+    ``mm_counts``; that mismatches the ``num_media`` media tokens emitted by
+    ``get_dummy_text`` and makes the processor's per-chunk ``pop`` run dry when
+    the vision_chunk limit is > 1. Replicate the upstream dummy item
+    ``num_media`` times so the two counts agree.
+    """
+
+    def get_dummy_mm_data(
+        self,
+        seq_len: int,
+        mm_counts: Mapping[str, int],
+        mm_options: Mapping[str, BaseDummyOptions] | None = None,
+    ) -> MultiModalDataDict:
+        num_media = mm_counts.get("vision_chunk", 0)
+        # ``get_dummy_mm_items()`` returns a single-element list (the larger of
+        # the image/video-chunk dummy); replicate it to match ``num_media``.
+        return {"vision_chunk": self.get_dummy_mm_items() * num_media}
+
+
+# Re-register the multimodal processor on the upstream model class with the
+# fixed dummy-inputs builder. ``register_processor`` overwrites the existing
+# ``_processor_factory`` (it logs a warning on override, which is expected).
+MULTIMODAL_REGISTRY.register_processor(
+    KimiK25MultiModalProcessor,
+    info=KimiK25ProcessingInfo,
+    dummy_inputs=HpuKimiK25DummyInputsBuilder,
+)(KimiK25ForConditionalGeneration)

--- a/vllm_gaudi/models/kimi_k25_vit.py
+++ b/vllm_gaudi/models/kimi_k25_vit.py
@@ -20,6 +20,7 @@ approach ``qwen3_5.py`` uses for GDN attention):
    re-wrapped in the module's own first-call shape decorator.
 """
 
+import habana_frameworks.torch.internal.bridge_config as bridge_config
 import torch
 import torch.nn.functional as F
 
@@ -73,15 +74,34 @@ def get_freqs_cis(self, grid_thws, device: torch.device) -> torch.Tensor:
 
     Identical to upstream but reshapes/repeats with the extra trailing (cos, sin)
     axis carried by the real ``freqs_cis`` buffer (``..., dim/2, 2``).
+
+    The ``freqs_cis`` table is materialized lazily and cached on first call, so
+    upstream steady-state behaviour is unchanged: it is built once — on ``device``,
+    in float32 (``_precompute_freqs_cis`` calls ``.float()``), AFTER the vision
+    tower's ``.to(dtype=...)`` has run — then reused. The only change is the
+    ``PT_COMPILE_ONLY_MODE`` guard: during HPU warmup Synapse compiles the recipe
+    without executing kernels, so ``_precompute_freqs_cis`` returns an
+    *uninitialized* tensor. Caching that garbage (as the plain ``hasattr`` guard
+    would) permanently poisons every real vision forward, yielding token-0 ("!")
+    output. So in compile-only mode we build the table for recipe compilation but
+    do NOT cache it; the first genuinely-executed forward then computes and caches
+    the real values. The per-bucket slice/reshape/repeat/concat recipes are
+    identical either way (same shapes), so no runtime recompilation results — the
+    Kimi vision tower runs eager (not hpu-graph-wrapped; ``compile_mm_encoder`` is
+    off), and eager recipes are keyed by shape, not by surrounding ops.
     """
-    if not hasattr(self, "freqs_cis"):
-        self.register_buffer("freqs_cis", _precompute_freqs_cis(self, device), persistent=False)
+    if hasattr(self, "freqs_cis"):
+        freqs_cis_buf = self.freqs_cis
+    else:
+        freqs_cis_buf = _precompute_freqs_cis(self, device)
+        if not bridge_config.get_pt_compile_only_mode():
+            self.register_buffer("freqs_cis", freqs_cis_buf, persistent=False)
 
     shapes = grid_thws if isinstance(grid_thws, list) else grid_thws.tolist()
     assert all(1 <= h <= self.max_height and 1 <= w <= self.max_width for t, h, w in shapes), \
         (shapes, self.max_height, self.max_width)
     return torch.cat(
-        [self.freqs_cis[:h, :w].reshape(-1, self.dim // 2, 2).repeat(t, 1, 1) for t, h, w in shapes],
+        [freqs_cis_buf[:h, :w].reshape(-1, self.dim // 2, 2).repeat(t, 1, 1) for t, h, w in shapes],
         dim=0,
     )
 

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -5624,10 +5624,27 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
         return prompt_cfg, decode_cfg
 
     def get_patch_size_from_model(self):
-        """Get patch_size from the loaded vision model."""
-        # For Qwen2.5-VL and similar models
-        if hasattr(self.model.model, 'visual'):
-            return self.model.model.visual.patch_size
+        """Get patch_size from the loaded vision model.
+
+        Different vision models expose the tower at different attribute names
+        and nesting depths, so probe the known layouts:
+          * Qwen2.5-VL and similar: ``model.model.visual.patch_size``
+          * Kimi-K2.5/K2.6 (MoonViT): ``vision_tower.patch_size``
+        Falls back to 1 only when no known vision tower is found.
+        """
+        model = self.get_model()
+        candidates = [
+            getattr(getattr(model, 'model', None), 'visual', None),
+            getattr(model, 'visual', None),
+            getattr(model, 'vision_tower', None),
+        ]
+        for vision_model in candidates:
+            patch_size = getattr(vision_model, 'patch_size', None)
+            if patch_size is not None:
+                # Some towers store patch_size as a (h, w) tuple/list.
+                if isinstance(patch_size, (tuple, list)):
+                    return int(patch_size[0])
+                return int(patch_size)
         return 1
 
     def _get_dummy_mm_inputs_with_options(


### PR DESCRIPTION
Two independent HPU warmup bugs made the Kimi-K2.5/K2.6 vision path unusable unless warmup was disabled entirely (VLLM_SKIP_WARMUP=true):

Corrupted vision RoPE table. Rope2DPosEmbRepeated.get_freqs_cis materializes its freqs_cis buffer lazily on first call and caches it behind a hasattr guard. In graph mode that first call happens during warmup inside PT_COMPILE_ONLY_MODE, where Synapse compiles the recipe but never executes the kernels, so the buffer is filled with uninitialized garbage. The hasattr guard then keeps that garbage forever, so every real image forward uses a corrupt RoPE table and emits repeated token-0 ("!") output. Skip caching while in compile-only mode so the first genuinely-executed forward computes and caches the real (float32, on-device) values. The vision tower runs eager (not hpu-graph-wrapped, compile_mm_encoder off) and its per-shape recipes are unchanged, so this adds no runtime recompilation and does not alter numerics.

Dummy-input count mismatch. Upstream KimiK25DummyInputsBuilder emits one media token per requested item in get_dummy_text but returns a single dummy chunk from get_dummy_mm_data. When limit_per_prompt['vision_chunk'] > 1, KimiK25Processor pops a per-chunk token count for each media token and runs dry, raising "IndexError: pop from empty list" and failing engine init. Replicate the dummy chunk to match the media-token count. Only warmup dummy generation is affected; real requests never touch this path.

Both fixes are scoped to Kimi: the vision-tower patches mutate only vllm.model_executor.models.kimi_k25_vit (whose sole importer is kimi_k25.py), and the processor re-registration targets only KimiK25ForConditionalGeneration.