### PR TITLE
[FIX_FOR_VLLM_CUSTOM=22013f74ffb0ae22deb29233cbe9fcd3efb1b374] fix(test): keep mm processor output on HPU via torch_shm

### DIFF
--- a/tests/unit_tests/multimodal/test_hpu_multimodal_processing.py
+++ b/tests/unit_tests/multimodal/test_hpu_multimodal_processing.py
@@ -146,8 +146,17 @@ def test_hf_processor_call_kwargs(
 ):
     """Test that HPU processor call uses correct device."""
 
+    # Upstream vLLM #50390 made InputProcessingContext._postprocess_output copy
+    # non-CPU processor outputs back to host unless the multimodal transport is
+    # the zero-copy "torch_shm" IPC. The default "direct_rpc" transport would
+    # move the HPU tensors to CPU, so keep them on the accelerator by selecting
+    # torch_shm — otherwise the device assertions below would never hold.
     ctx = InputProcessingContext(
-        model_config=ModelConfig(model_id, mm_processor_kwargs=config_kwargs),
+        model_config=ModelConfig(
+            model_id,
+            mm_processor_kwargs=config_kwargs,
+            mm_tensor_ipc="torch_shm",
+        ),
         tokenizer=None,
     )
 


### PR DESCRIPTION
## Root cause
Upstream vLLM #50390 changed `InputProcessingContext._postprocess_output` to
copy non-CPU processor outputs back to host memory unless the multimodal tensor
transport is the zero-copy `torch_shm` IPC. Under the default `direct_rpc`
transport the HPU tensors produced by the processor were moved to CPU, so the
device assertions in `test_hf_processor_call_kwargs` could never hold and the
test failed with `assert False`.

## Upstream PR
https://github.com/vllm-project/vllm/pull/50390
Changed the processor output post-processing to force a host copy unless
`mm_tensor_ipc == "torch_shm"`.

## Fix
Construct the test `ModelConfig` with `mm_tensor_ipc="torch_shm"` so processor
output tensors stay on the HPU device under the new upstream contract, restoring
the device-placement assertions the test is designed to check. The change is
confined to the unit test.