### PR TITLE
MiniMax-M3: tolerate dropped "<" in invoke tag; list validated model

### DIFF
--- a/docs/getting_started/validated_models.md
+++ b/docs/getting_started/validated_models.md
@@ -21,6 +21,7 @@ The following configurations have been validated to function with IntelÂ® GaudiÂ
 | [lmsys/gpt-oss-20b-bf16](https://huggingface.co/lmsys/gpt-oss-20b-bf16)     | 1, 2, 4    | BF16    | Gaudi 3|
 | [lmsys/gpt-oss-120b-bf16](https://huggingface.co/lmsys/gpt-oss-120b-bf16)     | 4    | BF16    | Gaudi 3|
 | [MiniMaxAI/MiniMax-M2](https://huggingface.co/MiniMaxAI/MiniMax-M2)     | 8    | BF16    | Gaudi 3|
+| [MiniMaxAI/MiniMax-M3](https://huggingface.co/MiniMaxAI/MiniMax-M3)     | 8    | BF16    | Gaudi 3|
 | [meta-llama/CodeLlama-34b-Instruct-hf](https://huggingface.co/meta-llama/CodeLlama-34b-Instruct-hf)     | 1    | BF16    |Gaudi 3|
 | [ibm-granite/Granite-3.1-8B-instruct](https://huggingface.co/ibm-granite/granite-3.1-8b-instruct)     | 1  | BF16    | Gaudi 3|
 | [ibm-granite/Granite-3B-code-instruct-128k](https://huggingface.co/ibm-granite/granite-3b-code-instruct-128k)     | 1  | BF16    | Gaudi 3|

--- a/tests/unit_tests/test_minimax_m3_tool_parser.py
+++ b/tests/unit_tests/test_minimax_m3_tool_parser.py
@@ -12,6 +12,7 @@ from vllm_gaudi.entrypoints.openai.tool_parsers.minimax_m3 import (
     ELEMENT_START,
     INVOKE_END,
     INVOKE_START,
+    INVOKE_START_NOLT,
     TOOL_CALL_END,
     TOOL_CALL_START,
     MinimaxM3PyToolParser,
@@ -41,6 +42,12 @@ def _element(name: str, value: str) -> str:
 def _invoke(path: str, count: int = 2, enabled: bool = True) -> str:
     body = (_element("path", path) + _element("count", str(count)) + _element("enabled", str(enabled).lower()))
     return f'{INVOKE_START} name="write_file">{body}{INVOKE_END}'
+
+
+def _invoke_dropped_lt(path: str, count: int = 2, enabled: bool = True) -> str:
+    # MiniMax-M3 sometimes drops the leading "<" of the invoke open tag.
+    body = (_element("path", path) + _element("count", str(count)) + _element("enabled", str(enabled).lower()))
+    return f'{INVOKE_START_NOLT} name="write_file">{body}{INVOKE_END}'
 
 
 def _function_field(function, name: str):
@@ -111,6 +118,38 @@ def test_extract_multiple_tool_calls():
 
     assert result.tools_called
     assert [json.loads(call.function.arguments)["path"] for call in result.tool_calls] == ["first", "second"]
+
+
+def test_extract_tool_calls_dropped_invoke_lt():
+    text = f"before{TOOL_CALL_START}{_invoke_dropped_lt('/tmp/out')}{TOOL_CALL_END}"
+
+    result = MinimaxM3PyToolParser(None).extract_tool_calls(text, _request())
+
+    assert result.tools_called
+    assert result.content == "before"
+    assert len(result.tool_calls) == 1
+    function = result.tool_calls[0].function
+    assert function.name == "write_file"
+    assert json.loads(function.arguments) == {
+        "path": "/tmp/out",
+        "count": 2,
+        "enabled": True,
+    }
+
+
+def test_streaming_dropped_invoke_lt():
+    text = f"before{TOOL_CALL_START}{_invoke_dropped_lt('/tmp/out')}{TOOL_CALL_END}"
+    parser = MinimaxM3PyToolParser(None)
+
+    content, names, arguments = _stream(parser, text, _request())
+
+    assert content == "before"
+    assert names == {0: "write_file"}
+    assert json.loads(arguments[0]) == {
+        "path": "/tmp/out",
+        "count": 2,
+        "enabled": True,
+    }
 
 
 def test_non_streaming_malformed_call_preserves_output():

--- a/vllm_gaudi/entrypoints/openai/tool_parsers/minimax_m3.py
+++ b/vllm_gaudi/entrypoints/openai/tool_parsers/minimax_m3.py
@@ -78,6 +78,11 @@ NS = "]<]minimax[>["
 TOOL_CALL_START = NS + "<tool_call>"
 TOOL_CALL_END = NS + "</tool_call>"
 INVOKE_START = NS + "<invoke"
+# MiniMax-M3 rarely drops the leading "<" of the invoke open tag, emitting
+# "]<]minimax[>[invoke name=..." instead of "]<]minimax[>[<invoke name=...".
+# Tolerate that variant, mirroring the headless-parameter recovery already done
+# for dropped parameter opening tags (see the NS branches below).
+INVOKE_START_NOLT = NS + "invoke"
 INVOKE_END = NS + "</invoke>"
 ELEMENT_START = NS + "<"
 ELEMENT_END_START = NS + "</"
@@ -88,6 +93,25 @@ _INVOKE_NAME_RE = re.compile(r"""name\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))"""
 
 # Sentinel for "schema-aware conversion failed, use fallback".
 _FAIL = object()
+
+
+def _find_invoke_open(text: str, start: int) -> tuple[int, int]:
+    """Find the next invoke open tag at/after ``start``.
+
+    Returns ``(pos, opener_len)`` for the earliest match of either the
+    well-formed ``INVOKE_START`` or the dropped-"<" variant
+    ``INVOKE_START_NOLT`` (a known MiniMax-M3 quirk); on a tie the well-formed
+    form wins. Returns ``(-1, 0)`` when neither is present. This can never
+    false-positive on well-formed text: right after the namespace marker a real
+    invoke has "<", so ``INVOKE_START_NOLT`` only matches where "<" was dropped.
+    """
+    p_full = text.find(INVOKE_START, start)
+    p_nolt = text.find(INVOKE_START_NOLT, start)
+    if p_full == -1:
+        return (p_nolt, len(INVOKE_START_NOLT)) if p_nolt != -1 else (-1, 0)
+    if p_nolt == -1 or p_full <= p_nolt:
+        return (p_full, len(INVOKE_START))
+    return (p_nolt, len(INVOKE_START_NOLT))
 
 
 class _ParseError(Exception):
@@ -564,11 +588,15 @@ class MinimaxM3PyToolParser(ToolParser):
 
     def _parse_one_invoke(self, inv_block: str, request) -> ToolCall:
         """Parse a complete ``<invoke ...>...</invoke>`` block into a ToolCall."""
-        # Search past INVOKE_START: the namespace marker itself contains a ">".
-        header_end = inv_block.find(">", len(INVOKE_START))
+        # Tolerate a dropped leading "<" on the invoke open tag (MiniMax-M3
+        # quirk); the block may start with INVOKE_START or INVOKE_START_NOLT.
+        opener_len = (len(INVOKE_START) if inv_block.startswith(INVOKE_START) else
+                      len(INVOKE_START_NOLT) if inv_block.startswith(INVOKE_START_NOLT) else len(INVOKE_START))
+        # Search past the opener: the namespace marker itself contains a ">".
+        header_end = inv_block.find(">", opener_len)
         if header_end == -1:
             raise _ParseError("invoke header not closed")
-        header = inv_block[len(INVOKE_START):header_end]
+        header = inv_block[opener_len:header_end]
         m = _INVOKE_NAME_RE.search(header)
         if not m:
             raise _ParseError("invoke name not found")
@@ -598,7 +626,7 @@ class MinimaxM3PyToolParser(ToolParser):
             cur.skip_ws()
             if cur.eof() or cur.startswith(TOOL_CALL_END):
                 break
-            if not cur.startswith(INVOKE_START):
+            if not (cur.startswith(INVOKE_START) or cur.startswith(INVOKE_START_NOLT)):
                 break  # stray text / malformed boundary -> stop
             inv_end = text.find(INVOKE_END, cur.i)
             if inv_end == -1:
@@ -732,17 +760,17 @@ class MinimaxM3PyToolParser(ToolParser):
                 while True:
                     if self._open is None:
                         end_pos = current_text.find(TOOL_CALL_END, self._m3_pos)
-                        inv_pos = current_text.find(INVOKE_START, self._m3_pos)
+                        inv_pos, inv_open_len = _find_invoke_open(current_text, self._m3_pos)
                         if end_pos != -1 and (inv_pos == -1 or end_pos < inv_pos):
                             self._m3_pos = end_pos + len(TOOL_CALL_END)
                             self._m3_mode = "done"
                             break
                         if inv_pos == -1:
                             break  # nothing to open yet
-                        header_end = current_text.find(">", inv_pos + len(INVOKE_START))
+                        header_end = current_text.find(">", inv_pos + inv_open_len)
                         if header_end == -1:
                             break  # invoke header still streaming
-                        header = current_text[inv_pos + len(INVOKE_START):header_end]
+                        header = current_text[inv_pos + inv_open_len:header_end]
                         m = _INVOKE_NAME_RE.search(header)
                         name = ((m.group(1) or m.group(2) or m.group(3) or "").strip() if m else "")
                         if not name:

--- a/vllm_gaudi/entrypoints/openai/tool_parsers/minimax_m3.py
+++ b/vllm_gaudi/entrypoints/openai/tool_parsers/minimax_m3.py
@@ -83,6 +83,11 @@ INVOKE_START = NS + "<invoke"
 # Tolerate that variant, mirroring the headless-parameter recovery already done
 # for dropped parameter opening tags (see the NS branches below).
 INVOKE_START_NOLT = NS + "invoke"
+# All recognized invoke open tags, in preference order (well-formed first, so it
+# wins a same-position tie). Any future dropped-tag variant is added here only;
+# every parsing path resolves openers through ``_match_invoke_opener`` /
+# ``_find_invoke_open`` so the call sites never need per-variant updates.
+INVOKE_OPENERS = (INVOKE_START, INVOKE_START_NOLT)
 INVOKE_END = NS + "</invoke>"
 ELEMENT_START = NS + "<"
 ELEMENT_END_START = NS + "</"
@@ -95,23 +100,38 @@ _INVOKE_NAME_RE = re.compile(r"""name\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))"""
 _FAIL = object()
 
 
+def _match_invoke_opener(s: str, pos: int = 0) -> int | None:
+    """Length of the invoke opener at ``s[pos:]``, or ``None`` if none matches.
+
+    Openers come from ``INVOKE_OPENERS`` (well-formed ``INVOKE_START`` and the
+    dropped-"<" ``INVOKE_START_NOLT`` MiniMax-M3 quirk). At most one can match at
+    a given position -- right after the namespace marker a real invoke has "<",
+    so ``INVOKE_START_NOLT`` only matches where the "<" was dropped.
+    """
+    for opener in INVOKE_OPENERS:
+        if s.startswith(opener, pos):
+            return len(opener)
+    return None
+
+
 def _find_invoke_open(text: str, start: int) -> tuple[int, int]:
     """Find the next invoke open tag at/after ``start``.
 
-    Returns ``(pos, opener_len)`` for the earliest match of either the
-    well-formed ``INVOKE_START`` or the dropped-"<" variant
-    ``INVOKE_START_NOLT`` (a known MiniMax-M3 quirk); on a tie the well-formed
-    form wins. Returns ``(-1, 0)`` when neither is present. This can never
-    false-positive on well-formed text: right after the namespace marker a real
-    invoke has "<", so ``INVOKE_START_NOLT`` only matches where "<" was dropped.
+    Returns ``(pos, opener_len)`` for the earliest matching opener in
+    ``INVOKE_OPENERS`` (well-formed ``INVOKE_START`` or the dropped-"<" variant
+    ``INVOKE_START_NOLT``), preferring the earlier -- and, on a tie, the earlier
+    entry in ``INVOKE_OPENERS`` (well-formed). Returns ``(-1, 0)`` when neither
+    is present. Never false-positives on well-formed text (see
+    ``_match_invoke_opener``).
     """
-    p_full = text.find(INVOKE_START, start)
-    p_nolt = text.find(INVOKE_START_NOLT, start)
-    if p_full == -1:
-        return (p_nolt, len(INVOKE_START_NOLT)) if p_nolt != -1 else (-1, 0)
-    if p_nolt == -1 or p_full <= p_nolt:
-        return (p_full, len(INVOKE_START))
-    return (p_nolt, len(INVOKE_START_NOLT))
+    best_pos = -1
+    best_len = 0
+    for opener in INVOKE_OPENERS:
+        p = text.find(opener, start)
+        if p != -1 and (best_pos == -1 or p < best_pos):
+            best_pos = p
+            best_len = len(opener)
+    return (best_pos, best_len)
 
 
 class _ParseError(Exception):
@@ -589,9 +609,8 @@ class MinimaxM3PyToolParser(ToolParser):
     def _parse_one_invoke(self, inv_block: str, request) -> ToolCall:
         """Parse a complete ``<invoke ...>...</invoke>`` block into a ToolCall."""
         # Tolerate a dropped leading "<" on the invoke open tag (MiniMax-M3
-        # quirk); the block may start with INVOKE_START or INVOKE_START_NOLT.
-        opener_len = (len(INVOKE_START) if inv_block.startswith(INVOKE_START) else
-                      len(INVOKE_START_NOLT) if inv_block.startswith(INVOKE_START_NOLT) else len(INVOKE_START))
+        # quirk); the block may start with any opener in INVOKE_OPENERS.
+        opener_len = _match_invoke_opener(inv_block) or len(INVOKE_START)
         # Search past the opener: the namespace marker itself contains a ">".
         header_end = inv_block.find(">", opener_len)
         if header_end == -1:
@@ -626,7 +645,7 @@ class MinimaxM3PyToolParser(ToolParser):
             cur.skip_ws()
             if cur.eof() or cur.startswith(TOOL_CALL_END):
                 break
-            if not (cur.startswith(INVOKE_START) or cur.startswith(INVOKE_START_NOLT)):
+            if _match_invoke_opener(cur.s, cur.i) is None:
                 break  # stray text / malformed boundary -> stop
             inv_end = text.find(INVOKE_END, cur.i)
             if inv_end == -1:


### PR DESCRIPTION
## Summary

MiniMax-M3 occasionally drops the leading `<` of a tool-call invoke opening tag,
emitting `]<]minimax[>[invoke name="...">` instead of
`]<]minimax[>[<invoke name="...">`. The HPU MiniMax-M3 tool parser detects invoke
tags via the literal marker `INVOKE_START = NS + "<invoke"`, so a dropped `<`
caused the call to be silently missed — no tool call was produced in the
streaming path, and the entire generation was returned as plain content in the
non-streaming path.

This PR makes invoke detection tolerant of the dropped `<`, mirroring the
parser's existing headless-recovery tolerance for dropped *parameter* opening
tags.

## Changes

- **Parser fix** (`vllm_gaudi/entrypoints/openai/tool_parsers/minimax_m3.py`):
  - Add a variant marker `INVOKE_START_NOLT = NS + "invoke"` and a
    `_find_invoke_open()` helper that returns the earliest of the well-formed or
    dropped-`<` opener along with its length (preferring the well-formed form on
    ties).
  - Use it in the streaming path, and accept either opener in the non-streaming
    `_parse_block` / `_parse_one_invoke`.
  - The fix is **position-preserving** (no text rewriting), so streaming offset
    tracking is unaffected, and it **cannot false-positive** on well-formed text
    (a real invoke always has `<` right after the namespace marker). Scope is
    limited to the opening invoke tag; `INVOKE_END` and other tags are untouched.
- **Tests** (`tests/unit_tests/test_minimax_m3_tool_parser.py`): add regression
  tests for the dropped-`<` case in both the non-streaming and streaming paths.
- **Docs** (`docs/getting_started/validated_models.md`): add MiniMax-M3
  (TP=8, BF16, Gaudi 3) to the validated models list.