### PR TITLE
Fix Gemma4 decode performance with VLLM_CONTIGUOUS_PA=true

### DIFF
--- a/vllm_gaudi/attention/backends/hpu_attn.py
+++ b/vllm_gaudi/attention/backends/hpu_attn.py
@@ -658,10 +658,16 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
             # Decoding run.
             # GAUDISW-248985: decode block_list is the contiguous-identity layout, so
             # keep the zero-copy slice fetch (cache[:n]); only prefill needs gather.
+            # Exception: sliding window with contiguous PA needs gather-by-id because
+            # window_block_list contains scattered block IDs (not identity layout).
             _set_fetch_by_id(self.k_cache, False)
             _set_fetch_by_id(self.v_cache, False)
+
             if self.sliding_window and \
                 attn_metadata.window_block_list is not None:
+                # Sliding window blocks are not contiguous - need gather-by-id
+                _set_fetch_by_id(self.k_cache, True)
+                _set_fetch_by_id(self.v_cache, True)
                 block_list = attn_metadata.window_block_list
                 block_groups = attn_metadata.window_block_groups
                 block_mapping = attn_metadata.window_block_mapping

--- a/vllm_gaudi/patches.py
+++ b/vllm_gaudi/patches.py
@@ -669,6 +669,27 @@ def _patch_free_blocks() -> None:
 _CACHED_FSDPA_OP = None
 
 
+def _ensure_fsdpa_cached() -> None:
+    """Eagerly initialize the FusedSDPA operator cache.
+
+    Must be called BEFORE torch.compile traces _hpu_sdpa_attention_forward,
+    otherwise dynamo creates a guard on `_CACHED_FSDPA_OP is None` which
+    fails at runtime and triggers recompilation.
+
+    Called from hpu_model_runner.py during model initialization.
+    """
+    global _CACHED_FSDPA_OP
+    if _CACHED_FSDPA_OP is not None:
+        return
+    try:
+        from vllm_gaudi.extension.utils import ModuleFusedSDPA
+        import vllm_gaudi.extension.kernels as kernels
+        HPUFusedSDPA = kernels.fsdpa()
+        _CACHED_FSDPA_OP = ModuleFusedSDPA(HPUFusedSDPA)
+    except Exception:
+        pass
+
+
 def _hpu_sdpa_attention_forward(
     module: torch.nn.Module,
     query: torch.Tensor,
@@ -740,12 +761,12 @@ def _hpu_sdpa_attention_forward(
             pass
 
     if _use_hpu_fsdpa and _config is not None:
+        # _CACHED_FSDPA_OP is initialized eagerly by _ensure_fsdpa_cached()
+        # before torch.compile traces this function. This avoids the dynamo
+        # guard on `_CACHED_FSDPA_OP is None` that would trigger recompilation.
         global _CACHED_FSDPA_OP
-        if _CACHED_FSDPA_OP is None:
-            from vllm_gaudi.extension.utils import ModuleFusedSDPA
-            import vllm_gaudi.extension.kernels as kernels
-            HPUFusedSDPA = kernels.fsdpa()
-            _CACHED_FSDPA_OP = ModuleFusedSDPA(HPUFusedSDPA)
+        _ensure_fsdpa_cached()
+        assert _CACHED_FSDPA_OP is not None
 
         softmax_mode = "fp32" if _config.fp32_softmax else "fast"
         attn_output = _CACHED_FSDPA_OP(
@@ -795,6 +816,11 @@ def _patch_sdpa_attention_forward() -> None:
             ALL_ATTENTION_FUNCTIONS["sdpa"] = _hpu_sdpa_attention_forward
     except ImportError:
         pass  # transformers version without this module
+
+    # Eagerly initialize the operator cache at patch-registration time,
+    # before torch.compile traces the function. Same pattern as hpu_attn.py
+    # which calls kernels.fsdpa() in __init__.
+    _ensure_fsdpa_cached()
 
 
 def apply() -> None:

--- a/vllm_gaudi/patches.py
+++ b/vllm_gaudi/patches.py
@@ -764,9 +764,9 @@ def _hpu_sdpa_attention_forward(
         # _CACHED_FSDPA_OP is initialized eagerly by _ensure_fsdpa_cached()
         # before torch.compile traces this function. This avoids the dynamo
         # guard on `_CACHED_FSDPA_OP is None` that would trigger recompilation.
-        global _CACHED_FSDPA_OP
         _ensure_fsdpa_cached()
-        assert _CACHED_FSDPA_OP is not None
+        if _CACHED_FSDPA_OP is None:
+            raise RuntimeError("FSDPA op failed to initialize")
 
         softmax_mode = "fp32" if _config.fp32_softmax else "fast"
         attn_output = _CACHED_FSDPA_OP(

--- a/vllm_gaudi/platform.py
+++ b/vllm_gaudi/platform.py
@@ -241,6 +241,9 @@ class HpuPlatform(Platform):
         if get_config().VLLM_CONTIGUOUS_PA:
             logger.warning("Using Contiguous PA, disabling prefix caching")
             vllm_config.cache_config.enable_prefix_caching = False
+            if vllm_config.model_config.get_sliding_window():
+                logger.info("Contiguous paged attention is enabled; sliding-window layers "
+                            "will use indexed KV-cache fetches.")
 
         if (vllm_config.cache_config.enable_prefix_caching and vllm_config.cache_config.mamba_cache_mode == "all"):
             vllm_config.cache_config.mamba_cache_mode = "align"

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -2410,7 +2410,16 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
                                                                               skip_copy=not batch_changed)
         return sampling_metadata
 
-    def get_habana_paged_attn_buffers(self, block_tables, slot_mapping, batch_size, block_size=None):
+    def get_habana_paged_attn_buffers(self, block_tables, slot_mapping, batch_size, block_size=None,
+                                       force_non_contiguous=False):
+        """Build paged attention buffers for decode.
+
+        Args:
+            force_non_contiguous: If True, use non-contiguous mode even when
+                use_contiguous_pa is enabled. Required for sliding window blocks
+                which have scattered block IDs that don't work with contiguous PA's
+                slice-based fetch.
+        """
         block_size = self.attn_block_size if block_size is None else block_size
         last_block_usage = [slot[0] % block_size + 1 for slot in slot_mapping]
         block_groups = [[i] * len(bt) for i, bt in enumerate(block_tables)]
@@ -2423,7 +2432,8 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
 
         padding_fn = None
         block_bucket_size: int
-        if self.use_contiguous_pa:
+        use_contiguous = self.use_contiguous_pa and not force_non_contiguous
+        if use_contiguous:
             actual_blocks_needed = max(block_list) + 1 if block_list else 0
 
             block_bucket_size = \
@@ -3202,11 +3212,14 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
                 sliding_block_size += 1
 
             window_block_tables = [block_table[-sliding_block_size:] for block_table in block_tables_list]
+            # Sliding window blocks have scattered IDs (not identity layout),
+            # so force non-contiguous mode to use gather-by-id fetch
             window_block_list, window_block_groups, window_block_usage = \
                 self.get_habana_paged_attn_buffers(
                     window_block_tables, slot_mapping.tolist(),
                     padded_batch_size * num_tokens,
-                    block_size=decode_block_size)
+                    block_size=decode_block_size,
+                    force_non_contiguous=True)
 
         if self.model_has_chunked_attention:
             chunk_size_in_blocks = (self.model.model.config.text_config.attention_chunk_size // decode_block_size)
@@ -5624,13 +5637,24 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
             # causing warmup to record wrong num_blocks otherwise.
             decode_block_size = self.attn_block_size
             if self.use_contiguous_pa:
-                decode_seq_lengths = [decode_block_size] * decode_bs
+                # For sliding window models, each dummy sequence needs at least
+                # sliding_block_size blocks to properly warmup the window_block_list
+                # bucket sizes. With force_non_contiguous=True, the bucket is based
+                # on len(block_list) not max(block_list)+1, so we need enough blocks
+                # per sequence to match runtime window sizes.
+                if self.interleaved_sliding_window:
+                    sw_blocks = self.sliding_window // decode_block_size + 1
+                    min_tokens_per_seq = sw_blocks * decode_block_size
+                else:
+                    min_tokens_per_seq = decode_block_size
+                decode_seq_lengths = [min_tokens_per_seq] * decode_bs
                 # Cap block_id at physical pool — contiguous PA uses
                 # block_id as the allocation base which must be valid.
                 block_id = min(decode_num_blocks - 1, self.kv_cache_config.num_blocks - 1)
             else:
                 decode_seq_lengths = self._generate_seq_lengths(decode_bs, decode_num_blocks, decode_block_size)
                 block_id = 0
+
             for dsl in decode_seq_lengths:
                 self._add_dummy_request(requests,
                                         scheduled_tokens,

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -2410,8 +2410,12 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
                                                                               skip_copy=not batch_changed)
         return sampling_metadata
 
-    def get_habana_paged_attn_buffers(self, block_tables, slot_mapping, batch_size, block_size=None,
-                                       force_non_contiguous=False):
+    def get_habana_paged_attn_buffers(self,
+                                      block_tables,
+                                      slot_mapping,
+                                      batch_size,
+                                      block_size=None,
+                                      force_non_contiguous=False):
         """Build paged attention buffers for decode.
 
         Args:


### PR DESCRIPTION
Two fixes that together resolve incorrect attention behavior and graph recompilation for Gemma4 models when contiguous pa is enabled.

1. Fix sliding window attention with VLLM_CONTIGUOUS_PA=true

With contiguous PA enabled, sliding window layers during decode were incorrectly using the slice-based fetch path (designed for identity-layout block lists), instead of gather-by-id. . The fix adds a force_non_contiguous parameter to get_habana_paged_attn_buffers(), forces non-contiguous (gather-by-id) mode for window block tables, sets _fetch_by_id=True in hpu_attn.py for the sliding window decode path, and corrects the warmup dummy sequence length for sliding window models so bucket sizes are properly exercised.

2. Fix FusedSDPA recompilation guard failure for Gemma4
_CACHED_FSDPA_OP in patches.py was lazily initialized inside _hpu_sdpa_attention_forward, which caused dynamo to create a guard on _CACHED_FSDPA_OP is None. After warmup populated the cache, this guard failed at runtime and triggered graph recompilation on the first real request. The fix eagerly initializes the cache inside _patch_sdpa_attention_forward() at patch-registration time (during load_general_plugins), matching the pattern used by HPUAttentionImpl.__init__ in hpu_attn.py.

  Benchmark results (Gemma4 models) with CONTIGUOUS_PA=True 
  Text only Input 8K , output 380. 
    - E4B: 979 -> 1157 tok/s (+18.2%)
    - 26B: 1151 -> 1230 tok/s (+6.8%)
    - 31B: 525 -> 579 tok/s (+10.2%)


