### PR TITLE
Fix _mamba_block_aligned_split signature mismatch with pinned vLLM on v0.26.0

### DIFF
--- a/vllm_gaudi/v1/core/sched/hpu_async_scheduler.py
+++ b/vllm_gaudi/v1/core/sched/hpu_async_scheduler.py
@@ -124,7 +124,6 @@ class HPUAsyncScheduler(AsyncScheduler):
         num_new_tokens: int,
         num_new_local_computed_tokens: int = 0,
         num_external_computed_tokens: int = 0,
-        num_uncached_common_prefix_tokens: int = 0,
     ) -> int:
         """HPU override: align chunked-prefill splits to mamba_chunk_size.
 
@@ -138,7 +137,7 @@ class HPUAsyncScheduler(AsyncScheduler):
             self.vllm_config.parallel_config, "mamba")
         if num_mamba_layers == 0 or not self.vllm_config.cache_config.enable_prefix_caching:
             return super()._mamba_block_aligned_split(request, num_new_tokens, num_new_local_computed_tokens,
-                                                      num_external_computed_tokens, num_uncached_common_prefix_tokens)
+                                                      num_external_computed_tokens)
 
         num_computed_tokens = (request.num_computed_tokens + num_new_local_computed_tokens +
                                num_external_computed_tokens)


### PR DESCRIPTION
## Problem

The port in #1671 (Granite-4.0-H-Small single-process model swap → `releases/v0.26.0`) was taken from the `releases/v0.24.0` port (#1595) rather than the port to `main` (#1565). The applied code is byte-for-byte identical to #1595, but the `_mamba_block_aligned_split` override no longer matches the vLLM base class pinned by this release branch.

`HPUAsyncScheduler` → `AsyncScheduler` → `Scheduler`. The override forwards a fifth positional argument, `num_uncached_common_prefix_tokens`, to `super()._mamba_block_aligned_split(...)`. That parameter exists in the vLLM base pinned by `releases/v0.24.0`, but **not** in the vLLM commit pinned by `releases/v0.26.0` (`VLLM_STABLE_COMMIT=568afb3…`), nor in the `v0.26.0` tag, nor on vLLM `main` — and `AsyncScheduler` does not override the method or accept `**kwargs`.

As a result, the delegation path raises `TypeError: _mamba_block_aligned_split() takes ... positional arguments but ... were given` whenever the HPU override forwards upstream (a mamba/`align`-cache model with prefix caching disabled).

## Fix

Drop the extra parameter and the extra forwarded argument so the override matches the base class pinned by this release branch. This mirrors the signature in the port to `main` (#1565) and restores the file to the pre-#1595 upstream-compatible signature.

## Verification

- vLLM pin `568afb3` `Scheduler._mamba_block_aligned_split`: 4 args, no `num_uncached_common_prefix_tokens`, no `**kwargs`.
- vLLM `v0.26.0` tag: same (4 args).
- vLLM `main`: same (4 args).
- vLLM pin for `releases/v0.24.0` (`ee0da84`): 5 args — which is why #1595 was correct there.
- `ruff check` passes on the edited file.

_Note: not yet exercised on HPU hardware — the change is a signature revert validated against the pinned upstream sources._

🤖 Generated with [Claude Code](https://claude.com/claude-code)