### PR TITLE
[FIX_FOR_VLLM_CUSTOM=b05ae5dc008850a620dec6de66635dec2b5913fd] Register _FakeINCConfig for inc via quantization registry

### DIFF
--- a/vllm_gaudi/patches.py
+++ b/vllm_gaudi/patches.py
@@ -797,6 +797,28 @@ def _patch_sdpa_attention_forward() -> None:
         pass  # transformers version without this module
 
 
+def _patch_inc_quantization_config() -> None:
+    """Register the HPU ``_FakeINCConfig`` as the resolver for ``inc``.
+
+    The Gaudi runtime-INC (Intel Neural Compressor) flow calibrates fp8 scales
+    at runtime and ships no on-disk config, so resolving ``inc`` to vLLM's
+    native ``INCConfig`` (whose ``get_config_filenames()`` expects
+    ``quantization_config.json``) makes ``get_quant_config`` raise ``Cannot find
+    the config file for inc`` — surfacing as a ``VllmConfig`` ValidationError
+    during ``create_engine_config`` (exposed by upstream vllm#51695). The
+    existing ``ops`` shim on ``get_quantization_config`` is order-sensitive;
+    registering via the public ``register_quantization_config`` API is immune to
+    import order because ``get_quantization_config`` merges the registry on
+    every call. ``inc`` is already in ``QUANTIZATION_METHODS``, so this only
+    overrides the config class and does not touch ``current_platform``.
+    """
+    from vllm.model_executor.layers.quantization import register_quantization_config
+
+    from vllm_gaudi.extension.quant import _FakeINCConfig
+
+    register_quantization_config("inc")(_FakeINCConfig)
+
+
 def apply() -> None:
     """Install all HPU runtime monkey-patches."""
     # --- torch.accelerator.empty_cache ---
@@ -834,6 +856,7 @@ def apply() -> None:
         _patch_mamba_bind_kv_cache()
         _patch_free_blocks()
         _patch_sdpa_attention_forward()
+        _patch_inc_quantization_config()
 
     _plugins_mod.load_general_plugins = _load_general_with_hpu_patches
 


### PR DESCRIPTION
## Root cause
vLLM ships a native `inc` quantization method whose `get_config_filenames()`
returns `["quantization_config.json"]`. The Gaudi runtime-INC (Intel Neural
Compressor) flow calibrates fp8 scales at runtime and ships no such on-disk
file, so resolving `inc` to the upstream config makes
`weight_utils.get_quant_config` raise `Cannot find the config file for inc`,
surfacing as a `pydantic ValidationError for VllmConfig` during
`create_engine_config`. The `extension.ops` function-object monkeypatch only
wins when import order lets it install before the front-end binds the config
resolver.

## Upstream PR
https://github.com/vllm-project/vllm/pull/51695
An import-graph change that pulls the quantization resolution chain in earlier
(new top-level imports across fused_moe and MoE models), defeating the import
order the `ops` monkeypatch relied on. Confirmed by git bisect as the first
commit exhibiting the failure; the prior parent build was green.

## Fix
Register a `_FakeINCConfig` for `inc` via `register_quantization_config` in the
`load_general_plugins` hook, populating the customized method-to-quant-config
map that `get_quantization_config` merges on every call. This is immune to
import order and no longer depends on the `ops` function-object override
winning the race.