### PR TITLE
Enable HPU residual fix for qwen3_next (Qwen3-Coder-Next)

### DIFF
--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -868,7 +868,7 @@ def apply_model_specific_patches(model_runner):
 
     is_llama4 = is_hpu_llama4_model(model_runner.model)
     model_type = getattr(model_runner.vllm_config.model_config.hf_config, "model_type", "")
-    is_qwen_moe = model_type in ("qwen3_moe", "qwen3_5_moe")
+    is_qwen_moe = model_type in ("qwen3_moe", "qwen3_5_moe", "qwen3_next")
     is_gemma4 = model_type in ("gemma4", )
 
     model_runner._has_heterogeneous_layers = is_llama4 or is_qwen_moe or is_gemma4


### PR DESCRIPTION
Add "qwen3_next" to the is_qwen_moe model_type set in apply_model_specific_patches so apply_hpu_qwen3_residual_fix runs for Qwen3NextForCausalLM (Qwen3-Coder-Next). This swaps the inner model to HpuQwen3NextModel, whose forward has no sequence-parallel all-gather/full_num_tokens batch-collapse.

Without the swap the upstream Qwen3NextModel.forward runs on HPU. In batched decode it computes full_num_tokens = positions.shape[-1] (=1, since HPU keeps decode positions as (B,1)) while hidden_states.shape[0] = B, so the guard fires and _all_gather_hidden_and_residual slices the batch down to 1. The dropped decode tokens then surface downstream as a conv-state shape mismatch in the gated-DeltaNet update (causal_conv1d cat: "Expected size 2 but got size 1"). Single requests worked (B==1, guard is a no-op); 2+ concurrent decodes crashed the engine.

Validated on Gaudi (TP=2, max-model-len=131072) in both eager and torch.compile modes: 2- and 8-concurrent chat completions, tool-calling (qwen3_coder parser), and vllm bench serve all pass with zero RuntimeErrors.