### PR TITLE
.cd: pin transformers==5.14.1 in vLLM build images

### DIFF
--- a/.cd/Dockerfile.rhel.ubi.vllm
+++ b/.cd/Dockerfile.rhel.ubi.vllm
@@ -218,7 +218,8 @@ RUN set -e && \
     # (see vllm_gaudi/patches.py). vLLM only sets transformers>=5.5.3, so the resolved
     # version can be older than what the plugin imports at runtime (e.g.
     # create_position_bias_mask, added in 5.14.1) -> ImportError on Gemma4. Installed
-    # after vLLM so it wins, with deps so huggingface_hub/tokenizers match.
+    # after vLLM so it wins, with deps so pip pulls the huggingface_hub/tokenizers
+    # 5.14.1 requires (already-satisfied versions are kept).
     # Remove once vLLM's own transformers pin covers this floor.
     pip install --no-cache-dir "transformers==5.14.1" && \
     pip check

--- a/.cd/Dockerfile.rhel.ubi.vllm
+++ b/.cd/Dockerfile.rhel.ubi.vllm
@@ -214,6 +214,13 @@ RUN set -e && \
     cd $VLLM_PATH2 && \
     git checkout ${VLLM_GAUDI_COMMIT} && \
     VLLM_TARGET_DEVICE=hpu pip install --no-cache-dir -v . --no-build-isolation && \
+    # Pin transformers to the version vllm-gaudi's HPU patches are written against
+    # (see vllm_gaudi/patches.py). vLLM only sets transformers>=5.5.3, so the resolved
+    # version can be older than what the plugin imports at runtime (e.g.
+    # create_position_bias_mask, added in 5.14.1) -> ImportError on Gemma4. Installed
+    # after vLLM so it wins, with deps so huggingface_hub/tokenizers match.
+    # Remove once vLLM's own transformers pin covers this floor.
+    pip install --no-cache-dir "transformers==5.14.1" && \
     pip check
 
 # Setup non-root user for OpenShift compatibility

--- a/.cd/Dockerfile.rhel.ubi.vllm.no-torchaudio
+++ b/.cd/Dockerfile.rhel.ubi.vllm.no-torchaudio
@@ -215,6 +215,13 @@ RUN set -e && \
     cd $VLLM_PATH2 && \
     git checkout ${VLLM_GAUDI_COMMIT} && \
     VLLM_TARGET_DEVICE=hpu pip install --no-cache-dir -v . --no-build-isolation && \
+    # Pin transformers to the version vllm-gaudi's HPU patches are written against
+    # (see vllm_gaudi/patches.py). vLLM only sets transformers>=5.5.3, so the resolved
+    # version can be older than what the plugin imports at runtime (e.g.
+    # create_position_bias_mask, added in 5.14.1) -> ImportError on Gemma4. Installed
+    # after vLLM so it wins, with deps so huggingface_hub/tokenizers match.
+    # Remove once vLLM's own transformers pin covers this floor.
+    pip install --no-cache-dir "transformers==5.14.1" && \
     pip check
 
 # Setup non-root user for OpenShift compatibility

--- a/.cd/Dockerfile.rhel.ubi.vllm.no-torchaudio
+++ b/.cd/Dockerfile.rhel.ubi.vllm.no-torchaudio
@@ -219,7 +219,8 @@ RUN set -e && \
     # (see vllm_gaudi/patches.py). vLLM only sets transformers>=5.5.3, so the resolved
     # version can be older than what the plugin imports at runtime (e.g.
     # create_position_bias_mask, added in 5.14.1) -> ImportError on Gemma4. Installed
-    # after vLLM so it wins, with deps so huggingface_hub/tokenizers match.
+    # after vLLM so it wins, with deps so pip pulls the huggingface_hub/tokenizers
+    # 5.14.1 requires (already-satisfied versions are kept).
     # Remove once vLLM's own transformers pin covers this floor.
     pip install --no-cache-dir "transformers==5.14.1" && \
     pip check

--- a/.cd/Dockerfile.ubuntu.pytorch.vllm
+++ b/.cd/Dockerfile.ubuntu.pytorch.vllm
@@ -68,10 +68,10 @@ RUN \
 # (see vllm_gaudi/patches.py). vLLM only sets a lower bound (transformers>=5.5.3),
 # so the resolved version can be older than what the plugin imports at runtime
 # (e.g. create_position_bias_mask from transformers.integrations.sdpa_attention,
-# added in 5.14.1) -> ImportError on Gemma4. Installed after vLLM so it wins, and
-# with deps so huggingface_hub/tokenizers resolve to matching versions.
-# Remove once vLLM's own transformers pin covers this floor.
-RUN pip install "transformers==5.14.1"
+# added in 5.14.1) -> ImportError on Gemma4. Installed after vLLM so it wins, with
+# deps so pip pulls the huggingface_hub/tokenizers 5.14.1 requires (already-satisfied
+# versions are kept). Remove once vLLM's own transformers pin covers this floor.
+RUN pip install --no-cache-dir "transformers==5.14.1"
 
 # Install additional Python packages
 ARG EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu

--- a/.cd/Dockerfile.ubuntu.pytorch.vllm
+++ b/.cd/Dockerfile.ubuntu.pytorch.vllm
@@ -64,6 +64,15 @@ RUN \
     VLLM_TARGET_DEVICE=hpu pip install -v . --no-build-isolation
 # --- END: COMBINED RUN COMMAND ---
 
+# Pin transformers to the version vllm-gaudi's HPU patches are written against
+# (see vllm_gaudi/patches.py). vLLM only sets a lower bound (transformers>=5.5.3),
+# so the resolved version can be older than what the plugin imports at runtime
+# (e.g. create_position_bias_mask from transformers.integrations.sdpa_attention,
+# added in 5.14.1) -> ImportError on Gemma4. Installed after vLLM so it wins, and
+# with deps so huggingface_hub/tokenizers resolve to matching versions.
+# Remove once vLLM's own transformers pin covers this floor.
+RUN pip install "transformers==5.14.1"
+
 # Install additional Python packages
 ARG EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu
 RUN pip install datasets && \

--- a/.cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest
+++ b/.cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest
@@ -68,10 +68,10 @@ RUN \
 # (see vllm_gaudi/patches.py). vLLM only sets a lower bound (transformers>=5.5.3),
 # so the resolved version can be older than what the plugin imports at runtime
 # (e.g. create_position_bias_mask from transformers.integrations.sdpa_attention,
-# added in 5.14.1) -> ImportError on Gemma4. Installed after vLLM so it wins, and
-# with deps so huggingface_hub/tokenizers resolve to matching versions.
-# Remove once vLLM's own transformers pin covers this floor.
-RUN pip install "transformers==5.14.1"
+# added in 5.14.1) -> ImportError on Gemma4. Installed after vLLM so it wins, with
+# deps so pip pulls the huggingface_hub/tokenizers 5.14.1 requires (already-satisfied
+# versions are kept). Remove once vLLM's own transformers pin covers this floor.
+RUN pip install --no-cache-dir "transformers==5.14.1"
 
 # Install torchaudio (CPU wheel, matching PyTorch version in base image)
 RUN pip install --no-cache-dir --no-deps --extra-index-url https://download.pytorch.org/whl/cpu torchaudio==${PT_VERSION}

--- a/.cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest
+++ b/.cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest
@@ -64,6 +64,15 @@ RUN \
     python install_nixl.py
 # --- END: COMBINED RUN COMMAND ---
 
+# Pin transformers to the version vllm-gaudi's HPU patches are written against
+# (see vllm_gaudi/patches.py). vLLM only sets a lower bound (transformers>=5.5.3),
+# so the resolved version can be older than what the plugin imports at runtime
+# (e.g. create_position_bias_mask from transformers.integrations.sdpa_attention,
+# added in 5.14.1) -> ImportError on Gemma4. Installed after vLLM so it wins, and
+# with deps so huggingface_hub/tokenizers resolve to matching versions.
+# Remove once vLLM's own transformers pin covers this floor.
+RUN pip install "transformers==5.14.1"
+
 # Install torchaudio (CPU wheel, matching PyTorch version in base image)
 RUN pip install --no-cache-dir --no-deps --extra-index-url https://download.pytorch.org/whl/cpu torchaudio==${PT_VERSION}
 

--- a/.cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest.no-torchaudio
+++ b/.cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest.no-torchaudio
@@ -72,10 +72,10 @@ RUN \
 # (see vllm_gaudi/patches.py). vLLM only sets a lower bound (transformers>=5.5.3),
 # so the resolved version can be older than what the plugin imports at runtime
 # (e.g. create_position_bias_mask from transformers.integrations.sdpa_attention,
-# added in 5.14.1) -> ImportError on Gemma4. Installed after vLLM so it wins, and
-# with deps so huggingface_hub/tokenizers resolve to matching versions.
-# Remove once vLLM's own transformers pin covers this floor.
-RUN pip install "transformers==5.14.1"
+# added in 5.14.1) -> ImportError on Gemma4. Installed after vLLM so it wins, with
+# deps so pip pulls the huggingface_hub/tokenizers 5.14.1 requires (already-satisfied
+# versions are kept). Remove once vLLM's own transformers pin covers this floor.
+RUN pip install --no-cache-dir "transformers==5.14.1"
 
 # torchaudio install removed.
 

--- a/.cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest.no-torchaudio
+++ b/.cd/Dockerfile.ubuntu.pytorch.vllm.nixl.latest.no-torchaudio
@@ -68,6 +68,15 @@ RUN \
     python install_nixl.py
 # --- END: COMBINED RUN COMMAND ---
 
+# Pin transformers to the version vllm-gaudi's HPU patches are written against
+# (see vllm_gaudi/patches.py). vLLM only sets a lower bound (transformers>=5.5.3),
+# so the resolved version can be older than what the plugin imports at runtime
+# (e.g. create_position_bias_mask from transformers.integrations.sdpa_attention,
+# added in 5.14.1) -> ImportError on Gemma4. Installed after vLLM so it wins, and
+# with deps so huggingface_hub/tokenizers resolve to matching versions.
+# Remove once vLLM's own transformers pin covers this floor.
+RUN pip install "transformers==5.14.1"
+
 # torchaudio install removed.
 
 # Workaround: Gaudi base image bundles HPU-patched PyTorch (e.g. 2.11.0a0+git...)

--- a/.cd/Dockerfile.ubuntu.pytorch.vllm.no-torchaudio
+++ b/.cd/Dockerfile.ubuntu.pytorch.vllm.no-torchaudio
@@ -68,6 +68,15 @@ RUN \
     VLLM_TARGET_DEVICE=hpu pip install -v . --no-build-isolation
 # --- END: COMBINED RUN COMMAND ---
 
+# Pin transformers to the version vllm-gaudi's HPU patches are written against
+# (see vllm_gaudi/patches.py). vLLM only sets a lower bound (transformers>=5.5.3),
+# so the resolved version can be older than what the plugin imports at runtime
+# (e.g. create_position_bias_mask from transformers.integrations.sdpa_attention,
+# added in 5.14.1) -> ImportError on Gemma4. Installed after vLLM so it wins, and
+# with deps so huggingface_hub/tokenizers resolve to matching versions.
+# Remove once vLLM's own transformers pin covers this floor.
+RUN pip install "transformers==5.14.1"
+
 # Install additional Python packages (torchaudio install removed)
 RUN pip install datasets && \
     pip install pandas

--- a/.cd/Dockerfile.ubuntu.pytorch.vllm.no-torchaudio
+++ b/.cd/Dockerfile.ubuntu.pytorch.vllm.no-torchaudio
@@ -72,10 +72,10 @@ RUN \
 # (see vllm_gaudi/patches.py). vLLM only sets a lower bound (transformers>=5.5.3),
 # so the resolved version can be older than what the plugin imports at runtime
 # (e.g. create_position_bias_mask from transformers.integrations.sdpa_attention,
-# added in 5.14.1) -> ImportError on Gemma4. Installed after vLLM so it wins, and
-# with deps so huggingface_hub/tokenizers resolve to matching versions.
-# Remove once vLLM's own transformers pin covers this floor.
-RUN pip install "transformers==5.14.1"
+# added in 5.14.1) -> ImportError on Gemma4. Installed after vLLM so it wins, with
+# deps so pip pulls the huggingface_hub/tokenizers 5.14.1 requires (already-satisfied
+# versions are kept). Remove once vLLM's own transformers pin covers this floor.
+RUN pip install --no-cache-dir "transformers==5.14.1"
 
 # Install additional Python packages (torchaudio install removed)
 RUN pip install datasets && \


### PR DESCRIPTION
## Problem

The HPU SDPA patch in `vllm_gaudi/patches.py` (`_hpu_sdpa_attention_forward`) imports `create_position_bias_mask` from `transformers.integrations.sdpa_attention`. That symbol only exists in **transformers >= 5.14.1** (the version the patch is written against).

vLLM only declares a lower bound (`transformers>=5.5.3`), so the `.cd` build images can resolve an older `transformers`. When they do, the module imports fine but the symbol is missing, and serving crashes at runtime:

```
File ".../vllm_gaudi/patches.py", line 526, in _hpu_sdpa_attention_forward
    from transformers.integrations.sdpa_attention import (repeat_kv, use_gqa_in_sdpa, create_position_bias_mask, ...)
ImportError: cannot import name 'create_position_bias_mask' from 'transformers.integrations.sdpa_attention'
```

This reproduces on Gemma-4 multimodal serving (e.g. `google/gemma-4-26B-A4B-it`) and blocks the v0.26.0 release.

## Fix

Pin `transformers==5.14.1` in all six `.cd` build Dockerfiles:

- `Dockerfile.ubuntu.pytorch.vllm`
- `Dockerfile.ubuntu.pytorch.vllm.no-torchaudio`
- `Dockerfile.ubuntu.pytorch.vllm.nixl.latest`
- `Dockerfile.ubuntu.pytorch.vllm.nixl.latest.no-torchaudio`
- `Dockerfile.rhel.ubi.vllm`
- `Dockerfile.rhel.ubi.vllm.no-torchaudio`

The pin is applied **after** the vLLM install so it takes precedence over vLLM's lower bound, and **with** dependencies so `huggingface_hub` / `tokenizers` resolve to matching versions. For the RHEL images it runs inside the combined build stage before `pip check`, so the final consistency check validates the pinned set.

To be removed once vLLM's own `transformers` pin covers this floor.

## Notes / open questions

- This addresses the environment side. A complementary hardening in `patches.py` (guard the `create_position_bias_mask` import so an older `transformers` degrades gracefully instead of crashing) is worth considering as a follow-up — happy to add if reviewers prefer defense-in-depth.
- Draft: pending a container build + Gemma-4 serving smoke test to confirm the resolved version set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)