### PR TITLE
Fix decode-block clamp misdetecting hybrid/SWA models (regression from #1700)

### DIFF
--- a/tests/unit_tests/test_decode_bucket_hybrid.py
+++ b/tests/unit_tests/test_decode_bucket_hybrid.py
@@ -90,15 +90,16 @@ class _MockConfig:
             object.__setattr__(self, k, v)
 
 
-def _make_bucketing_manager(block_size, max_model_len, max_num_seqs, num_hpu_blocks, is_hybrid=True):
+def _make_bucketing_manager(block_size, max_model_len, max_num_seqs, num_hpu_blocks, skip_decode_block_clamp=True):
     """Create a minimally-configured HPUBucketingManager.
 
-    Defaults to is_hybrid=True since this helper is used exclusively for hybrid
-    model scenarios, which keep the decode block range unbounded (not clamped).
+    Defaults to skip_decode_block_clamp=True since this helper is used
+    exclusively for hybrid model scenarios, which keep the full worst-case
+    decode block range (skip the 3x-physical clamp).
     """
     mgr = HPUBucketingManager.__new__(HPUBucketingManager)
     mgr.block_size = block_size
-    mgr.is_hybrid = is_hybrid
+    mgr.skip_decode_block_clamp = skip_decode_block_clamp
     mgr.max_model_len = max_model_len
     mgr.max_num_seqs = max_num_seqs
     mgr.max_num_prefill_seqs = 1
@@ -348,15 +349,15 @@ def test_hybrid_max_decode_blocks_formula(mock_exp_config):
     mock_exp_config.return_value = _MockConfig(use_contiguous_pa=False)
     strategy = ExponentialBucketingStrategy()
 
-    # Using attn_block_size=128 (correct). Hybrid models keep the unbounded
-    # worst case (is_hybrid=True), so no max_blocks*3 clamp is applied.
+    # Using attn_block_size=128 (correct). GDN hybrids keep the full worst
+    # case (skip_decode_block_clamp=True), so no max_blocks*3 clamp.
     _, _, block_cfg = strategy.get_decode_cfgs(
         max_num_seqs=_QWEN35_MAX_NUM_SEQS,
         block_size=_QWEN35_ATTN_BLOCK_SIZE,
         max_num_batched_tokens=131072,
         max_model_len=_QWEN35_MAX_MODEL_LEN,
         max_blocks=_QWEN35_NUM_HPU_BLOCKS,
-        is_hybrid=True,
+        skip_decode_block_clamp=True,
     )
     expected_max = math.ceil(_QWEN35_MAX_MODEL_LEN / _QWEN35_ATTN_BLOCK_SIZE) * _QWEN35_MAX_NUM_SEQS
     assert block_cfg[2] == expected_max, (
@@ -370,7 +371,7 @@ def test_hybrid_max_decode_blocks_formula(mock_exp_config):
         max_num_batched_tokens=131072,
         max_model_len=_QWEN35_MAX_MODEL_LEN,
         max_blocks=_QWEN35_NUM_HPU_BLOCKS,
-        is_hybrid=True,
+        skip_decode_block_clamp=True,
     )
     wrong_max = math.ceil(_QWEN35_MAX_MODEL_LEN / _QWEN35_BLOCK_SIZE) * _QWEN35_MAX_NUM_SEQS
     assert block_cfg_wrong[2] == wrong_max, (

--- a/vllm_gaudi/extension/bucketing/common.py
+++ b/vllm_gaudi/extension/bucketing/common.py
@@ -78,10 +78,13 @@ class HPUBucketingManager():
         self.max_num_prefill_seqs = max_num_prefill_seqs
         self.block_size = block_size
         self.max_num_batched_tokens = max_num_batched_tokens
-        # Set by the model runner before decode bucket generation for hybrid
-        # models (block_size != attn_block_size); keeps their decode block range
-        # unbounded (see ExponentialBucketingStrategy.get_decode_cfgs).
-        self.is_hybrid = False
+        # Set by the model runner before decode bucket generation for models
+        # whose decode block references can reach the theoretical worst case
+        # (GDN/mamba hybrids, interleaved sliding-window, or an inflated
+        # KV-cache block_size); keeps their full worst-case decode block
+        # range instead of clamping to 3x physical (see
+        # ExponentialBucketingStrategy.get_decode_cfgs).
+        self.skip_decode_block_clamp = False
         self.num_hpu_blocks = None
         self._fallback_max_ctx = 0
         self.max_model_len = max_model_len
@@ -206,7 +209,7 @@ class HPUBucketingManager():
                     max_num_batched_tokens=self.max_num_batched_tokens,
                     max_model_len=self.max_model_len,
                     max_blocks=self.num_hpu_blocks,
-                    is_hybrid=getattr(self, 'is_hybrid', False))
+                    skip_decode_block_clamp=getattr(self, 'skip_decode_block_clamp', False))
 
                 bs_range = strategy.get_range(bs_cfg)
                 query_range = strategy.get_range(query_cfg)

--- a/vllm_gaudi/extension/bucketing/exponential.py
+++ b/vllm_gaudi/extension/bucketing/exponential.py
@@ -87,7 +87,7 @@ class ExponentialBucketingStrategy():
                         max_num_batched_tokens,
                         max_model_len,
                         max_blocks,
-                        is_hybrid=False):
+                        skip_decode_block_clamp=False):
         self.check_for_user_flags('decode')
         use_contiguous_pa = get_config().use_contiguous_pa
 
@@ -104,7 +104,7 @@ class ExponentialBucketingStrategy():
             # Contiguous PA indexes blocks by the highest block id in the batch,
             # which is bounded by the size of the cache.
             max_decode_blocks = min(max_blocks, max_decode_blocks)
-        elif not is_hybrid:
+        elif not skip_decode_block_clamp:
             # Non-contiguous PA counts block *references*: len(block_list) =
             # sum(num_blocks). With prefix caching a shared block is counted once
             # per sequence, so the reference count can exceed num_hpu_blocks
@@ -113,10 +113,13 @@ class ExponentialBucketingStrategy():
             # ceiling also caps _fallback_max_ctx, so real high-reference decode
             # batches still find a matching bucket instead of recompiling.
             #
-            # Hybrid models (block_size != attn_block_size) are excluded: their
-            # sequences can share a single long prefix across the whole batch, so
-            # references legitimately reach the full worst case. They keep the
-            # unbounded range so runtime lookups never recompile.
+            # Models with structurally large or multi-group decode block tables
+            # (GDN/mamba hybrids, interleaved sliding-window, or an inflated
+            # KV-cache block_size) set skip_decode_block_clamp: their block
+            # references legitimately reach the full worst case, so they skip
+            # this clamp and keep the (still finite) worst-case ceiling, and
+            # runtime lookups never recompile. The runner decides this via
+            # HPUModelRunner.warmup_model.
             max_decode_blocks = min(max_decode_blocks, max_blocks * 3)
         decode_blocks_limit = math.ceil(math.log2(max_decode_blocks)) + 1
         # Compensate for wider range: add extra buckets to maintain density at high end

--- a/vllm_gaudi/extension/bucketing/linear.py
+++ b/vllm_gaudi/extension/bucketing/linear.py
@@ -59,7 +59,7 @@ class LinearBucketingStrategy:
                         max_num_batched_tokens,
                         max_model_len,
                         max_blocks,
-                        is_hybrid=False):
+                        skip_decode_block_clamp=False):
         prefix_caching = get_config().prefix_caching
         contiguous_pa = get_config().use_contiguous_pa
 

--- a/vllm_gaudi/extension/bucketing/padding_aware.py
+++ b/vllm_gaudi/extension/bucketing/padding_aware.py
@@ -70,7 +70,7 @@ class PaddingAwareBucketingStrategy:
                         max_num_batched_tokens,
                         max_model_len,
                         max_blocks,
-                        is_hybrid=False):
+                        skip_decode_block_clamp=False):
         contiguous_pa = get_config().use_contiguous_pa
 
         decode_bs_bucket_cfg = read_bucket_settings('decode',

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -6141,10 +6141,24 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
             # attn_block_size.  Scope the mutation to avoid affecting prompt
             # fallback paths that still need the original block_size.
             saved_block_size = self.bucketing_manager.block_size
-            # Hybrid models can share one long prefix across the whole batch, so
-            # decode block references can reach the full worst case; flag them so
-            # the decode block range is left unbounded (not clamped to 3x physical).
-            self.bucketing_manager.is_hybrid = self.attn_block_size != self.block_size
+            # Skip the 3x-physical clamp on the decode block range (keeping the
+            # full, still-finite worst-case ceiling) for models whose decode
+            # block references can reach that worst case, otherwise those
+            # references miss the warmed buckets and recompile at runtime.
+            # This covers:
+            #   - inflated KV-cache block_size (Granite-4.0-H, attn != block),
+            #   - GDN hybrids (e.g. Qwen3.5) whose virtual block splitting
+            #     inflates the per-sequence block table,
+            #   - mamba hybrids, and
+            #   - interleaved sliding-window models (e.g. Gemma4) whose global
+            #     layers keep full-context block tables.
+            # attn_block_size == block_size for GDN/interleaved-SWA models, so
+            # this must not be detected via the block_size mismatch alone.
+            # Plain dense models keep the clamp, which bounds first-decode
+            # warmup memory.
+            self.bucketing_manager.skip_decode_block_clamp = (self.attn_block_size != self.block_size
+                                                              or self.num_gdn > 0 or self.num_mamba_like_layers > 0
+                                                              or self.interleaved_sliding_window)
             if self.attn_block_size != self.block_size:
                 self.bucketing_manager.block_size = self.attn_block_size
             try:


### PR DESCRIPTION
## Problem

#1700 clamped non-contiguous PA decode block buckets to `max_blocks * 3` and tried to exclude "hybrid" models via `attn_block_size != block_size`. That signal only fires for non-GDN mamba models (Granite-4.0-H, inflated `cache_config.block_size`). For everything else `attn_block_size == block_size`, so **Qwen3.5** (GDN; HPU kernel at 128-token granularity) and **Gemma4** (interleaved sliding-window; `num_gdn == 0`, `num_mamba_like_layers == 0`) were treated as non-hybrid and clamped.

Their decode `block_list` references legitimately exceed 3× physical (GDN virtual block splitting; Gemma's global-attention layers keep full-context block tables), so runtime lookups miss the warmed buckets and recompile the decode graph — the reported regression.

## Fix

Detect the "leave the decode block range unbounded" set using the real signals available on the runner before warmup:

```python
self.bucketing_manager.unbounded_decode_blocks = (
    self.attn_block_size != self.block_size   # Granite-4.0-H (inflated block_size)
    or self.num_gdn > 0                        # GDN hybrids  → Qwen3.5
    or self.num_mamba_like_layers > 0          # mamba hybrids
    or self.interleaved_sliding_window)        # interleaved SWA → Gemma4
```

Plain dense models (Qwen3-0.6B, Llama) keep the clamp, preserving the original first-decode warmup-OOM fix.

Also renames the bucketing flag `is_hybrid` → `unbounded_decode_blocks` to describe what it controls and avoid confusion with the unrelated vLLM `model_config.is_hybrid`.

## Testing

- `pytest tests/unit_tests/test_bucketing.py` → 40 passed
- yapf + ruff clean
- Hybrid unit tests updated to the renamed kwarg
- **Pending:** HPU validation that Qwen3.5 and Gemma4 no longer recompile decode buckets at runtime, and that dense models still avoid the warmup OOM.