### PR TITLE
Restore MoE gate on the runner after INC conversion

### DIFF
--- a/tests/unit_tests/worker/test_moe_gate_sync.py
+++ b/tests/unit_tests/worker/test_moe_gate_sync.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+from vllm.model_executor.layers.fused_moe.layer import MoERunner
+
+from vllm_gaudi.v1.worker.hpu_model_runner import HPUModelRunner
+
+
+class _BareMoERunner(MoERunner):
+    """MoERunner with the heavyweight vLLM-config-dependent __init__ skipped."""
+
+    def __init__(self):
+        torch.nn.Module.__init__(self)
+        self.moe_config = SimpleNamespace()
+        self.gate = None
+
+
+class _StubModelRunner:
+    _sync_shared_moe_gates = HPUModelRunner._sync_shared_moe_gates
+
+    def __init__(self, layers):
+        self._layers = layers
+        self._detached_moe_gates: set[int] = set()
+
+    def _get_model_layers(self):
+        return self._layers
+
+
+def _build_layer():
+    gate = torch.nn.Linear(8, 4, bias=False)
+    experts = _BareMoERunner()
+    mlp = SimpleNamespace(gate=gate, experts=experts)
+    return SimpleNamespace(mlp=mlp), gate, experts
+
+
+def test_sync_shared_moe_gates_restores_runner_gate():
+    """The runner owns gate application, so INC sync must not clear it.
+
+    Models pass ``router_logits=hidden_states`` as a placeholder; a runner
+    without a gate forwards that placeholder into expert selection.
+    """
+    layer, gate, experts = _build_layer()
+    # _remove_duplicate_submodules() detaches the gate from the runner's
+    # _modules before INC conversion so INC patches it only under mlp.
+    experts._modules.pop("gate", None)
+    object.__setattr__(experts, "gate", None)
+
+    _StubModelRunner([layer])._sync_shared_moe_gates()
+
+    assert experts.gate is gate
+    assert "gate" not in experts._modules

--- a/vllm_gaudi/ops/hpu_fused_moe.py
+++ b/vllm_gaudi/ops/hpu_fused_moe.py
@@ -338,6 +338,15 @@ def select_experts_from_routed(layer, hidden_states: torch.Tensor,
     """
     from vllm.model_executor.layers.fused_moe.experts.cpu_moe import select_experts
 
+    # Models hand the runner a placeholder ``router_logits`` (== hidden_states)
+    # and expect the runner to overwrite it with the gate output. If that step
+    # is skipped the placeholder reaches expert selection and only fails later,
+    # deep inside the routing kernels, as an opaque broadcast error.
+    num_experts = layer.moe_config.num_logical_experts
+    if router_logits.size(-1) != num_experts:
+        raise RuntimeError(f"Router logits have {router_logits.size(-1)} columns but the layer routes to "
+                           f"{num_experts} experts; the MoE gate was not applied to the hidden states.")
+
     return select_experts(
         hidden_states=hidden_states,
         router_logits=router_logits,

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -5123,36 +5123,29 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
                 if orig_mod is not None:
                     _sync_moe_kernel_flags(orig_mod)
 
-                # Force external router path: the model's forward checks
-                # experts.is_internal_router to decide the gate path.
+                # Re-point the runner at the post-INC block-level gate.
+                # _remove_duplicate_submodules() detached the gate from the
+                # runner so INC would patch it only under mlp; the reference
+                # kept there is the pre-INC module, whose weight was mutated
+                # in place to fp8. The runner still owns gate application
+                # (upstream removed the external-router path together with
+                # is_internal_router), and models pass router_logits as a
+                # placeholder equal to hidden_states, so leaving the runner
+                # without a gate sends hidden_states into expert selection.
+                # object.__setattr__ keeps the gate out of _modules so INC's
+                # module->parent map still sees mlp as the sole parent.
                 if isinstance(experts, MoERunner):
-                    # is_internal_router is a read-only property backed by
-                    # the public `gate` attribute (returns gate is not None);
-                    # clearing gate makes it return False. Upstream #41184
-                    # inverted FusedMoE into a MoERunner factory, so the gate
-                    # now lives directly on the runner instead of `_gate`.
-                    experts.gate = None
-                else:
+                    object.__setattr__(experts, "gate", block_gate)
+                elif not isinstance(
+                        getattr(type(experts), "is_internal_router", None),
+                        property,
+                ):
                     # INC wrappers (e.g. PatchedMixtralMoE) may inherit
-                    # is_internal_router as a read-only @property;
-                    # runner.gate = None below handles that case.
-                    if not isinstance(
-                            getattr(type(experts), "is_internal_router", None),
-                            property,
-                    ):
-                        experts.is_internal_router = False
+                    # is_internal_router as a read-only @property.
+                    experts.is_internal_router = False
                 runner = getattr(experts, "runner", None)
                 if runner is not None and hasattr(runner, "gate"):
-                    runner.gate = None
-                    # Refresh the cached gate ref captured at
-                    # FusedMoE.__init__ to the post-INC block-level gate.
-                    # The dp_size==1 fast path (patched_fused_moe_forward)
-                    # falls back to runner._hpu_gate_ref when runner.gate
-                    # is None; the pre-INC reference points at the now-
-                    # replaced module and produced shape/dtype mismatches
-                    # under fp8.
-                    if block_gate is not None:
-                        object.__setattr__(runner, "_hpu_gate_ref", block_gate)
+                    object.__setattr__(runner, "gate", block_gate)
 
                 if id(experts) in self._detached_moe_gates:
                     self._detached_moe_gates.remove(id(experts))


### PR DESCRIPTION
## Root cause

`_sync_shared_moe_gates()` clears the gate on the MoE runner after INC conversion to
force what used to be the "external router" path:

```python
if isinstance(experts, MoERunner):
    experts.gate = None
```

That contract no longer exists upstream. After the `FusedMoE` -> `MoERunner` inversion
(vllm#41184) `mlp.experts` **is** the runner and the runner owns gate application;
`is_internal_router` was removed with vllm#51838. Models therefore pass
`router_logits=hidden_states` as a placeholder and rely on the runner to overwrite it.

With the gate cleared, `patched_fused_moe_forward()` skips
`router_logits, _ = self.gate(hidden_states)` and the placeholder flows straight into
expert selection. For DeepSeek-R1 (`topk_method: noaux_tc`) this fails when the routing
bias is added, because the "router logits" are `hidden_size` wide instead of
`n_routed_experts` wide:

```
Dynamo failed to run FX node with fake tensors: call_function <built-in function add>(
  *(FakeTensor(..., size=(128, 7168)), FakeTensor(..., size=(1, 256))))
```

For models without a routing bias there is no exception at all - routing is silently
computed from hidden states, which corrupts the output of every quantized MoE run.

The gate nulling was introduced together with the runner migration; the pre-migration
code cleared `FusedMoE._gate`, where clearing it really did mean "the model computes the
gate itself".

## Changes

- `_sync_shared_moe_gates()` re-points the runner at the post-INC block-level gate
  instead of clearing it. `object.__setattr__` keeps the gate out of `_modules`, so INC's
  module->parent map still sees `mlp` as the sole parent (the reason it was detached in
  `_remove_duplicate_submodules()` in the first place).
- Dropped the `_hpu_gate_ref` write: it was only set on `experts.runner`, which no longer
  exists after the inversion, and nothing ever read it.
- `select_experts_from_routed()` now rejects router logits whose width does not match the
  expert count, so a skipped gate fails with a clear message instead of an opaque
  broadcast error deep inside the routing kernels.
- Added a regression test for the gate synchronization.

## Test plan

Gaudi 3, 8 cards, current `main` + the matching stable vLLM commit:

| Test | before | after |
| --- | --- | --- |
| DeepSeek-R1 TP8, expert parallel, `fp8_inc` | broadcast error on first request | passes, coherent output |
| DeepSeek-R1 TP8 gsm8k, 5-shot, 100 samples | n/a (crash) | exact-match 0.95 (flexible and strict) |
| DeepSeek-V2-Lite-Chat + INC | degenerate output | passes |
| DeepSeek-V2-Lite-Chat + INC dynamic, TP2 | not run | passes |
| DeepSeek-V2-Lite-Chat bf16 (no INC) | not run | passes |
