### PR TITLE
Port of #1567: MXFP4 GPT-OSS SwiGLU-OAI + bias serving (releases/v0.26.0)

### DIFF
--- a/vllm_gaudi/__init__.py
+++ b/vllm_gaudi/__init__.py
@@ -116,6 +116,7 @@ def register_ops():
     import vllm_gaudi.ops.hpu_modelopt  # noqa: F401
     import vllm_gaudi.ops.hpu_compressed_tensors  # noqa: F401
     import vllm_gaudi.ops.hpu_fp8  # noqa: F401
+    import vllm_gaudi.ops.hpu_mxfp4  # noqa: F401
     import vllm_gaudi.ops.hpu_gptq  # noqa: F401
     import vllm_gaudi.ops.hpu_awq  # noqa: F401
     import vllm_gaudi.ops.hpu_conv  # noqa: F401

--- a/vllm_gaudi/extension/ops.py
+++ b/vllm_gaudi/extension/ops.py
@@ -1625,7 +1625,7 @@ class VllmMixtureOfExpertsOpMXFP4(VllmMixtureOfExpertsOpBase):
                     w12_list, w3_list, d_scale_w12, d_scale_w3,
                     block_size=block_size,
                     permuted_weights=True,
-                    activation=activation,
+                    activation="silu",
                     experts_min=experts_min,
                     experts_max=experts_max,
                     chunk_size=chunk_size,

--- a/vllm_gaudi/extension/ops.py
+++ b/vllm_gaudi/extension/ops.py
@@ -1551,10 +1551,11 @@ class VllmMixtureOfExpertsOpWNA16(torch.nn.Module):
 
 
 class MoeMXFP4Matmul(torch.nn.Module):
-    """Weight holder for packed MXFP4 weights + E8M0 scales."""
+    """Weight holder for packed MXFP4 weights + E8M0 scales (+ optional bias)."""
 
     def __init__(self):
         super().__init__()
+        self.bias = None
 
     def set_weight(self, w: torch.Tensor):
         """w: packed uint8 tensor, shape (rows, ceil(cols/2))."""
@@ -1563,6 +1564,10 @@ class MoeMXFP4Matmul(torch.nn.Module):
     def set_scale(self, s: torch.Tensor):
         """s: uint8 E8M0 scale tensor, shape (rows, ceil(cols/32))."""
         self.scale = s
+
+    def set_bias(self, b: torch.Tensor):
+        """b: bf16 per-expert bias (GPT-OSS SwiGLU-OAI), shape (out_features,)."""
+        self.bias = b
 
 
 class VllmMixtureOfExpertsOpMXFP4(VllmMixtureOfExpertsOpBase):
@@ -1583,9 +1588,18 @@ class VllmMixtureOfExpertsOpMXFP4(VllmMixtureOfExpertsOpBase):
                  experts_min: int = 0,
                  experts_max: int = 8,
                  block_size: int = 32,
+                 has_bias: bool = False,
+                 alpha: float = 1.702,
+                 limit: float = 7.0,
                  dispatch_fn: Callable[[torch.Tensor], torch.Tensor] = None):
         super().__init__(global_num_experts, num_total_experts, experts_min, experts_max, None, dispatch_fn)
         self.block_size = block_size
+        # GPT-OSS SwiGLU-OAI: per-expert bias on both projections + alpha/limit.
+        # When has_bias is set, the op applies gpt_swiglu (clamp ±limit, alpha-silu)
+        # internally and the "activation" string is ignored.
+        self.has_bias = has_bias
+        self.alpha = alpha
+        self.limit = limit
         self.w13_list = torch.nn.ModuleList([MoeMXFP4Matmul() for _ in range(num_total_experts)])
         self.w2_list = torch.nn.ModuleList([MoeMXFP4Matmul() for _ in range(num_total_experts)])
 
@@ -1593,6 +1607,8 @@ class VllmMixtureOfExpertsOpMXFP4(VllmMixtureOfExpertsOpBase):
         self._cached_w2_views = None
         self._cached_w13_scale_views = None
         self._cached_w2_scale_views = None
+        self._cached_w13_bias_views = None
+        self._cached_w2_bias_views = None
         self._compiled_forward = None
 
     def _cache_weight_lists(self):
@@ -1601,6 +1617,12 @@ class VllmMixtureOfExpertsOpMXFP4(VllmMixtureOfExpertsOpBase):
         self._cached_w2_views = tuple(self.w2_list[i].weight for i in experts_range)
         self._cached_w13_scale_views = tuple(self.w13_list[i].scale for i in experts_range)
         self._cached_w2_scale_views = tuple(self.w2_list[i].scale for i in experts_range)
+        if self.has_bias:
+            self._cached_w13_bias_views = tuple(self.w13_list[i].bias for i in experts_range)
+            self._cached_w2_bias_views = tuple(self.w2_list[i].bias for i in experts_range)
+        else:
+            self._cached_w13_bias_views = None
+            self._cached_w2_bias_views = None
 
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys,
                               error_msgs):
@@ -1615,23 +1637,59 @@ class VllmMixtureOfExpertsOpMXFP4(VllmMixtureOfExpertsOpBase):
 
     def _get_compiled_forward(self):
         if self._compiled_forward is None:
-            @torch.compile(backend="hpu_backend")
-            def _mxfp4_fused_fwd(hidden_states, expert_routing_table, router_weights,
-                                 w12_list, w3_list, d_scale_w12, d_scale_w3,
-                                 block_size, activation, experts_min, experts_max,
-                                 chunk_size, total_experts):
-                return torch.ops.hpu.mixture_of_experts.mxfp4_fused_weights(
-                    hidden_states, expert_routing_table, router_weights,
-                    w12_list, w3_list, d_scale_w12, d_scale_w3,
-                    block_size=block_size,
-                    permuted_weights=True,
-                    activation="silu",
-                    experts_min=experts_min,
-                    experts_max=experts_max,
-                    chunk_size=chunk_size,
-                    total_experts=total_experts,
-                )
-            self._compiled_forward = _mxfp4_fused_fwd
+            if self.has_bias:
+
+                @torch.compile(backend="hpu_backend")
+                def _mxfp4_bias_fused_fwd(hidden_states, expert_routing_table, router_weights, w12_list, w3_list,
+                                          w12_bias, w3_bias, d_scale_w12, d_scale_w3, block_size, experts_min,
+                                          experts_max, chunk_size, total_experts, alpha, limit):
+                    return torch.ops.hpu.mixture_of_experts.bias_mxfp4_fused_weights(
+                        hidden_states,
+                        expert_routing_table,
+                        router_weights,
+                        w12_list,
+                        w3_list,
+                        w12_bias,
+                        w3_bias,
+                        d_scale_w12,
+                        d_scale_w3,
+                        block_size=block_size,
+                        permuted_weights=True,
+                        experts_min=experts_min,
+                        experts_max=experts_max,
+                        is_fp4=True,
+                        chunk_size=chunk_size,
+                        total_experts=total_experts,
+                        alpha=alpha,
+                        limit=limit,
+                    )
+
+                self._compiled_forward = _mxfp4_bias_fused_fwd
+            else:
+
+                @torch.compile(backend="hpu_backend")
+                def _mxfp4_fused_fwd(hidden_states, expert_routing_table, router_weights, w12_list, w3_list,
+                                     d_scale_w12, d_scale_w3, block_size, activation, experts_min, experts_max,
+                                     chunk_size, total_experts):
+                    return torch.ops.hpu.mixture_of_experts.mxfp4_fused_weights(
+                        hidden_states,
+                        expert_routing_table,
+                        router_weights,
+                        w12_list,
+                        w3_list,
+                        d_scale_w12,
+                        d_scale_w3,
+                        block_size=block_size,
+                        permuted_weights=True,
+                        activation="silu",
+                        experts_min=experts_min,
+                        experts_max=experts_max,
+                        is_fp4=True,
+                        chunk_size=chunk_size,
+                        total_experts=total_experts,
+                    )
+
+                self._compiled_forward = _mxfp4_fused_fwd
         return self._compiled_forward
 
     def forward(self, hidden_states, expert_routing_table, router_weights, permuted_weights=True, activation="silu"):
@@ -1654,11 +1712,39 @@ class VllmMixtureOfExpertsOpMXFP4(VllmMixtureOfExpertsOpBase):
             expert_routing_table = expert_routing_table.to(torch.int32)
 
         compiled_fwd = self._get_compiled_forward()
+        if self.has_bias:
+            return compiled_fwd(
+                hidden_states,
+                expert_routing_table,
+                router_weights,
+                w13_list,
+                w2_list,
+                self._cached_w13_bias_views,
+                self._cached_w2_bias_views,
+                w13_scale,
+                w2_scale,
+                self.block_size,
+                self.experts_min,
+                self.experts_max,
+                chunk_size,
+                total_experts,
+                self.alpha,
+                self.limit,
+            )
         return compiled_fwd(
-            hidden_states, expert_routing_table, router_weights,
-            w13_list, w2_list, w13_scale, w2_scale,
-            self.block_size, activation, self.experts_min, self.experts_max,
-            chunk_size, total_experts,
+            hidden_states,
+            expert_routing_table,
+            router_weights,
+            w13_list,
+            w2_list,
+            w13_scale,
+            w2_scale,
+            self.block_size,
+            activation,
+            self.experts_min,
+            self.experts_max,
+            chunk_size,
+            total_experts,
         )
 
 

--- a/vllm_gaudi/extension/ops.py
+++ b/vllm_gaudi/extension/ops.py
@@ -1550,6 +1550,118 @@ class VllmMixtureOfExpertsOpWNA16(torch.nn.Module):
         return final_hidden_states
 
 
+class MoeMXFP4Matmul(torch.nn.Module):
+    """Weight holder for packed MXFP4 weights + E8M0 scales."""
+
+    def __init__(self):
+        super().__init__()
+
+    def set_weight(self, w: torch.Tensor):
+        """w: packed uint8 tensor, shape (rows, ceil(cols/2))."""
+        self.weight = w
+
+    def set_scale(self, s: torch.Tensor):
+        """s: uint8 E8M0 scale tensor, shape (rows, ceil(cols/32))."""
+        self.scale = s
+
+
+class VllmMixtureOfExpertsOpMXFP4(VllmMixtureOfExpertsOpBase):
+    """Native MXFP4 MOE op using torch.ops.hpu.mixture_of_experts.mxfp4_fused_weights.
+
+    Weights are stored in packed uint8 MXFP4 format (2 FP4 E2M1 values per byte)
+    with uint8 E8M0 scales (one per group of 32 elements). The native TPC kernel
+    performs dequantization on-the-fly during the MOE computation.
+
+    IMPORTANT: The mxfp4 ops have frontend_blocklist: [eager], meaning they can
+    only execute through the graph compilation path (torch.compile with hpu_backend).
+    The forward() method is decorated accordingly.
+    """
+
+    def __init__(self,
+                 global_num_experts: int,
+                 num_total_experts: int,
+                 experts_min: int = 0,
+                 experts_max: int = 8,
+                 block_size: int = 32,
+                 dispatch_fn: Callable[[torch.Tensor], torch.Tensor] = None):
+        super().__init__(global_num_experts, num_total_experts, experts_min, experts_max, None, dispatch_fn)
+        self.block_size = block_size
+        self.w13_list = torch.nn.ModuleList([MoeMXFP4Matmul() for _ in range(num_total_experts)])
+        self.w2_list = torch.nn.ModuleList([MoeMXFP4Matmul() for _ in range(num_total_experts)])
+
+        self._cached_w13_views = None
+        self._cached_w2_views = None
+        self._cached_w13_scale_views = None
+        self._cached_w2_scale_views = None
+        self._compiled_forward = None
+
+    def _cache_weight_lists(self):
+        experts_range = range(self.num_experts)
+        self._cached_w13_views = tuple(self.w13_list[i].weight for i in experts_range)
+        self._cached_w2_views = tuple(self.w2_list[i].weight for i in experts_range)
+        self._cached_w13_scale_views = tuple(self.w13_list[i].scale for i in experts_range)
+        self._cached_w2_scale_views = tuple(self.w2_list[i].scale for i in experts_range)
+
+    def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys,
+                              error_msgs):
+        super()._load_from_state_dict(state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys,
+                                      error_msgs)
+        self._cache_weight_lists()
+
+    def _apply(self, fn):
+        ret = super()._apply(fn)
+        self._cache_weight_lists()
+        return ret
+
+    def _get_compiled_forward(self):
+        if self._compiled_forward is None:
+            @torch.compile(backend="hpu_backend")
+            def _mxfp4_fused_fwd(hidden_states, expert_routing_table, router_weights,
+                                 w12_list, w3_list, d_scale_w12, d_scale_w3,
+                                 block_size, activation, experts_min, experts_max,
+                                 chunk_size, total_experts):
+                return torch.ops.hpu.mixture_of_experts.mxfp4_fused_weights(
+                    hidden_states, expert_routing_table, router_weights,
+                    w12_list, w3_list, d_scale_w12, d_scale_w3,
+                    block_size=block_size,
+                    permuted_weights=True,
+                    activation=activation,
+                    experts_min=experts_min,
+                    experts_max=experts_max,
+                    chunk_size=chunk_size,
+                    total_experts=total_experts,
+                )
+            self._compiled_forward = _mxfp4_fused_fwd
+        return self._compiled_forward
+
+    def forward(self, hidden_states, expert_routing_table, router_weights, permuted_weights=True, activation="silu"):
+        tokens_num, _ = hidden_states.shape
+        activation = _as_activation_str(activation)
+        kwargs = self._get_extra_kwargs(tokens_num)
+        chunk_size = kwargs.get("chunk_size", 0)
+        total_experts = kwargs.get("total_experts", 0)
+
+        if self._cached_w13_views is None or self._cached_w2_views is None:
+            self._cache_weight_lists()
+
+        w13_list = self._cached_w13_views
+        w2_list = self._cached_w2_views
+        w13_scale = self._cached_w13_scale_views
+        w2_scale = self._cached_w2_scale_views
+
+        # expert_routing_table must be int32 for the mxfp4 op
+        if expert_routing_table.dtype != torch.int32:
+            expert_routing_table = expert_routing_table.to(torch.int32)
+
+        compiled_fwd = self._get_compiled_forward()
+        return compiled_fwd(
+            hidden_states, expert_routing_table, router_weights,
+            w13_list, w2_list, w13_scale, w2_scale,
+            self.block_size, activation, self.experts_min, self.experts_max,
+            chunk_size, total_experts,
+        )
+
+
 def oot_get_quantization_config(quantization: str) -> QuantizationConfig:
     from .quant import _FakeINCConfig
     if quantization == "inc":

--- a/vllm_gaudi/extension/ops.py
+++ b/vllm_gaudi/extension/ops.py
@@ -1681,7 +1681,7 @@ class VllmMixtureOfExpertsOpMXFP4(VllmMixtureOfExpertsOpBase):
                         d_scale_w3,
                         block_size=block_size,
                         permuted_weights=True,
-                        activation="silu",
+                        activation=activation,
                         experts_min=experts_min,
                         experts_max=experts_max,
                         is_fp4=True,

--- a/vllm_gaudi/models/gptoss_mxfp4.py
+++ b/vllm_gaudi/models/gptoss_mxfp4.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterable
+import os
 
 import torch
 from transformers import PretrainedConfig
@@ -17,19 +18,32 @@ from vllm.model_executor.layers.fused_moe.config import FusedMoEParallelConfig
 from vllm.model_executor.models.utils import is_pp_missing_parameter
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 
+# HPU_MXFP4_NATIVE controls the MXFP4 execution strategy:
+#   True (HPU_MXFP4_NATIVE=1): If weights are packed, use native
+#     torch.ops.hpu.mixture_of_experts.mxfp4_fused_weights kernel.
+#     Quant config flows through normally (GptOssMxfp4Config is active).
+#     Upstream _load_weights_mxfp4 is used for weight loading.
+#   False (default, HPU_MXFP4_NATIVE=0): Suppress quant config, dequantize
+#     weights to BF16 at load time (legacy behavior).
+HPU_MXFP4_NATIVE = os.environ.get("HPU_MXFP4_NATIVE", "0") == "1"
+
 # Store original implementations before patching
 _original_normalize_quantization_config = ModelArchConfigConvertorBase._normalize_quantization_config
 _original_load_weights = GptOssModel.load_weights
 
 
 def _patched_normalize_quantization_config(self, config: PretrainedConfig):
-    # Skip mxfp4 quantization to use custom loading logic for gpt_oss
-    if getattr(config, "model_type", None) == "gpt_oss":
-        quant_cfg = getattr(config, "quantization_config", None)
-        if quant_cfg is not None and quant_cfg.get("quant_method", "").lower() == "mxfp4":
-            return None
-
-    # For all other models, use the original vLLM implementation
+    # When HPU_MXFP4_NATIVE=False (legacy mode), suppress the mxfp4 quant
+    # config so that BF16 params are allocated and we dequantize at load time.
+    # When HPU_MXFP4_NATIVE=True, let the quant config flow through so
+    # GptOssMxfp4Config is used and uint8 params are properly allocated.
+    if not HPU_MXFP4_NATIVE:
+        if getattr(config, "model_type", None) == "gpt_oss":
+            quant_cfg = getattr(config, "quantization_config", None)
+            if quant_cfg is not None and quant_cfg.get("quant_method", "").lower() == "mxfp4":
+                return None
+    print(f"HPU_MXFP4_NATIVE={'enabled' if HPU_MXFP4_NATIVE else 'disabled'}: ")
+    # For all other models (or native mode), use the original implementation
     return _original_normalize_quantization_config(self, config)
 
 
@@ -311,35 +325,45 @@ def patched_load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> s
 
     # Only use custom loading for gpt_oss + mxfp4.
     if quant_method == "gpt_oss_mxfp4":
-        stacked_params_mapping = [
-            # (param_name, shard_name, shard_id)
-            (".qkv_proj", ".q_proj", "q"),
-            (".qkv_proj", ".k_proj", "k"),
-            (".qkv_proj", ".v_proj", "v"),
-        ]
+        if 1:
+            print("HPU_MXFP4_NATIVE enabled: using upstream MXFP4 weight loading logic for MoE layers")
+            # Native mode: quant config is active, uint8 params are allocated
+            # by GptOssMxfp4MoEMethod.create_weights(). Use upstream loader
+            # which handles TP-sliced loading into uint8 params directly.
+            return _original_load_weights(self, weights)
+        else:
+            print("HPU_MXFP4_NATIVE disabled: using HPU MXFP4 weight loading logic for MoE layers with dequantization to BF16")
+            # Legacy mode: quant config suppressed, BF16 params allocated.
+            # Dequantize packed MXFP4 weights at load time.
+            stacked_params_mapping = [
+                # (param_name, shard_name, shard_id)
+                (".qkv_proj", ".q_proj", "q"),
+                (".qkv_proj", ".k_proj", "k"),
+                (".qkv_proj", ".v_proj", "v"),
+            ]
 
-        tp_rank = get_tensor_model_parallel_rank()
-        tp_size = get_tensor_model_parallel_world_size()
+            tp_rank = get_tensor_model_parallel_rank()
+            tp_size = get_tensor_model_parallel_world_size()
 
-        # Attention heads per rank
-        heads_per_rank = self.config.num_attention_heads // tp_size
-        head_start = tp_rank * heads_per_rank
+            # Attention heads per rank
+            heads_per_rank = self.config.num_attention_heads // tp_size
+            head_start = tp_rank * heads_per_rank
 
-        ep_size = get_ep_group().world_size
-        ep_rank = get_ep_group().rank
-        num_experts = self.config.num_local_experts
-        experts_per_rank = num_experts // ep_size
-        ep_rank_start = ep_rank * experts_per_rank
-        ep_rank_end = (ep_rank + 1) * experts_per_rank
+            ep_size = get_ep_group().world_size
+            ep_rank = get_ep_group().rank
+            num_experts = self.config.num_local_experts
+            experts_per_rank = num_experts // ep_size
+            ep_rank_start = ep_rank * experts_per_rank
+            ep_rank_end = (ep_rank + 1) * experts_per_rank
 
-        return self._load_weights_mxfp4_dequantize_hpu(
-            ep_rank_end,
-            ep_rank_start,
-            heads_per_rank,
-            head_start,
-            weights,
-            stacked_params_mapping,
-        )
+            return self._load_weights_mxfp4_dequantize_hpu(
+                ep_rank_end,
+                ep_rank_start,
+                heads_per_rank,
+                head_start,
+                weights,
+                stacked_params_mapping,
+            )
 
     # For all other models, use the original vLLM implementation
     return _original_load_weights(self, weights)

--- a/vllm_gaudi/models/gptoss_mxfp4.py
+++ b/vllm_gaudi/models/gptoss_mxfp4.py
@@ -354,7 +354,7 @@ def patched_load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> s
             ep_rank_start = ep_rank * experts_per_rank
             ep_rank_end = (ep_rank + 1) * experts_per_rank
 
-            return self._load_weights_mxfp4(
+            return self._load_weights_mxfp4_dequantize_hpu(
                 ep_rank_end,
                 ep_rank_start,
                 heads_per_rank,

--- a/vllm_gaudi/models/gptoss_mxfp4.py
+++ b/vllm_gaudi/models/gptoss_mxfp4.py
@@ -37,7 +37,7 @@ def _patched_normalize_quantization_config(self, config: PretrainedConfig):
     # config so that BF16 params are allocated and we dequantize at load time.
     # When HPU_MXFP4_NATIVE=True, let the quant config flow through so
     # GptOssMxfp4Config is used and uint8 params are properly allocated.
-    if not HPU_MXFP4_NATIVE:
+    if False:
         if getattr(config, "model_type", None) == "gpt_oss":
             quant_cfg = getattr(config, "quantization_config", None)
             if quant_cfg is not None and quant_cfg.get("quant_method", "").lower() == "mxfp4":
@@ -325,7 +325,7 @@ def patched_load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> s
 
     # Only use custom loading for gpt_oss + mxfp4.
     if quant_method == "gpt_oss_mxfp4":
-        if 1:
+        if 0:
             print("HPU_MXFP4_NATIVE enabled: using upstream MXFP4 weight loading logic for MoE layers")
             # Native mode: quant config is active, uint8 params are allocated
             # by GptOssMxfp4MoEMethod.create_weights(). Use upstream loader
@@ -356,7 +356,7 @@ def patched_load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> s
             ep_rank_start = ep_rank * experts_per_rank
             ep_rank_end = (ep_rank + 1) * experts_per_rank
 
-            return self._load_weights_mxfp4_dequantize_hpu(
+            return self._load_weights_mxfp4(
                 ep_rank_end,
                 ep_rank_start,
                 heads_per_rank,

--- a/vllm_gaudi/models/gptoss_mxfp4.py
+++ b/vllm_gaudi/models/gptoss_mxfp4.py
@@ -16,7 +16,10 @@ from vllm.distributed import (
 from vllm.model_executor.layers.quantization.utils.ocp_mx_utils import OCP_MX_BLOCK_SIZE
 from vllm.model_executor.layers.fused_moe.config import FusedMoEParallelConfig
 from vllm.model_executor.models.utils import is_pp_missing_parameter
-from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.model_loader.weight_utils import (
+    default_weight_loader,
+    remap_moe_expert_weights,
+)
 
 # HPU_MXFP4_NATIVE controls the MXFP4 execution strategy:
 #   True (HPU_MXFP4_NATIVE=1): If weights are packed, use native
@@ -181,7 +184,7 @@ def _load_weights_mxfp4_dequantize_hpu(
 
     block_weight_dict = {}
 
-    for name, weight in weights:
+    for name, weight in remap_moe_expert_weights(weights, params_dict):
         # Skip layers on other devices.
         if is_pp_missing_parameter(name, self):
             continue
@@ -199,7 +202,11 @@ def _load_weights_mxfp4_dequantize_hpu(
             # Read block weight
             block_name = name.replace("weight_scale", "weight")
             if block_name not in block_weight_dict:
-                raise ValueError(f"Expected block weight for {block_name} not found when processing {name}")
+                routed_block_name = block_name.replace(".experts.", ".experts.routed_experts.", 1)
+                if routed_block_name in block_weight_dict:
+                    block_name = routed_block_name
+                else:
+                    raise ValueError(f"Expected block weight for {block_name} not found when processing {name}")
             block_weight = block_weight_dict[block_name]
             param = params_dict[_param_key(block_name)]
 
@@ -231,7 +238,11 @@ def _load_weights_mxfp4_dequantize_hpu(
             # Read block weight
             block_name = name.replace("weight_scale", "weight")
             if block_name not in block_weight_dict:
-                raise ValueError(f"Expected block weight for {block_name} not found when processing {name}")
+                routed_block_name = block_name.replace(".experts.", ".experts.routed_experts.", 1)
+                if routed_block_name in block_weight_dict:
+                    block_name = routed_block_name
+                else:
+                    raise ValueError(f"Expected block weight for {block_name} not found when processing {name}")
             block_weight = block_weight_dict[block_name]
             param = params_dict[_param_key(block_name)]
 

--- a/vllm_gaudi/models/gptoss_mxfp4.py
+++ b/vllm_gaudi/models/gptoss_mxfp4.py
@@ -37,12 +37,10 @@ def _patched_normalize_quantization_config(self, config: PretrainedConfig):
     # config so that BF16 params are allocated and we dequantize at load time.
     # When HPU_MXFP4_NATIVE=True, let the quant config flow through so
     # GptOssMxfp4Config is used and uint8 params are properly allocated.
-    if False:
-        if getattr(config, "model_type", None) == "gpt_oss":
-            quant_cfg = getattr(config, "quantization_config", None)
-            if quant_cfg is not None and quant_cfg.get("quant_method", "").lower() == "mxfp4":
-                return None
-    print(f"HPU_MXFP4_NATIVE={'enabled' if HPU_MXFP4_NATIVE else 'disabled'}: ")
+    if not HPU_MXFP4_NATIVE and getattr(config, "model_type", None) == "gpt_oss":
+        quant_cfg = getattr(config, "quantization_config", None)
+        if quant_cfg is not None and quant_cfg.get("quant_method", "").lower() == "mxfp4":
+            return None
     # For all other models (or native mode), use the original implementation
     return _original_normalize_quantization_config(self, config)
 
@@ -325,14 +323,14 @@ def patched_load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> s
 
     # Only use custom loading for gpt_oss + mxfp4.
     if quant_method == "gpt_oss_mxfp4":
-        if 0:
-            print("HPU_MXFP4_NATIVE enabled: using upstream MXFP4 weight loading logic for MoE layers")
+        if HPU_MXFP4_NATIVE:
             # Native mode: quant config is active, uint8 params are allocated
-            # by GptOssMxfp4MoEMethod.create_weights(). Use upstream loader
-            # which handles TP-sliced loading into uint8 params directly.
+            # by HPUGptOssMxfp4MoEMethod.create_weights(). Use upstream loader
+            # which handles TP-sliced loading into uint8 params (packed weights,
+            # E8M0 scales, and w13_bias/w2_bias) directly, then
+            # process_weights_after_loading() builds VllmMixtureOfExpertsOpMXFP4.
             return _original_load_weights(self, weights)
         else:
-            print("HPU_MXFP4_NATIVE disabled: using HPU MXFP4 weight loading logic for MoE layers with dequantization to BF16")
             # Legacy mode: quant config suppressed, BF16 params allocated.
             # Dequantize packed MXFP4 weights at load time.
             stacked_params_mapping = [

--- a/vllm_gaudi/ops/hpu_mxfp4.py
+++ b/vllm_gaudi/ops/hpu_mxfp4.py
@@ -75,12 +75,18 @@ class HPUGptOssMxfp4MoEMethod(GptOssMxfp4MoEMethod):
         else:
             dispatch_fn = None
 
+        # GPT-OSS uses SwiGLU-OAI: per-expert bias on both projections, applied
+        # by the native op via the GPT_SWIGLU flag (alpha/limit). When the layer
+        # carries w13_bias/w2_bias, route through bias_mxfp4_fused_weights.
+        has_bias = hasattr(layer, "w13_bias") and hasattr(layer, "w2_bias")
+
         layer.moe_op = VllmMixtureOfExpertsOpMXFP4(
             layer.global_num_experts,
             num_experts,
             experts_min,
             experts_max,
             block_size=self.MXFP4_BLOCK_SIZE,
+            has_bias=has_bias,
             dispatch_fn=dispatch_fn,
         )
 
@@ -89,6 +95,9 @@ class HPUGptOssMxfp4MoEMethod(GptOssMxfp4MoEMethod):
             layer.moe_op.w13_list[expert_id].set_scale(layer.w13_weight_scale.data[expert_id])
             layer.moe_op.w2_list[expert_id].set_weight(layer.w2_weight.data[expert_id])
             layer.moe_op.w2_list[expert_id].set_scale(layer.w2_weight_scale.data[expert_id])
+            if has_bias:
+                layer.moe_op.w13_list[expert_id].set_bias(layer.w13_bias.data[expert_id])
+                layer.moe_op.w2_list[expert_id].set_bias(layer.w2_bias.data[expert_id])
 
         layer.moe_op._cache_weight_lists()
 
@@ -107,9 +116,7 @@ class HPUGptOssMxfp4MoEMethod(GptOssMxfp4MoEMethod):
             topk_weights = F.softmax(topk_weights, dim=-1, dtype=torch.float32)
         else:
             if layer.use_grouped_topk or getattr(layer, "custom_routing_function", None) is not None:
-                topk_weights, topk_ids = layer.router.select_experts(
-                    hidden_states=x, router_logits=router_logits
-                )
+                topk_weights, topk_ids = layer.router.select_experts(hidden_states=x, router_logits=router_logits)
             else:
                 topk_weights = F.softmax(router_logits, dim=1, dtype=torch.float32)
                 topk_weights, topk_ids = torch.topk(topk_weights, layer.top_k, dim=-1)

--- a/vllm_gaudi/ops/hpu_mxfp4.py
+++ b/vllm_gaudi/ops/hpu_mxfp4.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""HPU override for GptOssMxfp4MoEMethod.
+
+Monkey-patches the CUDA GptOssMxfp4MoEMethod so that when the quant config
+flows through (HPU_MXFP4_NATIVE=1), the HPU-specific kernel setup is used
+instead of CUDA kernel infrastructure.
+"""
+from collections.abc import Callable
+from functools import partial
+
+import torch
+import torch.nn.functional as F
+from vllm.config import get_current_vllm_config
+from vllm.model_executor.layers.fused_moe.layer import FusedMoE
+from vllm.model_executor.layers.quantization import mxfp4 as mxfp4_module
+from vllm.model_executor.layers.quantization.mxfp4 import GptOssMxfp4MoEMethod
+
+from vllm_gaudi.extension.ops import VllmMixtureOfExpertsOpMXFP4
+from vllm_gaudi.extension.runtime import get_config
+from vllm_gaudi.ops.hpu_fused_moe import _normalize_moe_activation
+from vllm_gaudi.v1.worker.hpu_dp_utils import (
+    dispatch_hidden_states,
+    dispatch_tensor,
+    get_hpu_dp_metadata,
+)
+
+
+class HPUGptOssMxfp4MoEMethod(GptOssMxfp4MoEMethod):
+    """HPU override of GptOssMxfp4MoEMethod.
+
+    Reuses parent's create_weights() (allocates uint8 params with correct shapes).
+    Overrides process_weights_after_loading to build VllmMixtureOfExpertsOpMXFP4
+    instead of CUDA kernels.
+    """
+
+    MXFP4_BLOCK_SIZE = 32
+
+    def __init__(self, moe):
+        # Call grandparent (FusedMoEMethodBase) init, skip CUDA backend selection
+        super(GptOssMxfp4MoEMethod, self).__init__(moe)
+        self.weight_dtype = "gpt_oss_mxfp4"
+        # No CUDA backend needed
+        self.mxfp4_backend = None
+        self.experts_cls = None
+        self.moe_kernel = None
+        self._cache_permute_indices = {}
+
+        self.use_dispatch_fn = get_config().use_dispatch_fn
+        torch.hpu.synchronize()
+        vllm_config = get_current_vllm_config()
+        self.model_type = None
+        if (vllm_config is not None and vllm_config.model_config is not None
+                and vllm_config.model_config.hf_config is not None):
+            self.model_type = vllm_config.model_config.hf_config.model_type
+
+    @property
+    def is_monolithic(self) -> bool:
+        return True
+
+    def _select_monolithic(self) -> Callable:
+        return self.apply_monolithic
+
+    def process_weights_after_loading(self, layer) -> None:
+        """Build VllmMixtureOfExpertsOpMXFP4 from the uint8 params loaded by upstream."""
+        num_experts = layer.local_num_experts
+        ep_shift = layer.ep_rank * num_experts
+        experts_min, experts_max = ep_shift, num_experts + ep_shift - 1
+
+        if layer.moe_config.dp_size > 1 and self.use_dispatch_fn:
+            dispatch_fn = partial(
+                dispatch_hidden_states,
+                is_sequence_parallel=layer.moe_config.is_sequence_parallel,
+            )
+        else:
+            dispatch_fn = None
+
+        layer.moe_op = VllmMixtureOfExpertsOpMXFP4(
+            layer.global_num_experts,
+            num_experts,
+            experts_min,
+            experts_max,
+            block_size=self.MXFP4_BLOCK_SIZE,
+            dispatch_fn=dispatch_fn,
+        )
+
+        for expert_id in range(num_experts):
+            layer.moe_op.w13_list[expert_id].set_weight(layer.w13_weight.data[expert_id])
+            layer.moe_op.w13_list[expert_id].set_scale(layer.w13_weight_scale.data[expert_id])
+            layer.moe_op.w2_list[expert_id].set_weight(layer.w2_weight.data[expert_id])
+            layer.moe_op.w2_list[expert_id].set_scale(layer.w2_weight_scale.data[expert_id])
+
+        layer.moe_op._cache_weight_lists()
+
+    def apply_monolithic(
+        self,
+        layer: FusedMoE,
+        x: torch.Tensor,
+        router_logits: torch.Tensor,
+        **kwargs,
+    ):
+        input_shape = x.shape
+        x = x.view(-1, x.shape[-1])
+
+        if self.model_type == "gpt_oss":
+            topk_weights, topk_ids = torch.topk(router_logits, layer.top_k, dim=-1)
+            topk_weights = F.softmax(topk_weights, dim=-1, dtype=torch.float32)
+        else:
+            if layer.use_grouped_topk or getattr(layer, "custom_routing_function", None) is not None:
+                topk_weights, topk_ids = layer.router.select_experts(
+                    hidden_states=x, router_logits=router_logits
+                )
+            else:
+                topk_weights = F.softmax(router_logits, dim=1, dtype=torch.float32)
+                topk_weights, topk_ids = torch.topk(topk_weights, layer.top_k, dim=-1)
+                topk_weights /= topk_weights.sum(dim=-1, keepdim=True)
+        topk_weights = topk_weights.to(x.dtype)
+
+        if not (layer.use_grouped_topk or getattr(layer, "custom_routing_function", None) is not None):
+            # MXFP4 kernel requires int32 routing table
+            topk_ids = topk_ids.to(torch.int32)
+            topk_weights = topk_weights.to(x.dtype)
+
+        if layer.moe_config.dp_size > 1:
+            dp_metadata = get_hpu_dp_metadata()
+            hidden_states_across_dp = dp_metadata.hidden_states_across_dp if dp_metadata is not None else None
+            x = dispatch_tensor(x, hidden_states_across_dp, layer.is_sequence_parallel)
+
+            topk_ids_across_dp = dp_metadata.topk_ids_across_dp if dp_metadata is not None else None
+            topk_ids = dispatch_tensor(topk_ids, topk_ids_across_dp, layer.is_sequence_parallel)
+
+            topk_weights_across_dp = dp_metadata.topk_weights_across_dp if dp_metadata is not None else None
+            topk_weights = dispatch_tensor(topk_weights, topk_weights_across_dp, layer.is_sequence_parallel)
+
+        topk_ids = topk_ids.view(-1, topk_ids.shape[-1])
+        topk_weights = topk_weights.view(-1, topk_weights.shape[-1])
+
+        output = layer.moe_op(
+            x,
+            topk_ids,
+            topk_weights,
+            permuted_weights=True,
+            activation=_normalize_moe_activation(layer.activation),
+        )
+        if layer.moe_config.dp_size > 1:
+            return output.view(*(output.size(0), *input_shape[1:]))
+        else:
+            return output.view(*input_shape)
+
+
+# Monkey-patch: replace CUDA GptOssMxfp4MoEMethod with HPU version
+mxfp4_module.GptOssMxfp4MoEMethod = HPUGptOssMxfp4MoEMethod

--- a/vllm_gaudi/ops/hpu_mxfp4.py
+++ b/vllm_gaudi/ops/hpu_mxfp4.py
@@ -64,7 +64,7 @@ class HPUGptOssMxfp4MoEMethod(GptOssMxfp4MoEMethod):
     def process_weights_after_loading(self, layer) -> None:
         """Build VllmMixtureOfExpertsOpMXFP4 from the uint8 params loaded by upstream."""
         num_experts = layer.local_num_experts
-        ep_shift = layer.ep_rank * num_experts
+        ep_shift = layer.moe_config.ep_rank * num_experts
         experts_min, experts_max = ep_shift, num_experts + ep_shift - 1
 
         if layer.moe_config.dp_size > 1 and self.use_dispatch_fn:
@@ -131,13 +131,13 @@ class HPUGptOssMxfp4MoEMethod(GptOssMxfp4MoEMethod):
         if layer.moe_config.dp_size > 1:
             dp_metadata = get_hpu_dp_metadata()
             hidden_states_across_dp = dp_metadata.hidden_states_across_dp if dp_metadata is not None else None
-            x = dispatch_tensor(x, hidden_states_across_dp, layer.is_sequence_parallel)
+            x = dispatch_tensor(x, hidden_states_across_dp, layer.moe_config.is_sequence_parallel)
 
             topk_ids_across_dp = dp_metadata.topk_ids_across_dp if dp_metadata is not None else None
-            topk_ids = dispatch_tensor(topk_ids, topk_ids_across_dp, layer.is_sequence_parallel)
+            topk_ids = dispatch_tensor(topk_ids, topk_ids_across_dp, layer.moe_config.is_sequence_parallel)
 
             topk_weights_across_dp = dp_metadata.topk_weights_across_dp if dp_metadata is not None else None
-            topk_weights = dispatch_tensor(topk_weights, topk_weights_across_dp, layer.is_sequence_parallel)
+            topk_weights = dispatch_tensor(topk_weights, topk_weights_across_dp, layer.moe_config.is_sequence_parallel)
 
         topk_ids = topk_ids.view(-1, topk_ids.shape[-1])
         topk_weights = topk_weights.view(-1, topk_weights.shape[-1])

--- a/vllm_gaudi/platform.py
+++ b/vllm_gaudi/platform.py
@@ -63,7 +63,9 @@ class HpuPlatform(Platform):
     dispatch_key: str = "HPU"
     ray_device_key: str = "HPU"
     device_control_env_var: str = "HABANA_VISIBLE_MODULES"
-    supported_quantization: list[str] = ["compressed-tensors", "fp8", "inc", "awq_hpu", "gptq_hpu", "modelopt"]
+    supported_quantization: list[str] = [
+        "compressed-tensors", "fp8", "inc", "awq_hpu", "gptq_hpu", "modelopt", "gpt_oss_mxfp4"
+    ]
     simple_compile_backend = "hpu_backend"
     additional_env_vars = [k for k, v in os.environ.items() if retain_envs(k)]
 


### PR DESCRIPTION
## Summary
Port of #1567 ("MXFP4 GPT-OSS SwiGLU-OAI + bias serving") onto `releases/v0.26.0`.

Routes GPT-OSS MXFP4 MoE through the native
`torch.ops.hpu.mixture_of_experts.bias_mxfp4_fused_weights` op so SwiGLU-OAI
(alpha=1.702, limit=7.0) + per-expert bias are applied on-device on the packed
weights, instead of dequantizing the experts to bf16 at load time.

## Changes
- `extension/ops.py`: `MoeMXFP4Matmul.set_bias`; `VllmMixtureOfExpertsOpMXFP4`
  gains `has_bias`/`alpha`/`limit`, caches w13/w2 bias views, and adds a
  bias-aware compiled forward calling `bias_mxfp4_fused_weights` (falls back to
  `mxfp4_fused_weights` when there is no bias).
- `ops/hpu_mxfp4.py`: detect `w13_bias`/`w2_bias` and load them into the op.
- `models/gptoss_mxfp4.py`: enable the `HPU_MXFP4_NATIVE` branches (were hardcoded
  off) so packed uint8 weights + E8M0 scales + bias reach the native op; and fix
  the reference (`HPU_MXFP4_NATIVE=0`) loader to call the branch's own
  `_load_weights_mxfp4_dequantize_hpu`.

## Notes on the port
- Because upstream #1526 ("Add Single Card support in GPTOSS") was closed unmerged,
  its two commits are included here (they are part of #1567's effective diff).
- Cherry-picked all 7 commits from #1567 cleanly onto `releases/v0.26.0`; no
  conflicts. Resulting `vllm_gaudi/` diff is content-identical to #1567.

## Dependencies
- A companion `habana_frameworks` build providing the `bias_mxfp4_fused_weights`
  op, plus the complex_guid MoeExperts GPT-SwiGLU MXFP4 fix.

Original PR: https://github.com/vllm-project/vllm-gaudi/pull/1567
