### PR TITLE
tests: add Nemotron-H FP8 GSM8K accuracy test

### DIFF
--- a/tests/full_tests/ci_e2e_discoverable_tests.sh
+++ b/tests/full_tests/ci_e2e_discoverable_tests.sh
@@ -445,6 +445,19 @@ run_gsm8k_qwen36_35b_a3b_test() {
     echo "✅ Test with Qwen3.6-35B-A3B passed."
 }
 
+
+# GSM8K on Nemotron-H FP8 (non-gated squared-ReLU MoE + quant-aware Mamba
+# in_proj). Guards the HPU enablement from PR #1667: the unfused non-gated FP8
+# expert path and the mixed-dtype Mamba2 KV-cache allocation both regress
+# silently, so an accuracy gate is the right guardrail.
+run_gsm8k_nemotron_h_fp8_test() {
+    echo "➡️ Testing GSM8K on Nemotron-H FP8..."
+    VLLM_SKIP_WARMUP=True \
+    pytest -v -s "${VLLM_GAUDI_PREFIX}/tests/models/language/generation/test_common.py" \
+        --model_card_path "${VLLM_GAUDI_PREFIX}/tests/full_tests/model_cards/nemotron-h-fp8.yaml"
+    echo "✅ Test with Nemotron-H FP8 passed."
+}
+
 # GSM8K on gemma-4-E4B (YOCO / KV-sharing model)
 run_gsm8k_gemma4_e4b_test() {
     echo "➡️ Testing GSM8K on gemma-4-E4B-it..."

--- a/tests/full_tests/model_cards/nemotron-h-fp8.yaml
+++ b/tests/full_tests/model_cards/nemotron-h-fp8.yaml
@@ -1,0 +1,28 @@
+model_card:
+  # Nemotron-H FP8 (non-gated squared-ReLU MoE + quant-aware Mamba in_proj),
+  # enabled on HPU by PR #1667. This GSM8K card guards the accuracy of that
+  # enablement so a rebase can't silently regress the unfused non-gated FP8
+  # expert path or the mixed-dtype Mamba2 KV-cache allocation.
+  #
+  # NOTE: RedHatAI/NVIDIA-Nemotron-3-Ultra-550B-A55B-FP8-dynamic is a 550B
+  # (55B-active) model -- weight load + warmup alone exceeds the 5-min CI
+  # target and it needs large TP (multi-card). If a smaller Nemotron-H FP8
+  # checkpoint is available, prefer it here to keep this test CI-affordable;
+  # otherwise this card should run in the long/nightly tier, not the fast set.
+  model_name: "RedHatAI/NVIDIA-Nemotron-3-Ultra-550B-A55B-FP8-dynamic"
+  tasks: "gsm8k"
+  num_fewshot: 5
+  trust_remote_code: true
+  limit: 256
+  max_num_seqs: 128
+  max_model_len: 16384
+  batch_size: 32
+  dtype: bfloat16
+  gpu_memory_utilization: 0.8
+  max_num_batched_tokens: 16384
+
+metrics:
+  name: exact_match,strict-match
+  # PLACEHOLDER -- replace with your measured GSM8K score. The harness gates on
+  # (value - 0.03), so set this to the observed score rounded down slightly.
+  value: 0.80


### PR DESCRIPTION
## What

Adds a GSM8K accuracy test for **Nemotron-H FP8** on HPU: a model card (`tests/full_tests/model_cards/nemotron-h-fp8.yaml`) plus a discoverable `run_gsm8k_nemotron_h_fp8_test` in `ci_e2e_discoverable_tests.sh`.

## Why

Nemotron-H FP8 enablement (#1667) adds two code paths that would regress silently with no accuracy coverage:
- the **unfused non-gated (squared-ReLU) FP8 expert MoE** path, and
- the **mixed-dtype Mamba2 KV-cache allocation** (bf16 conv + fp32 ssm).

A GSM8K gate is the right guardrail so a future rebase can't quietly break either.

## Conventions followed

- `gsm8k`, `num_fewshot: 5`, `limit: 256` -- the house standard for a stable but time-bounded score (matches Qwen3-30B, Qwen3.5, gemma-4 cards).
- **Not** added to `launch_all_tests` -- like the other large-model GSM8K tests (qwen3.5/3.6, gemma-4) it runs as a named CI job, keeping the fast default set within the CI time budget.

## Placeholders / open items (do not merge until resolved)

- **`model_name`** points at `RedHatAI/NVIDIA-Nemotron-3-Ultra-550B-A55B-FP8-dynamic`, a **550B (55B-active)** model. Weight load alone far exceeds the 5-min fast-CI target and needs large TP (multi-card) -- this belongs in the **long/nightly** tier, not the fast set. If a smaller Nemotron-H FP8 checkpoint exists, prefer it here.
- **`metrics.value: 0.80`** is a **placeholder** -- replace with a measured GSM8K score (harness gates on `value - 0.03`).
- Depends on #1667 landing on `adobrzyn/release-candidate-0.26.0`; until then the test will not pass (the `nemotron_h` enablement isn't on this branch yet).

Generated with Claude Code
