### PR TITLE
Remove qwen3.5 from flatten_input

### DIFF
--- a/vllm_gaudi/extension/features.py
+++ b/vllm_gaudi/extension/features.py
@@ -106,10 +106,8 @@ def get_features():
         Value('dynamic_shapes_compilation', True, env_var='VLLM_T_COMPILE_DYNAMIC_SHAPES', env_var_type=boolean),
         Value('fullgraph_compilation', False, env_var='VLLM_T_COMPILE_FULLGRAPH', env_var_type=boolean),
         Value('scale_adjustment', True, env_var='VLLM_SCALE_ADJUSTMENT', env_var_type=boolean),
-        Value(
-            'flatten_input',
-            Any(ModelType('qwen3_moe'), ModelType('qwen3_5_moe'), ModelType('granitemoe'), ModelType('glm4_moe'),
-                ModelType('gemma4'))),
+        Value('flatten_input',
+              Any(ModelType('qwen3_moe'), ModelType('granitemoe'), ModelType('glm4_moe'), ModelType('gemma4'))),
         Value('high_level_profiler_enabled', False, env_var='VLLM_PROFILER_ENABLED', env_var_type=boolean),
         Value('track_graph_compilation', False, env_var='PT_HPU_METRICS_GC_DETAILS', env_var_type=boolean),
         Value('per_token_kv_scaling_support',


### PR DESCRIPTION
This fixes the perf regression on Qwen3.6 by removing using a flatten_input that was slowing down perf by a few %.