### PR TITLE
[DO NOT MERGE] Enable Nemotron-H FP8 on HPU: quant-aware Mamba in_proj + non-gated FP8 MoE

### DIFF
--- a/vllm_gaudi/extension/features.py
+++ b/vllm_gaudi/extension/features.py
@@ -109,7 +109,7 @@ def get_features():
         Value(
             'flatten_input',
             Any(ModelType('qwen3_moe'), ModelType('qwen3_5_moe'), ModelType('granitemoe'), ModelType('glm4_moe'),
-                ModelType('gemma4'))),
+                ModelType('gemma4'), ModelType('nemotron_h'))),
         Value('high_level_profiler_enabled', False, env_var='VLLM_PROFILER_ENABLED', env_var_type=boolean),
         Value('track_graph_compilation', False, env_var='PT_HPU_METRICS_GC_DETAILS', env_var_type=boolean),
         Value('per_token_kv_scaling_support',

--- a/vllm_gaudi/ops/hpu_compressed_tensors.py
+++ b/vllm_gaudi/ops/hpu_compressed_tensors.py
@@ -52,7 +52,12 @@ from vllm_gaudi.extension.scales import ConvertScaleToHwAligned
 from vllm_gaudi.extension.ops import (VllmMixtureOfExpertsOpFP8, VllmMixtureOfExpertsOpFP8PerChannel,
                                       VllmMixtureOfExpertsOpWNA16)
 from vllm_gaudi.extension.runtime import get_config
-from vllm_gaudi.ops.hpu_fused_moe import _normalize_moe_activation, select_experts_from_routed
+from vllm_gaudi.ops.hpu_fused_moe import (
+    _NO_MUL_ACTIVATIONS,
+    _normalize_moe_activation,
+    _unfused_no_mul_moe_fp8,
+    select_experts_from_routed,
+)
 from vllm_gaudi.v1.worker.hpu_dp_utils import dispatch_tensor
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizeMethodBase, )
@@ -559,13 +564,27 @@ class HPUCompressedTensorsW8A8Fp8MoEMethod(CompressedTensorsW8A8Fp8MoEMethod):
         topk_ids = topk_ids.view(*x.shape[:-1], -1)
         topk_weights = topk_weights.view(*x.shape[:-1], -1)
 
-        output = layer.moe_op(
-            x,
-            topk_ids.to(torch.int64),
-            topk_weights.to(x.dtype),
-            permuted_weights=True,
-            activation=_normalize_moe_activation(layer.activation),
-        )
+        activation = _normalize_moe_activation(layer.activation)
+        if activation in _NO_MUL_ACTIVATIONS:
+            # Non-gated (is_act_and_mul=False) FP8 experts, e.g. Nemotron-H's
+            # squared-ReLU. The Habana fused-MoE kernel is gated-only and its
+            # MoeActivationMode_t enum has no relu2, so dequantize the experts
+            # and compute y = w2(act(w1 x)) unfused.
+            output = _unfused_no_mul_moe_fp8(
+                layer,
+                x,
+                topk_ids,
+                topk_weights,
+                _NO_MUL_ACTIVATIONS[activation],
+            )
+        else:
+            output = layer.moe_op(
+                x,
+                topk_ids.to(torch.int64),
+                topk_weights.to(x.dtype),
+                permuted_weights=True,
+                activation=activation,
+            )
         if layer.moe_config.is_sequence_parallel:
             return output.view(*(output.size(0), *input_shape[1:]))
         return output.view(*input_shape)

--- a/vllm_gaudi/ops/hpu_fused_moe.py
+++ b/vllm_gaudi/ops/hpu_fused_moe.py
@@ -66,6 +66,18 @@ _SWIGLU_OAI_ACTIVATION = "swigluoai_uninterleave"
 # which the HPU graph compiler requires. Tunable via env for large-prompt tuning.
 _SWIGLU_OAI_TOKEN_TILE = gaudi_envs.VLLM_MINIMAX_M3_MOE_TOKEN_TILE
 
+# Non-gated activations (``is_act_and_mul=False``). Their w13 is a single
+# up-projection of size I (not a 2*I gate+up split), and the elementwise
+# activation is applied directly: y = w2(act(w1 x)). The Habana fused-MoE kernel
+# is gated-only, so these are computed unfused (see _unfused_no_mul_moe). The
+# key is the MoEActivation ``.value`` (e.g. "relu2_no_mul" for Nemotron-H).
+_NO_MUL_ACTIVATIONS = {
+    "silu_no_mul": lambda h: torch.nn.functional.silu(h),
+    "gelu_no_mul": lambda h: torch.nn.functional.gelu(h),
+    "gelu_tanh_no_mul": lambda h: torch.nn.functional.gelu(h, approximate="tanh"),
+    "relu2_no_mul": lambda h: torch.square(torch.nn.functional.relu(h)),
+}
+
 
 def _unfused_swigluoai_moe(
     layer,
@@ -162,6 +174,130 @@ def _unfused_swigluoai_moe(
             acc = acc + (y.float() * gate_wc).sum(0).to(x.dtype)
         out_tiles.append(acc)
     return out_tiles[0] if len(out_tiles) == 1 else torch.cat(out_tiles, dim=0)
+
+
+def _unfused_no_mul_moe(
+    layer,
+    x: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    act_fn: Callable[[torch.Tensor], torch.Tensor],
+) -> torch.Tensor:
+    """Unfused expert MLP for non-gated (``is_act_and_mul=False``) MoE on HPU.
+
+    The Habana fused-MoE kernel (``torch.ops.hpu.mixture_of_experts``) only
+    implements the gated pattern ``act(gate) * up`` over a ``2*I`` w13
+    projection. Non-gated models (e.g. Nemotron-H, which uses squared-ReLU) have
+    a single ``I``-wide w13 up-projection with the activation applied directly:
+    ``y = w2(act(w1 x))``. This computes that unfused, mirroring
+    ``_unfused_swigluoai_moe``: a dense, sync-free, expert-chunked + token-tiled
+    ``bmm`` pass with static shapes for the HPU graph compiler, returning the
+    same per-rank (pre-all-reduce) partial the fused op would.
+
+    Args:
+        layer: the ``FusedMoE``/``RoutedExperts`` layer. Reads the stacked
+            per-rank expert weights ``layer.w13_weight`` [E_local, I, H] and
+            ``layer.w2_weight`` [E_local, H, I] and ``layer.moe_config.ep_rank`` /
+            ``layer.local_num_experts`` for this rank's expert-id offset.
+        x: [T, H] flattened activations.
+        topk_ids: [T, K] selected (global) expert ids.
+        topk_weights: [T, K] routing weights.
+        act_fn: elementwise activation applied to the w13 projection (fp32).
+    """
+    w13 = layer.w13_weight  # [E_local, I, H]
+    w2 = layer.w2_weight  # [E_local, H, I]
+    # First global expert id owned by this (EP) rank; matches experts_min in
+    # process_weights_after_loading.
+    experts_min = int(layer.moe_config.ep_rank * layer.local_num_experts)
+    return _no_mul_expert_bmm(x, w13, w2, topk_ids, topk_weights, experts_min, act_fn)
+
+
+def _no_mul_expert_bmm(
+    x: torch.Tensor,
+    w13: torch.Tensor,
+    w2: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    experts_min: int,
+    act_fn: Callable[[torch.Tensor], torch.Tensor],
+) -> torch.Tensor:
+    """Dense expert-chunked, token-tiled bmm for non-gated MoE.
+
+    Shared core of the unfused non-gated path. ``w13`` [E_local, I, H] is the
+    single up-projection (already dequantized to ``x.dtype`` for quantized
+    models) and ``w2`` [E_local, H, I] the down-projection. Returns the same
+    per-rank (pre-all-reduce) partial the fused op would.
+    """
+    e_local = w13.shape[0]
+    hidden = x.shape[-1]
+    tokens = x.shape[0]
+
+    # Per-(token, local-expert) combine weight, computed sync-free via scatter
+    # (no host sync). Mirrors _unfused_swigluoai_moe.
+    local_ids = topk_ids - experts_min  # [T, K]
+    in_range = (local_ids >= 0) & (local_ids < e_local)
+    safe_ids = torch.where(in_range, local_ids, torch.zeros_like(local_ids))
+    gate_w = x.new_zeros(tokens, e_local, dtype=torch.float32)
+    gate_w.scatter_add_(
+        1,
+        safe_ids,
+        torch.where(in_range, topk_weights, torch.zeros_like(topk_weights)).to(torch.float32),
+    )
+
+    # Dense experts via expert-chunked bmm (static shapes, no host sync); the
+    # token dimension is tiled so no single fused graph materializes the full
+    # [E_local, T, I] intermediate (which overflows the Synapse compiler for
+    # large prompt buckets). Per-tile shapes stay static.
+    chunk = 32
+    token_tile = _SWIGLU_OAI_TOKEN_TILE
+    if token_tile <= 0 or token_tile >= tokens:
+        token_tile = tokens
+    out_tiles = []
+    for tstart in range(0, tokens, token_tile):
+        tend = min(tstart + token_tile, tokens)
+        xt = x[tstart:tend]  # [t, H]
+        t = xt.shape[0]
+        acc = torch.zeros_like(xt)  # [t, H]
+        for start in range(0, e_local, chunk):
+            end = min(start + chunk, e_local)
+            c = end - start
+            w13c = w13[start:end].transpose(1, 2)  # [c, H, I]
+            w2c = w2[start:end].transpose(1, 2)  # [c, I, H]
+            xe = xt.unsqueeze(0).expand(c, t, hidden)  # [c, t, H]
+            h = torch.bmm(xe, w13c)  # [c, t, I]
+            # Non-gated activation in fp32 for accuracy (matches the fp32
+            # combine below), then cast back before the down-projection.
+            act = act_fn(h.float()).to(x.dtype)  # [c, t, I]
+            y = torch.bmm(act, w2c)  # [c, t, H] per-rank partial
+            gate_wc = gate_w[tstart:tend, start:end].t().unsqueeze(-1)  # [c, t, 1]
+            acc = acc + (y.float() * gate_wc).sum(0).to(x.dtype)
+        out_tiles.append(acc)
+    return out_tiles[0] if len(out_tiles) == 1 else torch.cat(out_tiles, dim=0)
+
+
+def _unfused_no_mul_moe_fp8(
+    layer,
+    x: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    act_fn: Callable[[torch.Tensor], torch.Tensor],
+) -> torch.Tensor:
+    """Unfused non-gated MoE for FP8-quantized experts on HPU.
+
+    Same as ``_unfused_no_mul_moe`` but the per-expert weights are FP8 and live
+    on ``layer.moe_op.w13_list`` / ``w2_list`` (set in
+    fp8_channel_moe_prepare_weights). Each is dequantized to ``x.dtype`` via the
+    MoeFP8Matmul helper, stacked into [E_local, I, H] / [E_local, H, I], then run
+    through the shared dense bmm core. The Habana fused-MoE kernel is gated-only
+    and has no ``relu2`` activation, so non-gated quantized experts (Nemotron-H)
+    must be computed unfused here.
+    """
+    moe_op = layer.moe_op
+    e_local = moe_op.num_experts
+    w13 = torch.stack([moe_op.w13_list[i].get_dequant_weight().to(x.dtype) for i in range(e_local)])
+    w2 = torch.stack([moe_op.w2_list[i].get_dequant_weight().to(x.dtype) for i in range(e_local)])
+    experts_min = int(moe_op.experts_min)
+    return _no_mul_expert_bmm(x, w13, w2, topk_ids, topk_weights, experts_min, act_fn)
 
 
 # --- Decode-time expert gather (bandwidth reduction) -------------------------
@@ -505,6 +641,16 @@ class HPUUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
                 beta=self.swiglu_beta,
                 limit=self.swiglu_limit,
             )
+        elif activation in _NO_MUL_ACTIVATIONS:
+            # Non-gated (is_act_and_mul=False) experts; the fused kernel is
+            # gated-only, so compute y = w2(act(w1 x)) unfused.
+            output = _unfused_no_mul_moe(
+                layer,
+                x,
+                topk_ids,
+                topk_weights,
+                _NO_MUL_ACTIVATIONS[activation],
+            )
         else:
             output = layer.moe_op(
                 x,
@@ -597,6 +743,16 @@ class HPUUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
                 alpha=self.swiglu_alpha,
                 beta=self.swiglu_beta,
                 limit=self.swiglu_limit,
+            )
+        elif activation in _NO_MUL_ACTIVATIONS:
+            # Non-gated (is_act_and_mul=False) experts; the fused kernel is
+            # gated-only, so compute y = w2(act(w1 x)) unfused.
+            output = _unfused_no_mul_moe(
+                layer,
+                x,
+                topk_ids,
+                topk_weights,
+                _NO_MUL_ACTIVATIONS[activation],
             )
         else:
             output = layer.moe_op(
@@ -914,3 +1070,27 @@ MoERunnerBase.forward = _patched_default_moe_runner_forward
 vllm.model_executor.layers.fused_moe.layer.get_compressed_expert_map = get_compressed_expert_map
 vllm.model_executor.layers.fused_moe.router.router_factory.create_fused_moe_router = create_fused_moe_router
 vllm.model_executor.layers.fused_moe.layer.create_fused_moe_router = create_fused_moe_router
+
+# Enable non-gated (is_act_and_mul=False) MoE on HPU.
+#
+# vLLM's FusedMoEConfig.__post_init__ raises NotImplementedError for non-gated
+# activations on any platform that is not CUDA/XPU/ROCm. HPU now serves them via
+# the unfused expert path in HPUUnquantizedFusedMoEMethod (see
+# _unfused_no_mul_moe), so relax that guard: run the original __post_init__ and
+# swallow only that specific error. The guard is the final statement of
+# __post_init__, so all other configuration has already completed by the time it
+# fires -- catching it leaves a fully-initialized config.
+from vllm.model_executor.layers.fused_moe import config as _vllm_moe_config  # noqa: E402
+
+_orig_moe_config_post_init = _vllm_moe_config.FusedMoEConfig.__post_init__
+
+
+def _patched_moe_config_post_init(self):
+    try:
+        _orig_moe_config_post_init(self)
+    except NotImplementedError as exc:
+        if "is_act_and_mul=False" not in str(exc):
+            raise
+
+
+_vllm_moe_config.FusedMoEConfig.__post_init__ = _patched_moe_config_post_init

--- a/vllm_gaudi/ops/hpu_mamba_mixer2.py
+++ b/vllm_gaudi/ops/hpu_mamba_mixer2.py
@@ -24,6 +24,7 @@ from vllm.model_executor.custom_op import CustomOp
 from vllm.model_executor.layers.linear import (
     MergedColumnParallelLinear,
     RowParallelLinear,
+    UnquantizedLinearMethod,
 )
 
 from vllm.model_executor.layers.mamba.mamba_mixer2 import (
@@ -44,6 +45,7 @@ from vllm_gaudi.ops.granite_causal_conv1d import (
 )
 from vllm_gaudi.ops.ssd_combined import hpu_mamba_chunk_scan_combined_varlen
 from vllm_gaudi.ops.ops_selector import get_selective_state_update_impl
+from vllm_gaudi.extension.runtime import get_config
 
 logger = logging.getLogger(__name__)
 
@@ -280,6 +282,10 @@ class HPUMambaMixer2(MambaMixer2):
         self.tped_dt_size = self.num_heads // self.tp_size
 
         self._split_weights_ready = False
+        # True when in_proj is quantized (e.g. FP8 compressed-tensors);
+        # the raw-weight split-GEMM path is invalid there, so forward()
+        # falls back to the quant-aware self.in_proj() call.
+        self._quantized_in_proj = False
 
         self.split_hidden_states_B_C_fn = lambda hidden_states_B_C: torch.split(
             hidden_states_B_C,
@@ -303,9 +309,17 @@ class HPUMambaMixer2(MambaMixer2):
         #    GEMM 2 (gate) is dispatched second.  The Gaudi runtime can
         #    overlap GEMM 2 on the MME with conv+SSM TPC work that
         #    depends only on GEMM 1.
-        states_proj = F.linear(hidden_states, self._states_weight, self._states_bias)
+        if self._quantized_in_proj:
+            # Quantized in_proj: run the standard quant-aware projection and
+            # split its output. gate is the leading tped_intermediate_size
+            # block; the remainder (x, B, C, dt) is the states projection.
+            projected, _ = self.in_proj(hidden_states)
+            gate = projected[..., :self.tped_intermediate_size]
+            states_proj = projected[..., self.tped_intermediate_size:]
+        else:
+            states_proj = F.linear(hidden_states, self._states_weight, self._states_bias)
 
-        gate = F.linear(hidden_states, self._gate_weight, self._gate_bias)
+            gate = F.linear(hidden_states, self._gate_weight, self._gate_bias)
 
         if mup_vector is not None:
             gate_size = self.tped_intermediate_size
@@ -331,6 +345,14 @@ class HPUMambaMixer2(MambaMixer2):
         # 5. Final linear projection
         output, _ = self.out_proj(hidden_states_varlen)
 
+        # flatten_input models (e.g. nemotron_h) keep the whole model in the
+        # flattened [num_tokens, hidden] layout, so the surrounding layers
+        # (MoE/MLP) expect a 2D tensor. out_proj already produces that shape,
+        # so return it as-is. Non-flatten mamba models run in the [batch, seq,
+        # hidden] layout and need the leading dims restored below.
+        if get_config().flatten_input:
+            return output
+
         if get_forward_context().attn_metadata.is_prompt:
             output = output.view(1, output.shape[0], output.shape[1])
         else:
@@ -351,6 +373,17 @@ class HPUMambaMixer2(MambaMixer2):
     # Called from apply_model_specific_patches() in hpu_model_runner.
     # ------------------------------------------------------------------
     def _init_split_weights(self):
+        # The split-GEMM optimization slices the raw in_proj weight and calls
+        # a plain F.linear, which is only valid for an unquantized weight whose
+        # logical layout is [out, hidden]. For a quantized in_proj (e.g. FP8
+        # compressed-tensors) the stored weight is packed/scaled and must go
+        # through the quant method's apply(); mark it so forward() uses the
+        # standard self.in_proj() path instead.
+        if not isinstance(self.in_proj.quant_method, UnquantizedLinearMethod):
+            self._quantized_in_proj = True
+            self._split_weights_ready = True
+            return
+
         gate_size = self.tped_intermediate_size
         w = self.in_proj.weight  # [total_out, hidden_size]
         b = self.in_proj.bias  # [total_out] or None

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -834,6 +834,7 @@ def maybe_set_mamba_kv_cache_groups_ids(model, kv_cache_config: KVCacheConfig):
                 if mamba_mixer is not None:
                     mamba_mixer.cache_group_idx = group_idx
             elif 'linear_attn' in layer_name:
+                layer_idx = int(layer_name.split('.')[-2])
                 layer = _get_decoder_layer_by_idx(model, layer_idx)
                 if layer is not None and hasattr(layer, "linear_attn"):
                     layer.linear_attn.cache_group_idx = torch.tensor(group_idx, dtype=torch.long, device="hpu")

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -790,7 +790,7 @@ def maybe_set_mamba_kv_cache_groups_ids(model, kv_cache_config: KVCacheConfig):
 
     mamba_like_arch = [
         "GraniteMoeHybridForCausalLM", "Qwen3_5MoeForConditionalGeneration", "Qwen3_5ForConditionalGeneration",
-        "Qwen3NextForCausalLM"
+        "Qwen3NextForCausalLM", "NemotronHForCausalLM"
     ]
     if not any(arch in getattr(model.config, 'architectures', []) for arch in mamba_like_arch):
         return
@@ -816,13 +816,23 @@ def maybe_set_mamba_kv_cache_groups_ids(model, kv_cache_config: KVCacheConfig):
             # Extract layer index from name (e.g., "model.layers.5.mixer" -> 5)
             if not any(pattern in layer_name for pattern in mamba_like_layer):
                 continue
-            parts = layer_name.split('.')
-            layer_idx = int(parts[-2])  # "model.layers.5.mixer" -> 5
-
             # Access the actual layer
             if '.mixer' in layer_name:
+                # Only the mamba state cache registers under a name ending in
+                # ".mixer". Nemotron-H nests attention under the same attribute
+                # ("model.layers.N.mixer.attn"), which must be skipped here (it
+                # would also break the int(parts[-2]) index parsing).
+                if not layer_name.endswith('.mixer'):
+                    continue
+                layer_idx = int(layer_name.split('.')[-2])  # "...layers.5.mixer" -> 5
                 layer = model.model.layers[layer_idx]
-                layer.mamba.cache_group_idx = group_idx
+                # The Mamba block is exposed as ".mamba" (Granite) or ".mixer"
+                # (Nemotron-H) depending on the model.
+                mamba_mixer = getattr(layer, 'mamba', None)
+                if mamba_mixer is None:
+                    mamba_mixer = getattr(layer, 'mixer', None)
+                if mamba_mixer is not None:
+                    mamba_mixer.cache_group_idx = group_idx
             elif 'linear_attn' in layer_name:
                 layer = _get_decoder_layer_by_idx(model, layer_idx)
                 if layer is not None and hasattr(layer, "linear_attn"):
@@ -6549,7 +6559,15 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
                     if isinstance(spec, MambaSpec) and \
                             spec.mamba_type in _GDN_MAMBA_TYPES:
                         continue
-                    # Standard Mamba2 or unknown spec — needs raw buffer
+                    if isinstance(spec, MambaSpec) and len(set(spec.dtypes)) > 1:
+                        # Mixed-dtype standard Mamba2 (e.g. Nemotron-H: bf16
+                        # conv_state + float32 ssm_state) gets its own
+                        # contiguous tensors below, not as_strided views of the
+                        # shared raw buffer — aot_autograd rejects in-place
+                        # mutation of differently-typed views of one input.
+                        continue
+                    # Standard Mamba2 (uniform dtype) or unknown spec — needs
+                    # raw buffer for the as_strided interleaved layout.
                     return True
                 return False
 
@@ -6638,10 +6656,31 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
                             for shared_layer in kv_cache_tensor.shared_by:
                                 kv_caches[shared_layer] = tuple(state_tensors)
                             break
+                    elif isinstance(kv_cache_spec, MambaSpec) and \
+                            len(set(kv_cache_spec.dtypes)) > 1:
+                        # Mixed-dtype standard Mamba2 (e.g. Nemotron-H: bf16
+                        # conv_state + float32 ssm_state). as_strided views of a
+                        # single raw buffer would alias one storage with two
+                        # dtypes; aot_autograd cannot compile the decode graph
+                        # then ("input mutations on views with different
+                        # dtypes"). Allocate separate contiguous tensors, like
+                        # the GDN path above, so each state is its own input.
+                        if isinstance(kv_caches.get(layer_name), tuple):
+                            continue
+                        state_tensors = []
+                        for shape, dtype in zip(kv_cache_spec.shapes, kv_cache_spec.dtypes):
+                            target_shape = (num_blocks + 1, *shape)
+                            state_tensors.append(torch.zeros(target_shape, dtype=dtype, device=self.device))
+                        for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
+                            if layer_name not in kv_cache_tensor.shared_by:
+                                continue
+                            for shared_layer in kv_cache_tensor.shared_by:
+                                kv_caches[shared_layer] = tuple(state_tensors)
+                            break
                     elif isinstance(kv_cache_spec, MambaSpec):
-                        # Standard Mamba2 and other MambaSpec types: use the
-                        # original as_strided interleaved layout from the raw
-                        # shared buffer.
+                        # Standard Mamba2 with uniform dtype: use the original
+                        # as_strided interleaved layout from the raw shared
+                        # buffer (same-dtype view mutations compile fine).
                         raw = kv_caches[layer_name]
                         offset = 0
                         state_tensors = []


### PR DESCRIPTION
This pull request adds support for non-gated (is_act_and_mul=False) Mixture-of-Experts (MoE) models, such as Nemotron-H, on HPU platforms. It introduces unfused expert computation paths for these models, allowing them to run despite the Habana fused-MoE kernel only supporting gated activations. The changes also improve quantized Mamba block handling and extend support for new architectures. 

**Support for non-gated MoE activations on HPU:**

* Introduced the `_NO_MUL_ACTIVATIONS` mapping and unfused expert computation functions (`_unfused_no_mul_moe`, `_unfused_no_mul_moe_fp8`, `_no_mul_expert_bmm`) to handle non-gated MoE activations (e.g., squared-ReLU in Nemotron-H) that the Habana fused-MoE kernel cannot process. These activations are now computed unfused, supporting both unquantized and FP8-quantized experts. [[1]](diffhunk://#diff-7e0f651174561c6d22f1fc1b2ca6cac075bcbb4cf0293f429895c3719e57ebe9R69-R80) [[2]](diffhunk://#diff-7e0f651174561c6d22f1fc1b2ca6cac075bcbb4cf0293f429895c3719e57ebe9R179-R302) [[3]](diffhunk://#diff-7e0f651174561c6d22f1fc1b2ca6cac075bcbb4cf0293f429895c3719e57ebe9R644-R653) [[4]](diffhunk://#diff-7e0f651174561c6d22f1fc1b2ca6cac075bcbb4cf0293f429895c3719e57ebe9R747-R756) [[5]](diffhunk://#diff-7c94975c5b4acf1eb548e95f3f98b52623205b6d331336b91d8bd547b1beec9dL55-R60) [[6]](diffhunk://#diff-7c94975c5b4acf1eb548e95f3f98b52623205b6d331336b91d8bd547b1beec9dR569-R588)
* Patched `FusedMoEConfig.__post_init__` to allow non-gated activations on HPU by catching and suppressing the specific `NotImplementedError`, enabling full configuration for these models.
* Extended the `flatten_input` feature to include the new `nemotron_h` model type.

**Quantized Mamba block improvements:**

* Updated Mamba block logic to detect quantized projections and route them through quantization-aware paths, ensuring correct handling of FP8 compressed-tensors. The split-GEMM optimization is now only used for unquantized weights. [[1]](diffhunk://#diff-8f4b1c976e70719a6dae706a95b734be732cdba588f59046df857e6db9f3828cR25) [[2]](diffhunk://#diff-8f4b1c976e70719a6dae706a95b734be732cdba588f59046df857e6db9f3828cR284-R287) [[3]](diffhunk://#diff-8f4b1c976e70719a6dae706a95b734be732cdba588f59046df857e6db9f3828cR311-R318) [[4]](diffhunk://#diff-8f4b1c976e70719a6dae706a95b734be732cdba588f59046df857e6db9f3828cR375-R385)
* The Mamba block output now respects the `flatten_input` configuration, returning the correct tensor shape for models like Nemotron-H.
* Added missing import for `get_config` to support the above logic.

**Nemotron-H and Mamba model support:**

* Added `NemotronHForCausalLM` to the list of Mamba-like architectures for proper state cache handling.
* Improved logic for setting cache group indices in Mamba blocks, handling both `.mamba` and `.mixer` attribute variants and skipping nested attention modules in Nemotron-H.
* Updated raw buffer logic to handle mixed-dtype Mamba2 models (e.g., Nemotron-H), ensuring correct tensor allocation and avoiding in-place mutation errors with mixed dtypes.This pull request adds support for non-gated (is_act_and_mul=False) Mixture-of-Experts (MoE) models—such as Nemotron-H—on HPU, including both unquantized and FP8-quantized experts. It introduces unfused expert paths for these activations, ensures proper handling in the Mamba mixer for flattened input layouts, and improves compatibility with pipeline parallelism and async scheduling. The changes also add necessary model and architecture hooks for Nemotron-H.

**Support for non-gated MoE activations on HPU:**

* Added `_NO_MUL_ACTIVATIONS` and unfused expert computation paths (`_unfused_no_mul_moe`, `_unfused_no_mul_moe_fp8`) to enable non-gated activations (like squared-ReLU in Nemotron-H) on HPU, bypassing the fused kernel which only supports gated activations. [[1]](diffhunk://#diff-7e0f651174561c6d22f1fc1b2ca6cac075bcbb4cf0293f429895c3719e57ebe9R68-R79) [[2]](diffhunk://#diff-7e0f651174561c6d22f1fc1b2ca6cac075bcbb4cf0293f429895c3719e57ebe9R178-R301)
* Updated `apply_monolithic` and `forward_oot` to select the unfused path for non-gated activations, both for unquantized and FP8-quantized experts. [[1]](diffhunk://#diff-7e0f651174561c6d22f1fc1b2ca6cac075bcbb4cf0293f429895c3719e57ebe9R512-R521) [[2]](diffhunk://#diff-7e0f651174561c6d22f1fc1b2ca6cac075bcbb4cf0293f429895c3719e57ebe9R614-R623) [[3]](diffhunk://#diff-7c94975c5b4acf1eb548e95f3f98b52623205b6d331336b91d8bd547b1beec9dR569-R588)
* Patched `FusedMoEConfig.__post_init__` to allow non-gated activations on HPU by swallowing the NotImplementedError, enabling these models to initialize.
* Registered `nemotron_h` as a supported model for `flatten_input`.

**Mamba mixer and flattened input support:**

* Modified `hpu_mamba_mixer2.py` to handle quantized projections and return correct output shapes for models with `flatten_input` (e.g., Nemotron-H), ensuring compatibility with both quantized and unquantized weights. [[1]](diffhunk://#diff-8f4b1c976e70719a6dae706a95b734be732cdba588f59046df857e6db9f3828cR27) [[2]](diffhunk://#diff-8f4b1c976e70719a6dae706a95b734be732cdba588f59046df857e6db9f3828cR48) [[3]](diffhunk://#diff-8f4b1c976e70719a6dae706a95b734be732cdba588f59046df857e6db9f3828cR285-R288) [[4]](diffhunk://#diff-8f4b1c976e70719a6dae706a95b734be732cdba588f59046df857e6db9f3828cR312-R319) [[5]](diffhunk://#diff-8f4b1c976e70719a6dae706a95b734be732cdba588f59046df857e6db9f3828cR348-R355)

**Model runner and architecture hooks:**

* Added `NemotronHForCausalLM` to the list of Mamba-like architectures for proper KV cache handling.
* Improved decoder layer indexing and cache group assignment to support Nemotron-H's attribute nesting in the model runner.

**Platform and scheduling compatibility:**

* Disabled async scheduling when pipeline parallelism is enabled on HPU, as the required token broadcast is not implemented, and added a warning.

**Other improvements:**

* Updated imports and internal logic to support new features and maintain compatibility. [[1]](diffhunk://#diff-7c94975c5b4acf1eb548e95f3f98b52623205b6d331336b91d8bd547b1beec9dL55-R60) [[2]](diffhunk://#diff-5ffdc7547fbc10ff45e9791caaef30c306a59a0e3f7c9515569f342baed8c0e2R91)