### PR TITLE
ci: adaptive hourly cadence (8h when healthy, 24h when failing)

### DIFF
--- a/.github/workflows/hourly-ci.yaml
+++ b/.github/workflows/hourly-ci.yaml
@@ -26,6 +26,9 @@ jobs:
       actions: read # Required to query this workflow's previous runs and their jobs
     outputs:
       should_run: ${{ steps.decide.outputs.should_run }}
+      # ISO-8601 start time of the last real run; empty on bootstrap/manual runs.
+      # setup_and_build uses this as the exact commit-diff window.
+      last_started: ${{ steps.decide.outputs.last_started }}
     steps:
       - name: Decide whether to run
         id: decide
@@ -75,6 +78,9 @@ jobs:
             exit 0
           fi
           echo "Last real run: conclusion=$LAST_CONCLUSION started_at=$LAST_STARTED"
+          # Expose the last real run's start so setup_and_build can scope the
+          # commit diff to exactly "since the last time we actually ran".
+          echo "last_started=$LAST_STARTED" >> "$GITHUB_OUTPUT"
 
           if [ "$LAST_CONCLUSION" = "success" ]; then
             echo "Last real run passed -> 8h cadence -> running."
@@ -118,8 +124,8 @@ jobs:
     if: |
       github.event_name == 'workflow_dispatch' ||
       github.ref == 'refs/heads/main'
-    # <-- UPDATED: Now needs 'discover_tests' AND 'discover_runner'
-    needs: [discover_tests, discover_runner]
+    # <-- UPDATED: Now needs 'gate' (for the diff window), 'discover_tests' AND 'discover_runner'
+    needs: [gate, discover_tests, discover_runner]
     # <-- UPDATED: Runs on the specific runner from the discover_runner job
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
     permissions:
@@ -153,14 +159,24 @@ jobs:
 
       - name: Calculate previous run time
         id: prev_run_time
+        env:
+          LAST_STARTED: ${{ needs.gate.outputs.last_started }}
         run: |
-          PREV_RUN_TIME=$(date -u -d "24 hours ago" +"%Y-%m-%dT%H:%M:%SZ")
+          # Scope the commit diff to exactly "since the last real run" so the
+          # window tracks the adaptive cadence (8h when healthy, up to 24h during
+          # back-off). Fall back to 24h when there is no prior run (bootstrap) or
+          # on manual dispatch, where the gate exposes no start time.
+          if [ -n "$LAST_STARTED" ]; then
+            PREV_RUN_TIME=$(date -u -d "$LAST_STARTED" +"%Y-%m-%dT%H:%M:%SZ")
+          else
+            PREV_RUN_TIME=$(date -u -d "24 hours ago" +"%Y-%m-%dT%H:%M:%SZ")
+          fi
           echo "Looking for commits since: $PREV_RUN_TIME"
           echo "PREV_RUN_TIME=$PREV_RUN_TIME" >> "$GITHUB_OUTPUT"
 
-      - name: List commit differences in the last 24 hours
+      - name: List commit differences since the last run
         run: |
-          echo "Commits merged/pushed in vllm-project/vllm.git in the last 24 hours:"
+          echo "Commits merged/pushed in vllm-project/vllm.git since ${{ steps.prev_run_time.outputs.PREV_RUN_TIME }}:"
           git log HEAD..vllm-upstream/main --pretty=format:"%h - %an, %ar : %s" --since="${{ steps.prev_run_time.outputs.PREV_RUN_TIME }}"
 
       - name: Get latest commit sha from vllm-upstream/main

--- a/.github/workflows/hourly-ci.yaml
+++ b/.github/workflows/hourly-ci.yaml
@@ -4,17 +4,98 @@
 name: Hourly Commit Check and Tests
 
 on:
-  # Schedule the workflow to run once a day
+  # The workflow is scheduled at the fast (8-hour) cadence; the 'gate' job below
+  # decides at runtime whether a given tick actually proceeds. Effective cadence:
+  #   - last real run PASSED  -> run every 8h (this schedule, every tick)
+  #   - last real run FAILED  -> back off to once every 24h (skip 2 of every 3 ticks)
   schedule:
-    # Runs at minute 0, hour 0 (00:00 UTC) every day
-    - cron: '0 0 * * *'
+    # Runs at minute 0, every 8th hour (00:00, 08:00, 16:00 UTC)
+    - cron: '0 */8 * * *'
 
   # Allow manual triggering from the GitHub Actions UI
   workflow_dispatch: {}
 
 jobs:
+  # JOB 0: (NEW) Decides whether this scheduled tick should proceed.
+  # Adaptive cadence: healthy pipeline runs every 8h; a failing pipeline backs
+  # off to every 24h so we don't burn HPU runners re-running a known-broken state.
+  gate:
+    # Runs on a cheap GitHub-hosted runner so a "skip" never locks an HPU runner.
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+    steps:
+      - name: Decide whether to run
+        id: decide
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          API="https://api.github.com/repos/$REPO"
+          AUTH="Authorization: Bearer $GH_TOKEN"
+          ACCEPT="Accept: application/vnd.github+json"
+
+          # Manual runs always proceed.
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "Manual dispatch -> running."
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Look at recent completed runs of THIS workflow on main and find the most
+          # recent *real* run: one where the unit-test job actually executed. This
+          # deliberately ignores earlier "backed-off" ticks (whose test jobs were
+          # skipped and whose overall conclusion is misleadingly 'success').
+          RUNS=$(curl -fsSL -H "$AUTH" -H "$ACCEPT" \
+            "$API/actions/workflows/hourly-ci.yaml/runs?branch=main&status=completed&per_page=20")
+
+          LAST_CONCLUSION=""
+          LAST_CREATED=""
+          for RUN_ID in $(echo "$RUNS" | jq -r '.workflow_runs[].id'); do
+            UT=$(curl -fsSL -H "$AUTH" -H "$ACCEPT" \
+              "$API/actions/runs/$RUN_ID/jobs?per_page=100" \
+              | jq -r '.jobs[] | select(.name=="run_unit_tests") | .conclusion' | head -n1)
+            if [ -n "$UT" ] && [ "$UT" != "null" ] && [ "$UT" != "skipped" ]; then
+              LAST_CONCLUSION=$(echo "$RUNS" | jq -r ".workflow_runs[] | select(.id==$RUN_ID) | .conclusion")
+              LAST_CREATED=$(echo "$RUNS" | jq -r ".workflow_runs[] | select(.id==$RUN_ID) | .created_at")
+              break
+            fi
+          done
+
+          if [ -z "$LAST_CONCLUSION" ]; then
+            echo "No prior real run found -> running (bootstrap)."
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Last real run: conclusion=$LAST_CONCLUSION created_at=$LAST_CREATED"
+
+          if [ "$LAST_CONCLUSION" = "success" ]; then
+            echo "Last real run passed -> 8h cadence -> running."
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Last real run did not pass -> 24h cadence. Only proceed once ~24h have
+          # elapsed since that run started. Using elapsed time (not an exact hour
+          # match) keeps this robust to GitHub's scheduled-event delivery drift.
+          LAST_EPOCH=$(date -u -d "$LAST_CREATED" +%s)
+          NOW_EPOCH=$(date -u +%s)
+          AGE_HOURS=$(( (NOW_EPOCH - LAST_EPOCH) / 3600 ))
+          echo "Last real run failing; hours since it started: $AGE_HOURS"
+          if [ "$AGE_HOURS" -ge 23 ]; then
+            echo "Failing cadence, >=23h elapsed -> running (24h back-off tick)."
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Failing cadence, only ${AGE_HOURS}h elapsed (<23h) -> skipping this tick."
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          fi
+
   # JOB 1: (NEW) Discovers an available runner and locks it for all subsequent jobs.
   discover_runner:
+    needs: gate
+    if: needs.gate.outputs.should_run == 'true'
     runs-on: hourly-ci # Picks any available runner from the 'hourly-ci' pool
     outputs:
       runner_name: ${{ steps.get_name.outputs.name }}
@@ -286,8 +367,10 @@ jobs:
 
   cleanup_docker_image:
     name: Cleanup Docker Image
-    if: always()
-    needs: [discover_runner, run_unit_tests, e2e, run_data_parallel_test, run_pd_disaggregate_test]
+    # Run whenever the pipeline actually proceeded (even on failure), but never on
+    # a gate-skipped tick, where no HPU runner was locked and runner_name is empty.
+    if: always() && needs.gate.outputs.should_run == 'true'
+    needs: [gate, discover_runner, run_unit_tests, e2e, run_data_parallel_test, run_pd_disaggregate_test]
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
     steps:
       - name: Remove Docker image to free up space

--- a/.github/workflows/hourly-ci.yaml
+++ b/.github/workflows/hourly-ci.yaml
@@ -22,6 +22,8 @@ jobs:
   gate:
     # Runs on a cheap GitHub-hosted runner so a "skip" never locks an HPU runner.
     runs-on: ubuntu-latest
+    permissions:
+      actions: read # Required to query this workflow's previous runs and their jobs
     outputs:
       should_run: ${{ steps.decide.outputs.should_run }}
     steps:
@@ -52,14 +54,17 @@ jobs:
             "$API/actions/workflows/hourly-ci.yaml/runs?branch=main&status=completed&per_page=20")
 
           LAST_CONCLUSION=""
-          LAST_CREATED=""
+          LAST_STARTED=""
           for RUN_ID in $(echo "$RUNS" | jq -r '.workflow_runs[].id'); do
-            UT=$(curl -fsSL -H "$AUTH" -H "$ACCEPT" \
-              "$API/actions/runs/$RUN_ID/jobs?per_page=100" \
-              | jq -r '.jobs[] | select(.name=="run_unit_tests") | .conclusion' | head -n1)
-            if [ -n "$UT" ] && [ "$UT" != "null" ] && [ "$UT" != "skipped" ]; then
+            JOBS=$(curl -fsSL -H "$AUTH" -H "$ACCEPT" \
+              "$API/actions/runs/$RUN_ID/jobs?per_page=100")
+            # First run_unit_tests conclusion, or empty if the job is absent/null.
+            # Done inside jq (no 'head', which would SIGPIPE under 'set -o pipefail').
+            UT=$(echo "$JOBS" | jq -r 'first(.jobs[] | select(.name=="run_unit_tests") | .conclusion) // empty')
+            if [ -n "$UT" ] && [ "$UT" != "skipped" ]; then
               LAST_CONCLUSION=$(echo "$RUNS" | jq -r ".workflow_runs[] | select(.id==$RUN_ID) | .conclusion")
-              LAST_CREATED=$(echo "$RUNS" | jq -r ".workflow_runs[] | select(.id==$RUN_ID) | .created_at")
+              # Prefer run_started_at (when the run actually began); fall back to created_at.
+              LAST_STARTED=$(echo "$RUNS" | jq -r ".workflow_runs[] | select(.id==$RUN_ID) | (.run_started_at // .created_at)")
               break
             fi
           done
@@ -69,7 +74,7 @@ jobs:
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          echo "Last real run: conclusion=$LAST_CONCLUSION created_at=$LAST_CREATED"
+          echo "Last real run: conclusion=$LAST_CONCLUSION started_at=$LAST_STARTED"
 
           if [ "$LAST_CONCLUSION" = "success" ]; then
             echo "Last real run passed -> 8h cadence -> running."
@@ -80,7 +85,7 @@ jobs:
           # Last real run did not pass -> 24h cadence. Only proceed once ~24h have
           # elapsed since that run started. Using elapsed time (not an exact hour
           # match) keeps this robust to GitHub's scheduled-event delivery drift.
-          LAST_EPOCH=$(date -u -d "$LAST_CREATED" +%s)
+          LAST_EPOCH=$(date -u -d "$LAST_STARTED" +%s)
           NOW_EPOCH=$(date -u +%s)
           AGE_HOURS=$(( (NOW_EPOCH - LAST_EPOCH) / 3600 ))
           echo "Last real run failing; hours since it started: $AGE_HOURS"
@@ -367,10 +372,11 @@ jobs:
 
   cleanup_docker_image:
     name: Cleanup Docker Image
-    # Run whenever the pipeline actually proceeded (even on failure), but never on
-    # a gate-skipped tick, where no HPU runner was locked and runner_name is empty.
-    if: always() && needs.gate.outputs.should_run == 'true'
-    needs: [gate, discover_runner, run_unit_tests, e2e, run_data_parallel_test, run_pd_disaggregate_test]
+    # Run whenever a runner was actually locked (even if later jobs failed), but
+    # never when discover_runner was skipped (gate said no) or failed -- in those
+    # cases runner_name is empty and this job would fail to start.
+    if: always() && needs.discover_runner.result == 'success'
+    needs: [discover_runner, run_unit_tests, e2e, run_data_parallel_test, run_pd_disaggregate_test]
     runs-on: ${{ needs.discover_runner.outputs.runner_name }}
     steps:
       - name: Remove Docker image to free up space


### PR DESCRIPTION
## Summary
Make the "Hourly Commit Check and Tests" cadence adaptive to pipeline health:

- **Last real run passed → run every 8h**
- **Last real run failed → back off to once every 24h**

GitHub cron can't be conditional, so the workflow is scheduled at the fast **8h** cadence (`0 */8 * * *` → 00:00 / 08:00 / 16:00 UTC) and a new lightweight **`gate`** job decides at runtime whether each tick proceeds.

## How the gate decides
- Runs on a cheap `ubuntu-latest` runner, so a "skip" never locks an HPU runner.
- `workflow_dispatch` always proceeds.
- Otherwise it queries recent runs via the API and finds the most recent **real** run — one where `run_unit_tests` actually executed:
  - **passed** → proceed (8h cadence).
  - **failed** → proceed only once **≥23h** have elapsed since that run started (24h back-off).

### Why "most recent real run" and not "most recent run"
A backed-off tick skips all test jobs, and GitHub reports such a run's overall conclusion as a misleading `success`. Keying off the last run where `run_unit_tests` actually ran prevents those skipped ticks from flipping the cadence back to 8h.

### Why elapsed-time and not exact-hour matching
Scheduled events can be delivered late/drifted by GitHub, so 24h spacing is enforced by comparing elapsed time to the last real run rather than matching a specific UTC hour.

## Wiring
- `discover_runner` is gated on `gate.outputs.should_run`; the rest of the pipeline already chains from it, so a skip cascades cleanly.
- `cleanup_docker_image` (`if: always()`) is guarded so it never runs on a skipped tick, where `discover_runner` was skipped and `runner_name` is empty.

## Notes
- Supersedes #1657 (flat once-a-day schedule) — that PR can be closed if this is preferred.
- The workflow display name still reads "Hourly"; left unchanged to avoid breaking references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)