### PR TITLE
[FIX_FOR_VLLM_CUSTOM=397094da1768c7a6f29dfa4f70079d793ac747df] Drop removed calculate_kv_scales runtime path in OOT attention (+1 more)

### DIFF
--- a/.github/Dockerfile.ci
+++ b/.github/Dockerfile.ci
@@ -22,6 +22,11 @@ RUN git checkout ${VLLM_COMMIT_ARG}
 # Test dependencies
 RUN pip install pytest pytest_asyncio pytest-timeout
 RUN pip install git+https://github.com/EleutherAI/lm-evaluation-harness.git
+# decord: video-decoding backend required by the ERNIE-4.5-VL trust_remote_code
+# modeling file (run_ernie4.5_vl_test). Upstream vLLM pins it in
+# requirements/test/cuda.in (x86_64); vllm-gaudi does not install that file, so
+# declare it explicitly here to keep the e2e multimodal test running.
+RUN pip install decord==0.6.0
 
 ENV no_proxy=localhost,127.0.0.1
 ENV PT_HPU_ENABLE_LAZY_COLLECTIVES=true

--- a/vllm_gaudi/attention/oot_mla.py
+++ b/vllm_gaudi/attention/oot_mla.py
@@ -69,8 +69,11 @@ class HPUMLAAttention(MLAAttention):
         # always passes this as None; accept and ignore it to keep the HPU path
         # behaviourally identical to pre-#45964.
         del q_dcp_replicated
-        if self.calculate_kv_scales:
-            torch.ops.vllm.maybe_calc_kv_scales(q, kv_c_normed, k_pe, self.layer_name)
+        # NOTE: vllm#49389 removed the deprecated runtime KV-scale calculation
+        # path (the `calculate_kv_scales` attribute and the
+        # `maybe_calc_kv_scales` custom op). Neither exists at the pinned vLLM
+        # SHA, so the OOT MLA forward no longer attempts runtime scale
+        # calculation.
 
         if self.use_direct_call:
             forward_context: ForwardContext = get_forward_context()

--- a/vllm_gaudi/ops/hpu_attention.py
+++ b/vllm_gaudi/ops/hpu_attention.py
@@ -31,8 +31,10 @@ def patched_attention_forward(
     if not self.use_direct_call:
         return layer.Attention._vllm_gaudi_original_forward(self, query, key, value, output_shape=output_shape)
 
-    if self.calculate_kv_scales:
-        torch.ops.vllm.maybe_calc_kv_scales(query, key, value, self.layer_name)
+    # NOTE: vllm#49389 removed the deprecated runtime KV-scale calculation path
+    # (the `calculate_kv_scales` attribute and the `maybe_calc_kv_scales` custom
+    # op). Neither exists at the pinned vLLM SHA, so the OOT forward no longer
+    # attempts runtime scale calculation.
     if self.query_quant is not None:
         # quantizing with a simple torch operation enables
         # torch.compile to fuse this into previous ops

--- a/vllm_gaudi/ops/hpu_fused_moe.py
+++ b/vllm_gaudi/ops/hpu_fused_moe.py
@@ -325,7 +325,8 @@ def select_experts_from_routed(layer, hidden_states: torch.Tensor,
     router moved onto ``MoERunner``). ``RoutedExperts`` does, however, carry all
     the routing parameters, so we reproduce upstream's behaviour via the
     standalone ``select_experts`` helper. It is imported lazily because
-    ``cpu_fused_moe`` registers a CPU custom op at module import time.
+    ``experts.cpu_moe`` pulls CPU custom ops from ``vllm._custom_ops`` at
+    module import time.
 
     Args:
         layer: The ``RoutedExperts`` instance holding the routing parameters.
@@ -335,7 +336,7 @@ def select_experts_from_routed(layer, hidden_states: torch.Tensor,
     Returns:
         A ``(topk_weights, topk_ids)`` tuple.
     """
-    from vllm.model_executor.layers.fused_moe.cpu_fused_moe import select_experts
+    from vllm.model_executor.layers.fused_moe.experts.cpu_moe import select_experts
 
     return select_experts(
         hidden_states=hidden_states,


### PR DESCRIPTION
This PR consolidates 2 hourly-CI fixes against vllm@`397094da1768c7a6f29dfa4f70079d793ac747df` per the single-rolling-PR rule (invariant I9).

## Bug 1: Drop removed calculate_kv_scales runtime path in OOT attention

- **State machine id**: attention_calculate_kv_scales_attributeerror
- **Commit**: b6977fc761382c216470acb933378f8e78447015

### Root cause
Upstream removed the runtime calculate_kv_scales attribute/path from the attention layer; the out-of-tree HPU attention wrapper still referenced it, raising AttributeError at model load.

### Upstream PR
https://github.com/vllm-project/vllm/pull/49389

### Fix
Remove the stale calculate_kv_scales runtime branch from the OOT attention path so it matches the current upstream attention API.

## Bug 2: Install decord in CI image for ernie4.5-vl e2e test

- **State machine id**: ernie4_5_vl_decord_missing_package_importerror
- **Commit**: e2a7fee1093dfc2ec039db6d7cad2a1c5e60a30f

### Root cause
The CI image installs pytest and lm-eval test dependencies but never decord. The ERNIE-4.5-VL trust_remote_code modeling file imports decord at load time, so the e2e ernie4.5-vl test fails with ImportError. Upstream pins decord for x86_64 in its test requirements.

### Upstream PR
Not identified — CI image dependency gap; see investigation notes in linked tracking ticket.

### Fix
Add decord to the CI image dependency install so the ERNIE-4.5-VL trust_remote_code modeling file imports successfully during the e2e test.