### PR TITLE
requirements: floor transformers>=5.14.1 for HPU SDPA patch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,10 @@
 # Dependencies for HPU code
+# vllm_gaudi/patches.py imports create_position_bias_mask from
+# transformers.integrations.sdpa_attention, added in transformers 5.14.1. vLLM
+# only sets transformers>=5.5.3, so without this floor an older transformers can
+# be resolved and the HPU SDPA patch fails at import (ImportError on Gemma4).
+# Floor, not ==, so it composes with vLLM's own bound and future bumps.
+transformers>=5.14.1
 pandas>=2.2.3
 numba>=0.58.0
 numpy>=1.26.0


### PR DESCRIPTION
> **Note:** this PR was repurposed. It previously contained the `patches.py`
> optional-import hardening; it now carries the `requirements.txt` floor
> instead. (The branch name is stale — content is the requirements change.)

## Problem

`vllm_gaudi/patches.py` (`_hpu_sdpa_attention_forward`) imports `create_position_bias_mask` from `transformers.integrations.sdpa_attention`, which only exists in **transformers >= 5.14.1**. vLLM declares only `transformers>=5.5.3` (no upper bound), so an older `transformers` can be resolved and the HPU SDPA patch fails at import:

```
ImportError: cannot import name 'create_position_bias_mask' from 'transformers.integrations.sdpa_attention'
```

This blocks Gemma-4 multimodal serving on v0.26.0.

## Change

Add a single floor to the plugin's own `requirements.txt`:

```
transformers>=5.14.1
```

`setup.py` feeds `requirements.txt` into `install_requires`, and all `.cd` images install the plugin with `pip install .` (no `--no-deps`), so the floor is honored at install time and pip upgrades `transformers` when the resolved version is too old. Because the plugin is installed **after** vLLM, this constraint wins.

Uses a **floor** (`>=`), not `==`: the real requirement is "the symbol exists," which composes cleanly with vLLM's own `>=5.5.3` bound and does not fight future bumps.

## Why this vs. pinning in the build images (#1698)

This is the alternative mechanism for the same fix, offered **for discussion** — not meant to land alongside #1698:

- **requirements.txt (this PR):** one line; covers *every* install path (bare `pip install vllm-gaudi`, not just the six `.cd` images); single source of truth. **But** it re-adds a `transformers` constraint that #1445 deliberately removed ("now expected to be provided by the base environment") and #1560 relaxed — so it reverses a documented policy.
- **Build-image pin (#1698):** scoped strictly to the images we ship; doesn't touch the plugin's declared deps, so it sidesteps the policy question — but only fixes the `.cd` images.

Both produce the same `transformers==5.14.1` in the resulting environment (vLLM permits it — no upper cap). Pick one; they shouldn't both land.

## Status

Draft — for discussion of the mechanism/policy tradeoff. Pending a Gemma-4 serving smoke test on HPU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)