### PR TITLE
[CI] Pin cosign to v2 in release signing workflow

### DIFF
--- a/.github/workflows/release-sign.yml
+++ b/.github/workflows/release-sign.yml
@@ -54,6 +54,11 @@ jobs:
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+        with:
+          # Pin cosign v2: v3 deprecates --output-signature/--output-certificate
+          # and defaults to the new bundle format, which breaks the sign-blob
+          # step below (it expects separate .sig/.pem outputs).
+          cosign-release: "v2.6.5"
 
       - name: Download GitHub's auto-generated source tarball
         id: build


### PR DESCRIPTION
## What

Pin `cosign` to **v2.6.5** in `.github/workflows/release-sign.yml`.

## Why

The first real run of the signing workflow (manual `workflow_dispatch` on `v0.24.0`) **failed** at the *Sign tarball (keyless)* step:

```
Error: signing vllm-gaudi-v0.24.0.tar.gz: create bundle file: open : no such file or directory
```

Root cause: `cosign-installer` now installs **cosign v3**, which deprecates `--output-signature` / `--output-certificate` and defaults to the new bundle format. With no `--bundle` path supplied, the bundle path is empty and signing aborts.

The workflow (and `RELEASE.md`'s verify instructions) are written for cosign v2's separate `.sig` / `.pem` outputs. Pinning `cosign-release: v2.6.5` realigns the installed CLI with that.

## Blast radius

None to existing releases — signing is ordered *before* verify/upload, so the failed run uploaded nothing and `v0.24.0` was left untouched (still 0 assets).

## Follow-up (not in this PR)

Migrating to cosign v3's `--bundle` format is the longer-term fix, but requires reworking the verify/upload steps and RELEASE.md. Deferred.

This change was prepared with the assistance of an AI coding tool.
