### PR TITLE
Fix MiniMax M2 fused MoE import for vLLM API change

### DIFF
--- a/vllm_gaudi/models/minimax_m2.py
+++ b/vllm_gaudi/models/minimax_m2.py
@@ -34,7 +34,10 @@ from vllm.model_executor.layers.attention import Attention
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, ModelConfig, VllmConfig
 from vllm.distributed import (get_pp_group, get_tensor_model_parallel_world_size)
-from vllm.model_executor.layers.fused_moe import FusedMoEFactory as FusedMoE
+from vllm.model_executor.layers.fused_moe import (
+    FusedMoEFactory as FusedMoE,
+    fused_moe_make_expert_params_mapping,
+)
 from vllm.model_executor.layers.minimax_rms_norm import MiniMaxText01RMSNormTP
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (QKVParallelLinear, ReplicatedLinear, RowParallelLinear)
@@ -343,7 +346,7 @@ class HpuMiniMaxM2Model(nn.Module):
         return hidden_states
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
-        return FusedMoE.make_expert_params_mapping(
+        return fused_moe_make_expert_params_mapping(
             self,
             ckpt_gate_proj_name="w1",
             ckpt_down_proj_name="w2",


### PR DESCRIPTION
With this small change, Minimax M2.7 runs on Gaudi 2.

It's kind of slow and tool calls seem a bit glitchy, but running is better than crashing.