### PR TITLE
[CI] Fix Scorecard publish break; move SARIF filter to a separate job

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -44,7 +44,10 @@ jobs:
           # public repository.
           publish_results: true
 
-      # Retain the raw SARIF as a build artifact for auditing/debugging.
+      # Retain the raw SARIF as a build artifact. This is ALSO the hand-off to
+      # the filter-and-upload job below: scorecard-action's publish_results
+      # requires its job to contain only `uses:` steps (no `run:`), so the jq
+      # filtering and code-scanning upload must live in a separate job.
       - name: Upload artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
@@ -52,13 +55,28 @@ jobs:
           path: results.sarif
           retention-days: 5
 
+  # Separate job so the analysis job stays `uses:`-only (a hard requirement of
+  # scorecard-action's publish step). Here we may freely use `run:` steps.
+  filter-and-upload:
+    name: Filter and upload to code-scanning
+    needs: analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the (filtered) SARIF to the code-scanning dashboard.
+      security-events: write
+    steps:
+      - name: Download SARIF artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        with:
+          name: SARIF file
+
       # Drop non-actionable rules from the code-scanning view only. The base
       # images and pip installs flagged by Pinned-Dependencies are
       # parameterized / internal-registry / VCS installs that cannot be
       # hash-pinned, so those alerts are pure noise in the Security tab. This
       # filters the dashboard copy ONLY -- the full result was already sent to
-      # the OpenSSF API by the analysis step's publish_results, so the
-      # Scorecard score and badge are unaffected. Raw SARIF is retained above.
+      # the OpenSSF API by the analysis job's publish_results, so the Scorecard
+      # score and badge are unaffected.
       - name: Filter non-actionable rules from dashboard SARIF
         env:
           DROP_RULES: '["PinnedDependenciesID"]'


### PR DESCRIPTION
## Problem
#1709 added a `run:` (jq) step to the **Scorecard analysis job** to filter `Pinned-Dependencies` out of the code-scanning dashboard. This broke the scheduled/push run:

```
error sending scorecard results to webapp: http response 400 …
workflow verification failed: scorecard job must only have steps with `uses`
```

`scorecard-action`'s `publish_results` **requires its job to contain only `uses:` steps** ([workflow-restrictions](https://github.com/ossf/scorecard-action#workflow-restrictions)). The `run:` step made publish fail → SARIF upload skipped → **"Code scanning configuration error"** in the Security tab.

## Fix
Split into two jobs:
- **`analysis`** — stays `uses:`-only (Checkout, Run analysis, Upload artifact). Publish/score/badge work again.
- **`filter-and-upload`** (`needs: analysis`) — downloads the SARIF artifact, runs the jq filter, uploads to code-scanning. The `uses:`-only restriction applies only to the scorecard job, so this job may use `run:`.

Net effect: restores the OpenSSF publish **and** keeps the dashboard filtering from #1709. Least-privilege preserved (`security-events: write` only on the second job).

## Validation
- YAML parsed; confirmed `analysis` job has zero `run:` steps and `filter-and-upload` carries the jq step.
- jq filter logic verified to drop only `PinnedDependenciesID` results.

This change was prepared with the assistance of an AI coding tool.
