### PR TITLE
[CI] Filter non-actionable Pinned-Dependencies from Scorecard dashboard

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -52,8 +52,25 @@ jobs:
           path: results.sarif
           retention-days: 5
 
+      # Drop non-actionable rules from the code-scanning view only. The base
+      # images and pip installs flagged by Pinned-Dependencies are
+      # parameterized / internal-registry / VCS installs that cannot be
+      # hash-pinned, so those alerts are pure noise in the Security tab. This
+      # filters the dashboard copy ONLY -- the full result was already sent to
+      # the OpenSSF API by the analysis step's publish_results, so the
+      # Scorecard score and badge are unaffected. Raw SARIF is retained above.
+      - name: Filter non-actionable rules from dashboard SARIF
+        env:
+          DROP_RULES: '["PinnedDependenciesID"]'
+        run: |
+          set -euo pipefail
+          jq --argjson drop "$DROP_RULES" '
+            .runs[].results |= map(select(.ruleId as $r | ($drop | index($r)) | not))
+          ' results.sarif > results.filtered.sarif
+          echo "Filtered out rules: $DROP_RULES"
+
       # Surface findings in the Security > Code scanning tab.
       - name: Upload to code-scanning
         uses: github/codeql-action/upload-sarif@ce28f5bb42b7a9f2c824e633a3f6ee835bab6858  # v3.29.0
         with:
-          sarif_file: results.sarif
+          sarif_file: results.filtered.sarif


### PR DESCRIPTION
## What
Add a `jq` filter step to `scorecard.yml` that removes `PinnedDependenciesID` findings from the SARIF uploaded to the code-scanning dashboard.

## Why
Scorecard's Pinned-Dependencies check raises **79** code-scanning alerts (67 pip, 12 container-image). None are hash-pinnable:
- Base images are parameterized / internal-registry tags — e.g. `vault.habana.ai/.../pytorch...:latest`, `...:${REVISION}`, build-arg driven.
- pip lines include `git+https://...` and editable installs (`pip install -e .`).

They can't be fixed, only pinned in ways that break these builds, so they're pure noise that buries the actionable High/Medium findings in the Security tab.

## Scope — what this does NOT change
- **OpenSSF score and README badge are unaffected.** The full, unfiltered result is published to the OpenSSF API by the analysis step's `publish_results: true`, which runs *before* this filter.
- Raw `results.sarif` is still retained as an audit artifact.
- Only the **dashboard copy** (`results.filtered.sarif`) is filtered.

## Companion action
The existing 79 open alerts are being bulk-dismissed with a "won't fix" reason; this PR prevents them from reappearing on future scheduled scans.

This change was prepared with the assistance of an AI coding tool.
