### PR TITLE
ci: run Hourly Commit Check once a day instead of every 4 hours

### DIFF
--- a/.github/workflows/hourly-ci.yaml
+++ b/.github/workflows/hourly-ci.yaml
@@ -4,10 +4,10 @@
 name: Hourly Commit Check and Tests
 
 on:
-  # Schedule the workflow to run every 4 hours
+  # Schedule the workflow to run once a day
   schedule:
-    # Runs at minute 0, every 4th hour (0, 4, 8, 12, 16, 20 UTC)
-    - cron: '0 */4 * * *'
+    # Runs at minute 0, hour 0 (00:00 UTC) every day
+    - cron: '0 0 * * *'
 
   # Allow manual triggering from the GitHub Actions UI
   workflow_dispatch: {}
@@ -68,13 +68,13 @@ jobs:
       - name: Calculate previous run time
         id: prev_run_time
         run: |
-          PREV_RUN_TIME=$(date -u -d "4 hours ago" +"%Y-%m-%dT%H:%M:%SZ")
+          PREV_RUN_TIME=$(date -u -d "24 hours ago" +"%Y-%m-%dT%H:%M:%SZ")
           echo "Looking for commits since: $PREV_RUN_TIME"
           echo "PREV_RUN_TIME=$PREV_RUN_TIME" >> "$GITHUB_OUTPUT"
 
-      - name: List commit differences in the last 4 hours
+      - name: List commit differences in the last 24 hours
         run: |
-          echo "Commits merged/pushed in vllm-project/vllm.git in the last 4 hours:"
+          echo "Commits merged/pushed in vllm-project/vllm.git in the last 24 hours:"
           git log HEAD..vllm-upstream/main --pretty=format:"%h - %an, %ar : %s" --since="${{ steps.prev_run_time.outputs.PREV_RUN_TIME }}"
 
       - name: Get latest commit sha from vllm-upstream/main


### PR DESCRIPTION
## Summary
Reduce the "Hourly Commit Check and Tests" workflow cadence from every 4 hours to once a day.

## Changes
- Schedule cron `0 */4 * * *` → `0 0 * * *` (daily at 00:00 UTC).
- Commit-diff window updated `4 hours ago` → `24 hours ago` (plus the matching log/step labels) so the "commits since last run" logic stays consistent with the new daily cadence.

Note: the workflow's display name still reads "Hourly" — left as-is to avoid breaking the name/references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)