### PR TITLE
Enable GLM-5.2 (DSA MoE) on HPU via dense-MLA fallback (#1664)

### DIFF
--- a/vllm_gaudi/attention/oot_mla.py
+++ b/vllm_gaudi/attention/oot_mla.py
@@ -295,7 +295,10 @@ class HPUMultiHeadLatentAttentionWrapper(MultiHeadLatentAttentionWrapper):
         # None for DeepSeek-V2/R1 (no gate proj), leaving the HPU path unchanged.
         self.g_proj = mla_modules.g_proj
 
-        self.skip_topk = skip_topk
+        # DSA sparse attention is not implemented on HPU: sparse layers run as
+        # dense MLA and the indexer must never be invoked (its kernels and the
+        # DeepseekV32IndexerBackend are CUDA-only).
+        self.skip_topk = skip_topk or self.is_sparse
         # vllm#45964 (DCP query replication) added `self.dcp_q_replicate`, which
         # the base MultiHeadLatentAttentionWrapper.forward (inherited here, since
         # we do not override forward) reads and forwards to mla_attn. Because we
@@ -325,7 +328,8 @@ class HPUMultiHeadLatentAttentionWrapper(MultiHeadLatentAttentionWrapper):
             quant_config=quant_config,
             prefix=layer_name,
             kv_b_proj=self.kv_b_proj,
-            use_sparse=self.is_sparse,
+            # Dense-MLA fallback: never request a sparse backend on HPU.
+            use_sparse=False,
             indexer=self.indexer,
             non_causal_multi_token_decode=non_causal_multi_token_decode,
         )

--- a/vllm_gaudi/models/deepseek_v2.py
+++ b/vllm_gaudi/models/deepseek_v2.py
@@ -83,3 +83,25 @@ def _hpu_deepseek_v2_model_forward(
 
 # Applies to DeepseekV2/V3/Deepseek/GlmMoe/DSA — all share model_cls = DeepseekV2Model.
 deepseek_v2.DeepseekV2Model.forward = _hpu_deepseek_v2_model_forward
+
+_orig_deepseek_v2_model_load_weights = deepseek_v2.DeepseekV2Model.load_weights
+
+
+def _hpu_deepseek_v2_model_load_weights(self, weights):
+    """Drop GLM-5 DSA shared-indexer projection weights (`indexers_proj`).
+
+    vLLM's DeepseekV2Model has no module for them, and on HPU DSA layers run
+    as dense MLA with the indexer never executed, so the projection that
+    shares indexer K caches across layers is dead weight here.
+    """
+
+    def _filtered(ws):
+        for name, weight in ws:
+            if ".indexers_proj." in name:
+                continue
+            yield name, weight
+
+    return _orig_deepseek_v2_model_load_weights(self, _filtered(weights))
+
+
+deepseek_v2.DeepseekV2Model.load_weights = _hpu_deepseek_v2_model_load_weights

--- a/vllm_gaudi/platform.py
+++ b/vllm_gaudi/platform.py
@@ -83,7 +83,10 @@ class HpuPlatform(Platform):
             return AttentionBackendEnum.CPU_ATTN.get_path()
 
         if attn_selector_config.use_sparse:
-            raise NotImplementedError("Sparse Attention is not supported on HPU.")
+            if not attn_selector_config.use_mla:
+                raise NotImplementedError("Sparse Attention is not supported on HPU.")
+            logger.warning("Sparse attention (DSA) is not implemented on HPU; running DSA layers as dense MLA "
+                           "(exact for sequences up to index_topk tokens, approximate beyond).")
 
         if attn_selector_config.use_mla:
             logger.info("Using HPUAttentionMLA backend.")


### PR DESCRIPTION
Performance measured
- Median TTFT 1.82 s, TPOT 88.5 ms, output 353.7 tok/s, 320 requests / 0 failures

Accuracy Evals : GSM8K 94.01%, HumanEval 98.8%

Server command :
export ENABLE_EXPERIMENTAL_FLAGS=true
export PT_HPU_LAZY_MODE=0
export PT_HPU_ENABLE_LAZY_COLLECTIVES=true
export EXPERIMENTAL_WEIGHT_SHARING=0
export VLLM_ALLOW_LONG_MAX_MODEL_LEN=1
export VLLM_ENGINE_ITERATION_TIMEOUT_S=36000
export VLLM_RPC_TIMEOUT=10000000
export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=3600
vllm serve /root/models/GLM-5.2-FP8 \
    --served-model-name zai-org/GLM-5.2-FP8 \
    --host localhost \
    --port 18080 \
    --tensor-parallel-size 8 \
    --max-model-len 131072 \
    --max_num_batched_tokens 4096 \
    --gpu-memory-util 0.90  \
    --no-enable-prefix-caching \
    --max-num-seqs 32 \
    --block-size 128 \
    --disable-log-stats \
    --async-scheduling \
    --enable-expert-parallel \
    --tool-call-parser glm47 \
    --enable-auto-tool-choice \
    --reasoning-parser glm45 \
    --trust-remote-code  2>&1 | tee server.log

Client
vllm bench serve \
    --model zai-org/GLM-5.2-FP8 \
    --dataset-name random \
    --base-url http://localhost:18080 \
    --num-prompts 320 \
    --max-concurrency 32 \
    --request-rate inf \
    --random-input-len 4096 \
    --random-output-len 1024 \
    --endpoint /v1/chat/completions \
    --percentile-metrics ttft,tpot,itl,e2el \
    --metric-percentiles 50,90,95,99 \
    --backend openai-chat \
    --tokenizer /root/models/GLM-5.2-FP8 \
    --ignore-eos \
    --trust-remote-code 2>&1 | tee bench.txt


(cherry picked from commit af75a9f9506d67cead0480f29c4c9b84cd037564)