### PR TITLE
[CI] Pin public UBI base image by digest

### DIFF
--- a/.cd/Dockerfile.rhel.ubi.vllm
+++ b/.cd/Dockerfile.rhel.ubi.vllm
@@ -24,7 +24,10 @@ ARG VLLM_GAUDI_REPO="https://github.com/vllm-project/vllm-gaudi.git"
 # ============================================================================
 # Stage 1: gaudi-base - Base system setup with Habana drivers
 # ============================================================================
-FROM registry.access.redhat.com/ubi9/ubi:${OS_VERSION} AS gaudi-base
+# Pin the public UBI base image by digest (OpenSSF Scorecard Pinned-Dependencies).
+# Digest is for registry.access.redhat.com/ubi9/ubi:9.6 (multi-arch manifest list).
+# When bumping OS_VERSION, update this digest to the matching ubi9/ubi:<ver> tag.
+FROM registry.access.redhat.com/ubi9/ubi@sha256:dec374e05cc13ebbc0975c9f521f3db6942d27f8ccdf06b180160490eef8bdbc AS gaudi-base
 
 # Re-declare global ARGs to use them in this stage
 ARG ARTIFACTORY_URL

--- a/.cd/Dockerfile.rhel.ubi.vllm
+++ b/.cd/Dockerfile.rhel.ubi.vllm
@@ -25,9 +25,10 @@ ARG VLLM_GAUDI_REPO="https://github.com/vllm-project/vllm-gaudi.git"
 # Stage 1: gaudi-base - Base system setup with Habana drivers
 # ============================================================================
 # Pin the public UBI base image by digest (OpenSSF Scorecard Pinned-Dependencies).
-# Digest is for registry.access.redhat.com/ubi9/ubi:9.6 (multi-arch manifest list).
-# When bumping OS_VERSION, update this digest to the matching ubi9/ubi:<ver> tag.
-FROM registry.access.redhat.com/ubi9/ubi@sha256:dec374e05cc13ebbc0975c9f521f3db6942d27f8ccdf06b180160490eef8bdbc AS gaudi-base
+# Tag + digest form: the :9.6 tag lets Dependabot's docker ecosystem track and
+# bump the digest; the digest is what Scorecard requires. Keep the tag aligned
+# with OS_VERSION (used below for the Habana RPM repo path).
+FROM registry.access.redhat.com/ubi9/ubi:9.6@sha256:dec374e05cc13ebbc0975c9f521f3db6942d27f8ccdf06b180160490eef8bdbc AS gaudi-base
 
 # Re-declare global ARGs to use them in this stage
 ARG ARTIFACTORY_URL

--- a/.cd/Dockerfile.rhel.ubi.vllm.no-torchaudio
+++ b/.cd/Dockerfile.rhel.ubi.vllm.no-torchaudio
@@ -28,7 +28,10 @@ ARG VLLM_GAUDI_REPO="https://github.com/vllm-project/vllm-gaudi.git"
 # ============================================================================
 # Stage 1: gaudi-base - Base system setup with Habana drivers
 # ============================================================================
-FROM registry.access.redhat.com/ubi9/ubi:${OS_VERSION} AS gaudi-base
+# Pin the public UBI base image by digest (OpenSSF Scorecard Pinned-Dependencies).
+# Digest is for registry.access.redhat.com/ubi9/ubi:9.6 (multi-arch manifest list).
+# When bumping OS_VERSION, update this digest to the matching ubi9/ubi:<ver> tag.
+FROM registry.access.redhat.com/ubi9/ubi@sha256:dec374e05cc13ebbc0975c9f521f3db6942d27f8ccdf06b180160490eef8bdbc AS gaudi-base
 
 # Re-declare global ARGs to use them in this stage
 ARG ARTIFACTORY_URL

--- a/.cd/Dockerfile.rhel.ubi.vllm.no-torchaudio
+++ b/.cd/Dockerfile.rhel.ubi.vllm.no-torchaudio
@@ -29,9 +29,10 @@ ARG VLLM_GAUDI_REPO="https://github.com/vllm-project/vllm-gaudi.git"
 # Stage 1: gaudi-base - Base system setup with Habana drivers
 # ============================================================================
 # Pin the public UBI base image by digest (OpenSSF Scorecard Pinned-Dependencies).
-# Digest is for registry.access.redhat.com/ubi9/ubi:9.6 (multi-arch manifest list).
-# When bumping OS_VERSION, update this digest to the matching ubi9/ubi:<ver> tag.
-FROM registry.access.redhat.com/ubi9/ubi@sha256:dec374e05cc13ebbc0975c9f521f3db6942d27f8ccdf06b180160490eef8bdbc AS gaudi-base
+# Tag + digest form: the :9.6 tag lets Dependabot's docker ecosystem track and
+# bump the digest; the digest is what Scorecard requires. Keep the tag aligned
+# with OS_VERSION (used below for the Habana RPM repo path).
+FROM registry.access.redhat.com/ubi9/ubi:9.6@sha256:dec374e05cc13ebbc0975c9f521f3db6942d27f8ccdf06b180160490eef8bdbc AS gaudi-base
 
 # Re-declare global ARGs to use them in this stage
 ARG ARTIFACTORY_URL

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,16 @@ updates:
     labels:
       - dependencies
       - github-actions
+
+  # Container base images in the .cd/ Dockerfiles. This keeps the digest of the
+  # SHA-pinned public UBI base image (tag + digest form) current: Dependabot
+  # tracks the tag and opens PRs bumping the digest. First-party Gaudi images on
+  # vault.habana.ai are parameterized/unpinned and are skipped automatically.
+  - package-ecosystem: docker
+    directory: /.cd
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - docker


### PR DESCRIPTION
> **Draft** — opening for review of approach before marking ready.

## What

Pins the one **public** container base image the build depends on — `registry.access.redhat.com/ubi9/ubi` — by `sha256` digest instead of the mutable tag, in the two RHEL/UBI Dockerfiles:

- `.cd/Dockerfile.rhel.ubi.vllm`
- `.cd/Dockerfile.rhel.ubi.vllm.no-torchaudio`

This addresses the OpenSSF Scorecard **Pinned-Dependencies** check (container-image portion) for these files.

Uses the **tag + digest** form so the image is both pinned *and* maintainable:

```dockerfile
FROM registry.access.redhat.com/ubi9/ubi:9.6@sha256:dec374e0…eef8bdbc AS gaudi-base
```

- The **digest** is what Scorecard requires (immutable).
- The **`:9.6` tag** lets Dependabot's `docker` ecosystem track the image and open PRs that bump the digest when Red Hat ships a new `9.6` build. A `docker` entry (`directory: /.cd`) is added to `.github/dependabot.yml` for this.

The digest resolves the `ubi9/ubi:9.6` multi-arch manifest list (verified against Red Hat's registry, resolvable by-digest).

## Scope / rationale

Intentionally limited to the **public** UBI image, which is a genuine external supply-chain surface.

**Not** pinned (deliberately):
- **`vault.habana.ai` Gaudi base images** — first-party Intel registry, and their `FROM` lines are fully `ARG`-parameterized (`VERSION` / `REVISION` / `PT_VERSION`) so CI can sweep SynapseAI/PyTorch versions. Dependabot can't resolve a concrete image from those and skips them automatically; pinning by digest would freeze the version-sweep matrix.
- **pip commands** (66 Scorecard warnings) — hash-pinning every `pip install` across build scripts and version-sweep Dockerfiles is brittle and fights the same parameterization; not appropriate for a hardware plugin tracking upstream vLLM/torch.

## Note

Because the base is pinned by digest, keep the `:9.6` tag aligned with `OS_VERSION` (still used for the Habana RPM repo path). A comment on each `FROM` documents this. With the Dependabot `docker` entry, digest bumps are automated going forward.

---
This PR was prepared with the assistance of an AI coding tool.