### PR TITLE
Fix Coverity-reported dead code and null residual issues

### DIFF
--- a/vllm_gaudi/models/deepseek_v2.py
+++ b/vllm_gaudi/models/deepseek_v2.py
@@ -69,7 +69,10 @@ def _hpu_deepseek_v2_model_forward(
             start=self.start_layer,
     ):
         if idx in self.aux_hidden_state_layers:
-            aux_hidden_states.append(hidden_states + residual)
+            # residual is None before the first layer runs (first PP rank);
+            # treat it as zero so the pre-residual hidden state is just
+            # hidden_states.
+            aux_hidden_states.append(hidden_states if residual is None else hidden_states + residual)
         hidden_states, residual = layer(positions, hidden_states, residual, llama_4_scaling)
 
     if not get_pp_group().is_last_rank:

--- a/vllm_gaudi/models/minimax_m3_mm.py
+++ b/vllm_gaudi/models/minimax_m3_mm.py
@@ -484,6 +484,7 @@ class MiniMaxM3VideoBackend(VideoBackend):
         if indices and indices[-1] != last_frame_idx and last_ts - prev_kept_ts > eps:
             indices.append(last_frame_idx)
 
-        if not indices:
-            indices = [0]
+        # Note: `indices` is guaranteed non-empty here because the early guard
+        # ensures total_frames >= 1, so the first loop iteration always appends
+        # frame 0.
         return indices


### PR DESCRIPTION
1) Coverity static analysis "Logically dead code"
flagged the `if not indices: indices = [0]` fallback at the end of
`MiniMaxM3VideoBackend.compute_frames_index_to_sample` as unreachable.
This removes the dead branch and documents why the invariant holds.

## Background

`compute_frames_index_to_sample` builds the list of source frame indices
to sample from a video, given source metadata (total frames, original fps)
and a target fps. It is registered as the `minimax_m3_vl` video loader
backend and drives which frames the MiniMax M3 vision pipeline actually
reads.

## Root cause

The function has two layers of protection that together guarantee a
non-empty result:

1. Early guard: `if total_frames <= 0 or video_fps <= 0 or fps <= 0`
   returns before the loop. Any execution reaching the loop therefore has
   `total_frames >= 1`.
2. First loop iteration: when `indices` is empty, `target_frame` is set to
   `0`. The break condition `target_frame >= total_frames` is
   `0 >= total_frames`, which is always false because `total_frames >= 1`,
   so frame `0` is unconditionally appended.

As a result, by the time control reaches the trailing
`if not indices: indices = [0]`, `indices` always contains at least one
element. The branch can never execute — it is dead code.

## Fix

- Remove the unreachable `if not indices: indices = [0]` fallback.
- Add a short comment recording the invariant (early guard ensures
  `total_frames >= 1`, so the first iteration always appends frame 0).

## Impact

- No functional/behavioral change: the removed branch was never taken.
- Resolves the Coverity DEADCODE finding.
- Slightly clearer control flow — the code no longer implies an
  "empty result" case that cannot occur.



2) Coverity static analysis (FORWARD_NULL — "Bad use of null-like
value") flagged a potential null dereference in the HPU
`DeepseekV2Model.forward` override (`_hpu_deepseek_v2_model_forward`). This
guards the auxiliary hidden-state computation so a `None` residual can no
longer be added to a tensor.

## Background

`_hpu_deepseek_v2_model_forward` is the HPU replacement for
`DeepseekV2Model.forward`. It restores the pre-#46635 plain decoder loop
because the upstream TP sequence-parallel all-gather block assumes the GPU
shape contract and misfires on HPU. The override applies to
DeepseekV2/V3/Deepseek/GlmMoe/DSA, all of which share
`model_cls = DeepseekV2Model`.

During the loop, when a layer index is in `self.aux_hidden_state_layers`,
the code captures the pre-residual hidden state via
`hidden_states + residual` for Eagle3 auxiliary outputs.

## Root cause

On the first pipeline-parallel rank, `residual` is initialized to `None`
and only becomes a tensor after the first decoder layer runs. The loop
computes `hidden_states + residual` *before* invoking the layer. If the
first processed layer index (`start_layer`) were present in
`aux_hidden_state_layers`, the expression would evaluate `tensor + None`
and raise at runtime.

In current practice the Eagle3 aux layers are
`(2, num_layers // 2, num_layers - 3)`, which never includes layer 0, so
the crash is not hit today. However, this relationship is not enforced, and
any future change to the aux-layer selection (or a model configured with
layer 0 as an aux layer) would trigger it. Static analysis correctly cannot
prove the layers exclude `start_layer`.

## Fix

Guard the aux hidden-state append:

```python
aux_hidden_states.append(
    hidden_states if residual is None else hidden_states + residual
)