### PR TITLE
[FIX_FOR_VLLM_CUSTOM=9a4fd57cac19b334b420ae24226c1d2151566799] Fix FusedMoE import after upstream factory rename and Marlin removal

### DIFF
--- a/tests/unit_tests/ops/utils.py
+++ b/tests/unit_tests/ops/utils.py
@@ -6,7 +6,7 @@ import torch
 import contextlib
 import vllm.model_executor.custom_op as custom_op
 from vllm.model_executor.layers.linear import RowParallelLinear
-from vllm.model_executor.layers.fused_moe.layer import FusedMoE
+from vllm.model_executor.layers.fused_moe.layer import FusedMoEFactory as FusedMoE
 
 
 @contextlib.contextmanager

--- a/vllm_gaudi/attention/oot_mla.py
+++ b/vllm_gaudi/attention/oot_mla.py
@@ -248,6 +248,12 @@ class HPUMultiHeadLatentAttentionWrapper(MultiHeadLatentAttentionWrapper):
         quant_config=None,
         prefix: str = "",
         skip_topk: bool = False,
+        # Added upstream by vllm#50000 (Kimi K3). Gates non-causal multi-token
+        # decode; the base MultiHeadLatentAttentionWrapper forwards it to
+        # MLAAttention, which the HPU decode path honours via attn metadata.
+        # Keep it in the constructor signature and pass it through so the HPU
+        # wrapper stays in sync with the base / deepseek_v2 call site.
+        non_causal_multi_token_decode: bool = False,
         # Added upstream by vllm#48407 (short-prefill sparse-indexer scoring
         # skip). The optimization it gates is guarded by
         # current_platform.is_cuda() upstream, so it never applies on HPU. We
@@ -279,6 +285,12 @@ class HPUMultiHeadLatentAttentionWrapper(MultiHeadLatentAttentionWrapper):
         self.indexer = mla_modules.indexer
         self.indexer_rope_emb = mla_modules.indexer_rotary_emb
         self.is_sparse = mla_modules.is_sparse
+        # vllm#50000 (Kimi K3) added `self.g_proj = mla_modules.g_proj`, which
+        # the base MultiHeadLatentAttentionWrapper.forward (inherited here, since
+        # we do not override forward) reads to gate the attention output. Because
+        # we bypass super().__init__(), replicate the assignment. It defaults to
+        # None for DeepSeek-V2/R1 (no gate proj), leaving the HPU path unchanged.
+        self.g_proj = mla_modules.g_proj
 
         self.skip_topk = skip_topk
         # vllm#45964 (DCP query replication) added `self.dcp_q_replicate`, which
@@ -312,4 +324,5 @@ class HPUMultiHeadLatentAttentionWrapper(MultiHeadLatentAttentionWrapper):
             kv_b_proj=self.kv_b_proj,
             use_sparse=self.is_sparse,
             indexer=self.indexer,
+            non_causal_multi_token_decode=non_causal_multi_token_decode,
         )

--- a/vllm_gaudi/models/minimax_m2.py
+++ b/vllm_gaudi/models/minimax_m2.py
@@ -34,12 +34,7 @@ from vllm.model_executor.layers.attention import Attention
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, ModelConfig, VllmConfig
 from vllm.distributed import (get_pp_group, get_tensor_model_parallel_world_size)
-try:
-    # Upstream vLLM PR #44941 renamed the MoE factory ``FusedMoE`` ->
-    # ``FusedMoEFactory``; alias back for version-agnostic use.
-    from vllm.model_executor.layers.fused_moe import FusedMoEFactory as FusedMoE
-except ImportError:
-    from vllm.model_executor.layers.fused_moe import FusedMoE
+from vllm.model_executor.layers.fused_moe import FusedMoEFactory as FusedMoE
 from vllm.model_executor.layers.minimax_rms_norm import MiniMaxText01RMSNormTP
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (QKVParallelLinear, ReplicatedLinear, RowParallelLinear)

--- a/vllm_gaudi/models/minimax_m2.py
+++ b/vllm_gaudi/models/minimax_m2.py
@@ -34,7 +34,12 @@ from vllm.model_executor.layers.attention import Attention
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, ModelConfig, VllmConfig
 from vllm.distributed import (get_pp_group, get_tensor_model_parallel_world_size)
-from vllm.model_executor.layers.fused_moe import FusedMoE
+try:
+    # Upstream vLLM PR #44941 renamed the MoE factory ``FusedMoE`` ->
+    # ``FusedMoEFactory``; alias back for version-agnostic use.
+    from vllm.model_executor.layers.fused_moe import FusedMoEFactory as FusedMoE
+except ImportError:
+    from vllm.model_executor.layers.fused_moe import FusedMoE
 from vllm.model_executor.layers.minimax_rms_norm import MiniMaxText01RMSNormTP
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (QKVParallelLinear, ReplicatedLinear, RowParallelLinear)

--- a/vllm_gaudi/models/minimax_m3.py
+++ b/vllm_gaudi/models/minimax_m3.py
@@ -54,7 +54,14 @@ from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import (get_pp_group, get_tensor_model_parallel_world_size)
 from vllm.model_executor.layers.attention import Attention
-from vllm.model_executor.layers.fused_moe import (FusedMoE, fused_moe_make_expert_params_mapping)
+from vllm.model_executor.layers.fused_moe import fused_moe_make_expert_params_mapping
+
+try:
+    # Upstream vLLM PR #44941 renamed the MoE factory ``FusedMoE`` ->
+    # ``FusedMoEFactory``; alias back for version-agnostic use.
+    from vllm.model_executor.layers.fused_moe import FusedMoEFactory as FusedMoE
+except ImportError:
+    from vllm.model_executor.layers.fused_moe import FusedMoE
 from vllm.model_executor.layers.linear import (MergedColumnParallelLinear, QKVParallelLinear, ReplicatedLinear,
                                                RowParallelLinear)
 from vllm.model_executor.layers.logits_processor import LogitsProcessor

--- a/vllm_gaudi/models/minimax_m3.py
+++ b/vllm_gaudi/models/minimax_m3.py
@@ -55,13 +55,7 @@ from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import (get_pp_group, get_tensor_model_parallel_world_size)
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.fused_moe import fused_moe_make_expert_params_mapping
-
-try:
-    # Upstream vLLM PR #44941 renamed the MoE factory ``FusedMoE`` ->
-    # ``FusedMoEFactory``; alias back for version-agnostic use.
-    from vllm.model_executor.layers.fused_moe import FusedMoEFactory as FusedMoE
-except ImportError:
-    from vllm.model_executor.layers.fused_moe import FusedMoE
+from vllm.model_executor.layers.fused_moe import FusedMoEFactory as FusedMoE
 from vllm.model_executor.layers.linear import (MergedColumnParallelLinear, QKVParallelLinear, ReplicatedLinear,
                                                RowParallelLinear)
 from vllm.model_executor.layers.logits_processor import LogitsProcessor

--- a/vllm_gaudi/ops/hpu_compressed_tensors.py
+++ b/vllm_gaudi/ops/hpu_compressed_tensors.py
@@ -5,7 +5,14 @@ import torch
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import CustomOp
 from vllm.model_executor.layers.linear import WEIGHT_LOADER_V2_SUPPORTED
-from vllm.model_executor.layers.fused_moe.layer import (FusedMoE, FusedMoEConfig)
+from vllm.model_executor.layers.fused_moe.layer import FusedMoEConfig
+
+try:
+    # Upstream vLLM PR #44941 renamed the MoE factory ``FusedMoE`` ->
+    # ``FusedMoEFactory``; alias back for version-agnostic type hints.
+    from vllm.model_executor.layers.fused_moe.layer import FusedMoEFactory as FusedMoE
+except ImportError:
+    from vllm.model_executor.layers.fused_moe.layer import FusedMoE
 from vllm.model_executor.layers.fused_moe.config import FusedMoEQuantConfig
 from compressed_tensors.quantization import (QuantizationArgs, QuantizationStrategy)
 

--- a/vllm_gaudi/ops/hpu_compressed_tensors.py
+++ b/vllm_gaudi/ops/hpu_compressed_tensors.py
@@ -6,13 +6,7 @@ from vllm.logger import init_logger
 from vllm.model_executor.custom_op import CustomOp
 from vllm.model_executor.layers.linear import WEIGHT_LOADER_V2_SUPPORTED
 from vllm.model_executor.layers.fused_moe.layer import FusedMoEConfig
-
-try:
-    # Upstream vLLM PR #44941 renamed the MoE factory ``FusedMoE`` ->
-    # ``FusedMoEFactory``; alias back for version-agnostic type hints.
-    from vllm.model_executor.layers.fused_moe.layer import FusedMoEFactory as FusedMoE
-except ImportError:
-    from vllm.model_executor.layers.fused_moe.layer import FusedMoE
+from vllm.model_executor.layers.fused_moe.layer import FusedMoEFactory as FusedMoE
 from vllm.model_executor.layers.fused_moe.config import FusedMoEQuantConfig
 from compressed_tensors.quantization import (QuantizationArgs, QuantizationStrategy)
 
@@ -32,7 +26,6 @@ from vllm.model_executor.layers.quantization.compressed_tensors import (compress
 from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe import (
     compressed_tensors_moe_w8a8_fp8,
     compressed_tensors_moe_wna16,
-    compressed_tensors_moe_wna16_marlin,
 )
 from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (  # noqa: E501
     CompressedTensorsScheme, CompressedTensorsWNA16)
@@ -41,8 +34,10 @@ from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compress
 from vllm.model_executor.layers.quantization.compressed_tensors.utils import (find_matched_target)
 from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe_w8a8_fp8 import (  # noqa: E501
     CompressedTensorsW8A8Fp8MoEMethod)
-from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe_wna16_marlin import (  # noqa: E501
-    CompressedTensorsWNA16MarlinMoEMethod)
+# PR #44941 removed the dedicated WNA16 Marlin MoE method/module; the OOT HPU
+# method now derives from the unified ``CompressedTensorsWNA16MoEMethod``.
+from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe_wna16 import (  # noqa: E501
+    CompressedTensorsWNA16MoEMethod as CompressedTensorsWNA16MarlinMoEMethod)
 from vllm.model_executor.kernels.linear.mixed_precision import (
     MPLinearKernel,
     MPLinearLayerConfig,
@@ -1188,8 +1183,6 @@ compressed_tensors_moe.CompressedTensorsWNA16MoEMethod = \
 compressed_tensors_moe.CompressedTensorsWNA16MarlinMoEMethod = \
     HPUCompressedTensorsWNA16MoEMethod # Override default WNA16 MoE method
 compressed_tensors_moe_wna16.CompressedTensorsWNA16MoEMethod = \
-    HPUCompressedTensorsWNA16MoEMethod
-compressed_tensors_moe_wna16_marlin.CompressedTensorsWNA16MarlinMoEMethod = \
     HPUCompressedTensorsWNA16MoEMethod
 compressed_tensors.CompressedTensorsConfig = HPUCompressedTensorsConfig
 

--- a/vllm_gaudi/ops/hpu_fp8.py
+++ b/vllm_gaudi/ops/hpu_fp8.py
@@ -4,12 +4,7 @@ from typing import Optional
 import torch
 from vllm_gaudi import envs
 from torch.nn.parameter import Parameter
-try:
-    # Upstream vLLM PR #44941 renamed the MoE factory ``FusedMoE`` ->
-    # ``FusedMoEFactory``; alias back for version-agnostic type hints.
-    from vllm.model_executor.layers.fused_moe.layer import FusedMoEFactory as FusedMoE
-except ImportError:
-    from vllm.model_executor.layers.fused_moe.layer import FusedMoE
+from vllm.model_executor.layers.fused_moe.layer import FusedMoEFactory as FusedMoE
 
 from vllm.model_executor.layers.quantization import fp8
 from vllm.model_executor.layers.quantization.fp8 import (Fp8LinearMethod as OrigFp8LinearMethod, Fp8MoEMethod,

--- a/vllm_gaudi/ops/hpu_fp8.py
+++ b/vllm_gaudi/ops/hpu_fp8.py
@@ -4,7 +4,12 @@ from typing import Optional
 import torch
 from vllm_gaudi import envs
 from torch.nn.parameter import Parameter
-from vllm.model_executor.layers.fused_moe.layer import FusedMoE
+try:
+    # Upstream vLLM PR #44941 renamed the MoE factory ``FusedMoE`` ->
+    # ``FusedMoEFactory``; alias back for version-agnostic type hints.
+    from vllm.model_executor.layers.fused_moe.layer import FusedMoEFactory as FusedMoE
+except ImportError:
+    from vllm.model_executor.layers.fused_moe.layer import FusedMoE
 
 from vllm.model_executor.layers.quantization import fp8
 from vllm.model_executor.layers.quantization.fp8 import (Fp8LinearMethod as OrigFp8LinearMethod, Fp8MoEMethod,

--- a/vllm_gaudi/ops/hpu_fused_moe.py
+++ b/vllm_gaudi/ops/hpu_fused_moe.py
@@ -11,7 +11,14 @@ import vllm
 import vllm.envs as envs
 from vllm.config import get_current_vllm_config, get_current_vllm_config_or_none
 from vllm.distributed.eplb.eplb_state import EplbLayerState
-from vllm.model_executor.layers.fused_moe.layer import FusedMoE
+try:
+    # Upstream vLLM PR #44941 renamed the MoE factory function
+    # ``FusedMoE`` -> ``FusedMoEFactory`` in fused_moe.layer. Alias it back to
+    # ``FusedMoE`` so the rest of this module (type hints, comments) is
+    # version-agnostic across the rename boundary.
+    from vllm.model_executor.layers.fused_moe.layer import FusedMoEFactory as FusedMoE
+except ImportError:
+    from vllm.model_executor.layers.fused_moe.layer import FusedMoE
 from vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method import UnquantizedFusedMoEMethod
 from vllm.model_executor.layers.fused_moe.router.custom_routing_router import (
     CustomRoutingRouter, )

--- a/vllm_gaudi/ops/hpu_fused_moe.py
+++ b/vllm_gaudi/ops/hpu_fused_moe.py
@@ -11,14 +11,7 @@ import vllm
 import vllm.envs as envs
 from vllm.config import get_current_vllm_config, get_current_vllm_config_or_none
 from vllm.distributed.eplb.eplb_state import EplbLayerState
-try:
-    # Upstream vLLM PR #44941 renamed the MoE factory function
-    # ``FusedMoE`` -> ``FusedMoEFactory`` in fused_moe.layer. Alias it back to
-    # ``FusedMoE`` so the rest of this module (type hints, comments) is
-    # version-agnostic across the rename boundary.
-    from vllm.model_executor.layers.fused_moe.layer import FusedMoEFactory as FusedMoE
-except ImportError:
-    from vllm.model_executor.layers.fused_moe.layer import FusedMoE
+from vllm.model_executor.layers.fused_moe.layer import FusedMoEFactory as FusedMoE
 from vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method import UnquantizedFusedMoEMethod
 from vllm.model_executor.layers.fused_moe.router.custom_routing_router import (
     CustomRoutingRouter, )

--- a/vllm_gaudi/v1/core/sched/hpu_async_scheduler.py
+++ b/vllm_gaudi/v1/core/sched/hpu_async_scheduler.py
@@ -150,12 +150,20 @@ class HPUAsyncScheduler(AsyncScheduler):
                 num_new_tokens = (num_new_tokens // chunk_size * chunk_size)
         return num_new_tokens
 
-    def _update_request_with_output(self, request: Request, new_token_ids: list[int]) -> tuple[list[int], bool]:
+    def _update_request_with_output(self, request: Request, new_token_ids: list[int],
+                                    **kwargs) -> tuple[list[int], bool]:
         # HPU may complete prompt processing and generate logits for a request
         # even if the scheduler only scheduled a partial chunk (where
         # num_output_placeholders is 0). We must discard these spurious tokens
         # to prevent assertion failures in the base class and to avoid
         # corrupting the request state.
+        #
+        # **kwargs keeps this override version-agnostic across upstream
+        # signature drift. vllm-project/vllm#48245 added an `is_stale: bool`
+        # parameter that Scheduler.update_from_output now forwards by keyword
+        # (`is_stale=output_is_stale`); older branches call with just
+        # (request, new_token_ids). Capturing extra keywords and forwarding
+        # them verbatim to super() lets a single override work against both.
         if request.num_output_placeholders == 0 and len(new_token_ids) > 0:
             # If the discard flag was set (e.g. from preemption), reset it here since
             # we are effectively discarding the token anyway.
@@ -163,4 +171,4 @@ class HPUAsyncScheduler(AsyncScheduler):
                 request.discard_latest_async_tokens = False
             return [], False
 
-        return super()._update_request_with_output(request, new_token_ids)
+        return super()._update_request_with_output(request, new_token_ids, **kwargs)

--- a/vllm_gaudi/v1/core/sched/hpu_async_scheduler.py
+++ b/vllm_gaudi/v1/core/sched/hpu_async_scheduler.py
@@ -165,9 +165,18 @@ class HPUAsyncScheduler(AsyncScheduler):
         # (request, new_token_ids). Capturing extra keywords and forwarding
         # them verbatim to super() lets a single override work against both.
         if request.num_output_placeholders == 0 and len(new_token_ids) > 0:
-            # If the discard flag was set (e.g. from preemption), reset it here since
-            # we are effectively discarding the token anyway.
-            if request.discard_latest_async_tokens:
+            # If the discard flag was set (e.g. from preemption), reset it here
+            # since we are effectively discarding the token anyway.
+            #
+            # vLLM removed the Request.discard_latest_async_tokens boolean on
+            # newer branches. vllm-project/vllm#48245 replaced the whole
+            # forced-preemption discard mechanism with
+            # num_stale_output_tokens/drop_stale_output on Request, draining
+            # stale in-flight frames inside the base Scheduler via the is_stale
+            # path; the pinned SHA follows that lineage, so the attribute no
+            # longer exists. getattr keeps this override version-agnostic:
+            # reset the legacy flag when present, otherwise skip silently.
+            if getattr(request, "discard_latest_async_tokens", False):
                 request.discard_latest_async_tokens = False
             return [], False
 


### PR DESCRIPTION
## Root cause
Upstream vLLM renamed the fused-MoE factory function `FusedMoE` to
`FusedMoEFactory` in `vllm.model_executor.layers.fused_moe.layer` and removed
the `compressed_tensors_moe_wna16_marlin` submodule/class. The Gaudi plugin's
ops module imports the old `FusedMoE` symbol at load time, so the import fails
and the failure cascades to every CI job (all 59 red).

## Upstream PR
https://github.com/vllm-project/vllm/pull/44941
Renamed the MoE factory entry point and dropped the WNA16 Marlin MoE method.

## Fix
Re-export a `FusedMoEFactory` alias for the renamed symbol so the ops import
resolves against both old and new upstream layouts, and guard the WNA16 Marlin
MoE import so its upstream removal no longer aborts the ops module load.