### PR TITLE
fix(hpu): don't merge mamba/hybrid prefills (single-request only)

### DIFF
--- a/tests/unit_tests/worker/test_hpu_mm_prefill_batching.py
+++ b/tests/unit_tests/worker/test_hpu_mm_prefill_batching.py
@@ -66,6 +66,12 @@ def _make_runner_stub(max_prefill_batch_size: int,
     stub.max_num_tokens = max_num_tokens
     stub.use_merged_prefill = use_merged_prefill
     stub.unified_attn = unified_attn
+    # num_mamba_like_layers is an instance-only attribute (set in __init__), so
+    # MagicMock(spec=HPUModelRunner) does not provide it. _can_merge_prefill_contents
+    # reads it on its first line; default to 0 (plain attention) so the existing
+    # merge tests exercise the non-mamba path. Tests that need the mamba guard
+    # override this to a positive value.
+    stub.num_mamba_like_layers = 0
 
     stub._can_merge_prefill_contents = (HPUModelRunner._can_merge_prefill_contents.__get__(stub))
     stub._get_prompt_bucketing_fn = (HPUModelRunner._get_prompt_bucketing_fn.__get__(stub))
@@ -163,6 +169,23 @@ class TestCanMergePrefillContents:
         lhs = BatchContents()
         rhs = _make_batch_contents("req-0", 128)
         assert runner._can_merge_prefill_contents(lhs, rhs) is True
+
+    def test_mamba_never_merges(self):
+        """Mamba/hybrid models must never merge prefills, even when the batch
+        size limit would otherwise allow it.
+
+        The mamba2 prefill path requires single-request batches: merging trips
+        ``assert len(req_ids) == 1`` in _form_prefill_batch with prefix
+        caching, or ``padded_batch == 1`` in granite_causal_conv1d_fn without
+        it. max_prefill_batch_size=8 with two history-less prefills merges for
+        plain attention (see test_bs4_allows_merge); the guard must block it
+        purely on model type.
+        """
+        runner = _make_runner_stub(max_prefill_batch_size=8)
+        runner.num_mamba_like_layers = 4  # hybrid/mamba model
+        lhs = _make_batch_contents("req-0", 128)
+        rhs = _make_batch_contents("req-1", 128)
+        assert runner._can_merge_prefill_contents(lhs, rhs) is False
 
 
 # ===========================================================================

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -2546,6 +2546,20 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
             return self._bucketize_2d_prompt
 
     def _can_merge_prefill_contents(self, lhs, rhs):
+        # Mamba/hybrid models require single-request prefill batches on HPU: the
+        # mamba2 prefill path is built around single-sequence chunks (see the
+        # "Chunks contain tokens from a *single* sequence only" invariant in
+        # _form_prefill_batch). Merging >=2 co-scheduled fresh prefills breaks
+        # that invariant in two ways:
+        #   * with prefix caching, _form_prefill_batch asserts
+        #     len(contents.req_ids) == 1 and the merged batch trips it;
+        #   * without prefix caching, granite_causal_conv1d_fn asserts
+        #     padded_batch == 1 and the merged batch trips it downstream.
+        # Neither is prefix-caching-specific, so gate on the model type, not on
+        # use_prefix_caching (which would also wrongly block merges for plain
+        # attention models that CAN merge under prefix caching).
+        if self.num_mamba_like_layers > 0:
+            return False
         # --- Logic to handle chunked prefill/prefix caching for HPU ---
         # 1. Check basic states of LHS (accumulated batch) and RHS (incoming request).
         # lhs_is_not_empty: Check if the accumulated batch actually contains any requests.


### PR DESCRIPTION
## Summary

Hybrid/mamba models require **single-request prefill batches** on HPU. The
mamba2 prefill path in `_form_prefill_batch` is built around the invariant
that a prefill batch holds tokens from a single sequence only, and two
downstream guards enforce it:

- with prefix caching, `_form_prefill_batch` asserts `len(contents.req_ids) == 1`;
- without prefix caching, `granite_causal_conv1d_fn` asserts `padded_batch == 1`.

When two or more history-less prefills are co-scheduled in one engine step and
`VLLM_PROMPT_BS_BUCKET_MAX` (`max_prefill_batch_size`) is >= 2,
`_can_merge_prefill_contents` merged them into one batch and tripped whichever
guard applied — an engine-fatal assert at step 0.

This was exposed once vllm-project/vllm PR #50210 registered
`Qwen3_5MoeForCausalLM` as a hybrid model (routing it to the mamba
prefix-cache path) and the plugin's stable-commit bump (#1691) pulled it in;
the merge itself had been unguarded since #1366.

## Fix

Gate the prefill merge on the **model type** rather than on prefix caching:

```python
def _can_merge_prefill_contents(self, lhs, rhs):
    if self.num_mamba_like_layers > 0:
        return False
    ...
```

The single-request requirement is not prefix-caching-specific (the conv-kernel
crash reproduces with prefix caching off), and gating on `use_prefix_caching`
would also wrongly disable merging for plain-attention models — which merge
safely under prefix caching. `num_mamba_like_layers > 0` is exactly the set of
models that hit either assert and is a no-op for every other model.

## Test plan

Verified on a single Gaudi3 card (granite-4.0-tiny hybrid + Qwen2.5-0.5B plain
attention, TP1, `VLLM_PROMPT_BS_BUCKET_MAX=8`, 24 co-scheduled short prompts):

| Model | prefix caching | before | after |
|-------|:--:|--------|-------|
| granite-4.0-tiny (hybrid) | on  | crash `assert len(req_ids)==1` | completes; per-batch req count capped at 1 |
| granite-4.0-tiny (hybrid) | off | crash `padded_batch must be 1` | completes |
| Qwen2.5-0.5B (plain attn)  | on  | merges | still merges (per-batch req count up to 8), completes — no regression |

`ruff check` passes.
