### PR TITLE
Fix #1612: don't wrap INT8 W8A8 loader with FP8-only gaudi_weight_wrapper

### DIFF
--- a/tests/unit_tests/ops/test_hpu_compressed_tensors.py
+++ b/tests/unit_tests/ops/test_hpu_compressed_tensors.py
@@ -454,8 +454,11 @@ def test_compressed_tensors_linear_method_w8a8int8_bf16fallback_static_per_chann
     with safe_open(get_data_path("data/compressed_tensors/linear_w8a8int8_bf16fallback_static_per_channel.safetensors"),
                    framework="pt",
                    device="hpu") as f:
-        oot_op.weight.copy_(f.get_tensor("weight"))
-        oot_op.weight_scale.copy_(f.get_tensor("weight_scale"))
+        # Load through the real weight_loader (not param.copy_()) so the full
+        # served-model path is exercised. See issue #1612: the INT8 scheme must
+        # not wrap this loader with the FP8-only gaudi_weight_wrapper.
+        oot_op.weight.weight_loader(oot_op.weight, f.get_tensor("weight"))
+        oot_op.weight_scale.weight_loader(oot_op.weight_scale, f.get_tensor("weight_scale"))
         input = f.get_tensor("input")
         ref_output = f.get_tensor("ref_output")
 
@@ -464,6 +467,70 @@ def test_compressed_tensors_linear_method_w8a8int8_bf16fallback_static_per_chann
     sut_output = oot_op(input)
 
     torch.testing.assert_close(ref_output, sut_output.float(), atol=1e-3, rtol=1e-3)
+
+
+def test_compressed_tensors_w8a8int8_weight_loader_does_not_corrupt_int8(default_vllm_config: None, dist_init):
+    """Regression test for #1612.
+
+    Load INT8 weights and their fp32 scales through the *real* `weight_loader`
+    stored on each parameter (the path a served model actually takes), not via
+    `param.copy_()`. On Gaudi2 the INT8 scheme used to wrap that loader with the
+    FP8-only `gaudi_weight_wrapper`, which doubled every non-fp8 tensor (INT8
+    weight overflowed +/-127, fp32 scale scaled by 2x) -> garbage output.
+
+    Prior unit tests missed this because they copied straight into the params,
+    bypassing the wrapper entirely.
+    """
+    config = {
+        "config_groups": {
+            "group_0": {
+                "input_activations": {
+                    "dynamic": True,
+                    "num_bits": 8,
+                    "strategy": "token",
+                    "symmetric": True,
+                    "type": "int"
+                },
+                "output_activations": None,
+                "targets": ["Linear"],
+                "weights": {
+                    "dynamic": False,
+                    "num_bits": 8,
+                    "observer": "mse",
+                    "strategy": "channel",
+                    "symmetric": True,
+                    "type": "int"
+                }
+            }
+        },
+        "format": "int-quantized",
+        "ignore": ["lm_head"],
+        "kv_cache_scheme": None,
+        "quant_method": "compressed-tensors",
+        "quantization_status": "compressed"
+    }
+
+    oot_quant_config = CompressedTensorsConfig.from_config(config)
+    oot_op = create_row_parallel_linear(input_size=128, output_size=64, quant_config=oot_quant_config).to("hpu")
+    assert isinstance(oot_op.scheme, HPUCompressedTensorsW8A8Int8_BF16Fallback)
+
+    # Deliberately include a near-int8-max value: if the loader doubles the
+    # weight it overflows int8 and wraps around, which torch.int8.copy_ would
+    # also clamp -> the corruption is unmistakable.
+    src_weight = torch.zeros(64, 128, dtype=torch.int8)
+    src_weight.fill_(3)
+    src_weight[0, 0] = 100  # 100 * 2 = 200 overflows int8 (max 127)
+    src_weight[1, 1] = -100
+    src_weight = src_weight.to("hpu")
+    src_scale = torch.full((64, 1), 0.02093, dtype=torch.float32, device="hpu")
+
+    # Drive the real loader bound to each param.
+    oot_op.weight.weight_loader(oot_op.weight, src_weight)
+    oot_op.weight_scale.weight_loader(oot_op.weight_scale, src_scale)
+
+    # The loader must not mutate INT8 weights or fp32 scales.
+    torch.testing.assert_close(oot_op.weight.data.cpu(), src_weight.cpu())
+    torch.testing.assert_close(oot_op.weight_scale.data.cpu(), src_scale.cpu())
 
 
 def test_compressed_tensors_linear_method_w8a8fp8_block(default_vllm_config: None, dist_init):

--- a/vllm_gaudi/ops/hpu_compressed_tensors.py
+++ b/vllm_gaudi/ops/hpu_compressed_tensors.py
@@ -330,8 +330,6 @@ class HPUCompressedTensorsW8A8Int8_BF16Fallback(CompressedTensorsScheme):
                        input_size: int, output_size: int, params_dtype: torch.dtype, **extra_weight_attrs):
 
         weight_loader = extra_weight_attrs.get("weight_loader")
-        if hpu_ops.is_hpu_gaudi2:
-            weight_loader = hpu_ops.gaudi_weight_wrapper(weight_loader)
         output_size_per_partition = sum(output_partition_sizes)
         layer.logical_widths = output_partition_sizes
         layer.input_size_per_partition = input_size_per_partition


### PR DESCRIPTION
This pull request addresses a regression related to loading INT8 weights in the HPU compressed tensors implementation, ensuring the correct loader path is exercised and preventing data corruption. It also adds a dedicated regression test to catch similar issues in the future. The main changes are:

**Bug Fixes and Loader Path Improvements:**

* In `tests/unit_tests/ops/test_hpu_compressed_tensors.py`, switched from direct parameter copying (`param.copy_()`) to using the actual `weight_loader` for loading weights and scales in the test, ensuring the real served-model code path is tested and preventing the INT8 loader from being incorrectly wrapped with the FP8-only wrapper.
* In `vllm_gaudi/ops/hpu_compressed_tensors.py`, removed the unconditional wrapping of the INT8 weight loader with the FP8-only `gaudi_weight_wrapper` on Gaudi2, preventing data corruption for non-FP8 tensors.

**Testing Improvements:**

* Added a new regression test (`test_compressed_tensors_w8a8int8_weight_loader_does_not_corrupt_int8`) to verify that loading INT8 weights and FP32 scales through the real loader does not corrupt the data, specifically guarding against the issue described in #1612.…pper

HPUCompressedTensorsW8A8Int8_BF16Fallback.create_weights wrapped the weight loader with hpu_ops.gaudi_weight_wrapper on Gaudi2. That wrapper is FP8-only: it applies the FNUZ scale adjustment (x0.5 for float8_e4m3fn, x2.0 otherwise). INT8 weights and fp32 scales are not fp8, so they hit the x2.0 branch, overflowing the int8 weight past +/-127 and doubling the scale, producing garbage output on Gaudi2.

Remove the wrapper from the INT8 scheme (FP8 scheme and FP8-MoE keep it, correctly). Validated red->green on Gaudi2 (HL-225): the two INT8 unit tests fail with the buggy line and pass without it; no regression on Gaudi3.

Also update the tests to load through the real weight_loader instead of param.copy_(), which is what let the bug slip past CI, and add a loader-corruption regression test.