### PR TITLE
[CI] Add OpenSSF Scorecard, Dependabot, and SHA-pin GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# Dependabot keeps dependencies patched and, together with SHA-pinned
+# GitHub Actions, addresses the OpenSSF Scorecard "Pinned-Dependencies"
+# and "Vulnerabilities" checks. See:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates
+version: 2
+updates:
+  # Python packaging metadata (requirements*.txt, pyproject.toml).
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+
+  # GitHub Actions used by the workflows in .github/workflows.
+  # Dependabot updates the pinned SHAs while preserving the human-readable
+  # version comment, so actions can stay pinned and current.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions

--- a/.github/workflows/create-release-branch.yaml
+++ b/.github/workflows/create-release-branch.yaml
@@ -43,13 +43,13 @@ jobs:
       # Step 2: Checkout the correct code based on whether the branch exists.
       - name: "Checkout existing branch"
         if: steps.check_branch.outputs.exists == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           ref: ${{ github.event.inputs.branch_name }}
 
       - name: "Checkout base for new branch"
         if: steps.check_branch.outputs.exists == 'false'
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           # This checks out the branch that the workflow was manually triggered on.
           ref: ${{ github.ref_name }}
@@ -146,7 +146,7 @@ jobs:
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
     steps:
       - name: "Checkout the release branch"
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           ref: ${{ needs.prepare-release-branch.outputs.branch_name }}
       - name: Setup Docker environment and build image
@@ -194,7 +194,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: "Checkout the release branch"
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           ref: ${{ needs.prepare-release-branch.outputs.branch_name }}
       - name: Discover test functions
@@ -406,7 +406,7 @@ jobs:
           echo "SUBJECT=$SUBJECT" >> "$GITHUB_ENV"
 
       - name: "Create GitHub Issue with Summary"
-        uses: peter-evans/create-issue-from-file@v5
+        uses: peter-evans/create-issue-from-file@e8ef132d6df98ed982188e460ebb3b5d4ef3a9cd  # v5.0.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           title: ${{ env.SUBJECT }}

--- a/.github/workflows/hourly-ci.yaml
+++ b/.github/workflows/hourly-ci.yaml
@@ -42,7 +42,7 @@ jobs:
       latest_commit: ${{ steps.latest_vllm_commit.outputs.LATEST_COMMIT }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           # Fetch full history for accurate commit comparison
           fetch-depth: 0
@@ -55,7 +55,7 @@ jobs:
           echo "Cleanup complete."
 
       - name: Clean and Checkout repository again
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
           clean: true # Ensure a clean workspace before checkout
@@ -132,7 +132,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Discover test functions
         id: set-matrix
         run: |
@@ -259,7 +259,7 @@ jobs:
       contents: write # Permission is required to push a commit
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           ref: vllm/last-good-commit-for-vllm-gaudi
           fetch-depth: 0 # Fetch full history to ensure we can push changes

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -50,7 +50,7 @@ jobs:
     steps:
       # Add this checkout step
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           ref: ${{ needs.retrieve_head_sha.outputs.head_sha }}
           clean: true # Ensure a clean workspace before checkout
@@ -115,7 +115,7 @@ jobs:
         continue-on-error: true
         # Only run this step for non-merge-group PRs where a PR number is available
         if: inputs.is_merge_group != 'true' && inputs.pr_number != '' && steps.check_conditions.outputs.run_ci == 'false'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # v4.0.0
         with:
           issue-number: ${{ inputs.pr_number }}
           body: |
@@ -158,7 +158,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           ref: ${{ needs.retrieve_head_sha.outputs.head_sha }}
           clean: true # Ensure a clean workspace before checkout
@@ -189,7 +189,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           ref: ${{ needs.retrieve_head_sha.outputs.head_sha }}
           clean: true
@@ -215,7 +215,7 @@ jobs:
     timeout-minutes: 720
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           ref: ${{ needs.retrieve_head_sha.outputs.head_sha }}
           clean: true # Ensure a clean workspace before checkout
@@ -248,7 +248,7 @@ jobs:
       target_commit: ${{ steps.checkout_vllm_upstream.outputs.TEST_VLLM_COMMIT }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           # Fetch full history for accurate commit comparison
           ref: ${{ needs.retrieve_head_sha.outputs.head_sha }}
@@ -340,7 +340,7 @@ jobs:
           echo "TEST_VLLM_COMMIT=$COMMIT_ID" >> "$GITHUB_ENV"
           echo "Target commit ID for testing: $COMMIT_ID"
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           # Fetch full history for accurate commit comparison
           ref: ${{ needs.retrieve_head_sha.outputs.head_sha }}
@@ -569,7 +569,7 @@ jobs:
       nixl_changed: ${{ steps.check.outputs.nixl_changed }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           ref: ${{ needs.retrieve_head_sha.outputs.head_sha }}
           fetch-depth: 0
@@ -595,7 +595,7 @@ jobs:
     timeout-minutes: 720
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           ref: ${{ needs.retrieve_head_sha.outputs.head_sha }}
           clean: true
@@ -635,7 +635,7 @@ jobs:
     steps:
       - name: Post Comment on Success
         if: inputs.is_merge_group != 'true' && inputs.pr_number != '' && needs.pre_merge_hpu_test.result == 'success'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # v4.0.0
         with:
           issue-number: ${{ inputs.pr_number }}
           body: |

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,59 @@
+# OpenSSF Scorecard – automated supply-chain security posture checks.
+# Runs the ossf/scorecard-action, uploads results as SARIF to the
+# GitHub code-scanning dashboard, and publishes them to the public
+# OpenSSF REST API (which backs the README badge).
+name: Scorecard supply-chain security
+
+on:
+  # Weekly full scan; branch-protection and other repo-level checks only
+  # produce meaningful results on a schedule against the default branch.
+  schedule:
+    - cron: '32 4 * * 1'
+  # Re-scan when this workflow itself changes.
+  push:
+    branches: [main]
+
+# Least-privilege default; jobs opt in to what they need.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the SARIF results to the code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (id-token) and read OIDC.
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@05b42c624433fc40578a4040d5cf5e36ddca8cde  # v2.4.2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish results to the OpenSSF API so the README badge resolves.
+          # Uses the workflow's OIDC token; no secret (PAT) required for a
+          # public repository.
+          publish_results: true
+
+      # Retain the raw SARIF as a build artifact for auditing/debugging.
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Surface findings in the Security > Code scanning tab.
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@ce28f5bb42b7a9f2c824e633a3f6ee835bab6858  # v3.29.0
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/update-community-commit.yaml
+++ b/.github/workflows/update-community-commit.yaml
@@ -52,7 +52,7 @@ jobs:
 
       # Step 2: Check out the specific branch we need to modify
       - name: "Checkout the target branch"
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           ref: "vllm/last-good-commit-for-vllm-gaudi"
           # Fetch full history to ensure we can push changes

--- a/.github/workflows/update-pr-dashboard.yaml
+++ b/.github/workflows/update-pr-dashboard.yaml
@@ -94,13 +94,13 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Find Previous Comment
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e  # v3.1.0
         id: fc
         with:
           issue-number: 701
           body-includes: 
       - name: Create or Update Comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # v4.0.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: 701

--- a/.github/workflows/update-stable-commit.yaml
+++ b/.github/workflows/update-stable-commit.yaml
@@ -21,7 +21,7 @@ jobs:
     steps:
       # Step 1: Check out the specific branch we need to modify
       - name: "Checkout the target branch"
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           ref: "vllm/last-good-commit-for-vllm-gaudi"
           # Fetch full history to ensure we can push changes

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ vLLM Hardware Plugin for Intel® Gaudi®
 | <a href="https://vllm-gaudi.readthedocs.io/en/latest/index.html"><b>Documentation</b></a> | <a href="https://docs.habana.ai/en/latest/index.html"><b>Intel® Gaudi® Documentation</b></a> | <a href="https://docs.habana.ai/en/latest/PyTorch/Model_Optimization_PyTorch/Optimization_in_Training_Platform.html"><b>Optimizing Training Platform Guide</b></a> |
 </p>
 
+<p align="center">
+  <a href="https://scorecard.dev/viewer/?uri=github.com/vllm-project/vllm-gaudi"><img src="https://api.scorecard.dev/projects/github.com/vllm-project/vllm-gaudi/badge" alt="OpenSSF Scorecard"></a>
+</p>
+
 ---
 *Latest News* 🔥
 - [2026/07] Version 0.24.0 is now available, built on [vLLM 0.24.0](https://github.com/vllm-project/vllm/releases/tag/v0.24.0) and fully compatible with [Intel® Gaudi® v1.24.1](https://docs.habana.ai/en/v1.24.1/Release_Notes/GAUDI_Release_Notes.html) with PyTorch 2.11.


### PR DESCRIPTION
## What

Improves the repository's supply-chain security posture and addresses the "Development in the Open" security requirements.

- **OpenSSF Scorecard** — adds `.github/workflows/scorecard.yml`, a weekly (and on-push-to-main) run of `ossf/scorecard-action` that publishes results to the public OpenSSF API and uploads SARIF to the code-scanning dashboard. Adds a Scorecard badge to the README.
- **Dependabot** — adds `.github/dependabot.yml` for the `pip` and `github-actions` ecosystems, so both Python dependencies and pinned action SHAs stay patched over time.
- **SHA-pin GitHub Actions** — pins the remaining unpinned actions (`actions/checkout`, `peter-evans/*`) to full-length commit SHAs, matching the existing style already used elsewhere (`@<sha>  # vX.Y.Z`). This satisfies the Scorecard *Pinned-Dependencies* check.

## Notes

- All action references in the new workflow are themselves SHA-pinned.
- Pins keep the same major version already in use, so there is no functional change to existing CI behavior — every changed line in the existing workflows is a `uses:` reference.
- The badge will render once the workflow has run at least once on `main` and published to the OpenSSF API.

---
This PR was prepared with the assistance of an AI coding tool.