### PR TITLE
[FIX_FOR_VLLM_CUSTOM=14617c2b6c1257ac0d6c7b5e05b195ca30013827] 4 fixes: MLA W_UV, WNA16 MoE backend, preemption KV, launcher import

### DIFF
--- a/tests/full_tests/preemption.py
+++ b/tests/full_tests/preemption.py
@@ -24,7 +24,10 @@ def main():
         max_model_len=1024,
         max_num_batched_tokens=1024,
         gpu_memory_utilization=0.9,
-        num_gpu_blocks_override=8,  # to trigger preemption
+        # Small KV cache to force preemption. Must stay above the upstream
+        # admission check (needs >= max_model_len/block_size worth of blocks,
+        # rounded up), yet below the ~20 blocks the 4 requests peak at.
+        num_gpu_blocks_override=12,
         disable_log_stats=False,
     )
     # Generate texts from the prompts.

--- a/vllm_gaudi/attention/backends/hpu_attn.py
+++ b/vllm_gaudi/attention/backends/hpu_attn.py
@@ -357,15 +357,17 @@ class HPUMLAImpl(MLACommonImpl[HPUAttentionMetadata], torch.nn.Module):
     # during each graph execution
     def process_weights_after_loading(self, act_dtype: torch.dtype):
         super().process_weights_after_loading(act_dtype)
-        # Since vllm#48251 the base process_weights_after_loading registers
-        # W_UV and W_UK_T as nn.Parameter (via replace_parameter), so a plain
-        # tensor reassignment raises TypeError. Route the contiguous/.to("hpu")
-        # update back through replace_parameter to preserve the registration.
-        # When INC CPU-first loading is active the source weights live on CPU,
-        # making these derived tensors CPU-resident too — which then causes a
-        # device mismatch at the bmm calls in forward.  Explicitly place on HPU.
-        replace_parameter(self, "W_UV", self.W_UV.contiguous().to("hpu"))
-        replace_parameter(self, "W_UK_T", self.W_UK_T.contiguous().to("hpu"))
+        # Upstream moved MLA weight packing off the attention impl onto the
+        # MLAAttention module, so the base process_weights_after_loading is now
+        # the AttentionImplBase no-op and W_UV/W_UK_T are no longer registered on
+        # the impl. Only massage them when this impl actually owns them: they are
+        # registered as nn.Parameter, so route through replace_parameter to keep
+        # the registration; .to("hpu") avoids a CPU/HPU bmm device mismatch under
+        # INC CPU-first loading.
+        for name in ("W_UV", "W_UK_T"):
+            weight = getattr(self, name, None)
+            if weight is not None:
+                replace_parameter(self, name, weight.contiguous().to("hpu"))
 
     # NOTE(Chendi): PR25184 using output buffer as default, which can't be used in HPU Graph,
     # so we override and always return a new tensor

--- a/vllm_gaudi/entrypoints/openai/multi_model_api_server.py
+++ b/vllm_gaudi/entrypoints/openai/multi_model_api_server.py
@@ -21,13 +21,13 @@ import vllm.envs as envs
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.chat_utils import load_chat_template
-from vllm.entrypoints.launcher import serve_http
+from vllm.entrypoints.launchers.launcher import serve_http
 from vllm.entrypoints.serve.utils.request_logger import RequestLogger
 from vllm.entrypoints.openai.api_server import build_app, setup_server
 from vllm.entrypoints.openai.cli_args import make_arg_parser, validate_parsed_serve_args
 from vllm.entrypoints.openai.models.protocol import BaseModelPath
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
-from vllm.entrypoints.serve.utils.server_utils import get_uvicorn_log_config
+from vllm.entrypoints.launchers.utils.server_utils import get_uvicorn_log_config
 from vllm.entrypoints.scale_out.render.serving import ServingRender
 from vllm.entrypoints.serve.tokenize.serving import ServingTokenization
 from vllm.renderers.online_renderer import OnlineRenderer

--- a/vllm_gaudi/ops/hpu_compressed_tensors.py
+++ b/vllm_gaudi/ops/hpu_compressed_tensors.py
@@ -38,6 +38,7 @@ from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tenso
 # method now derives from the unified ``CompressedTensorsWNA16MoEMethod``.
 from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe_wna16 import (  # noqa: E501
     CompressedTensorsWNA16MoEMethod as CompressedTensorsWNA16MarlinMoEMethod)
+from vllm.model_executor.layers.fused_moe.oracle.int_wna16 import WNA16MoEBackend
 from vllm.model_executor.kernels.linear.mixed_precision import (
     MPLinearKernel,
     MPLinearLayerConfig,
@@ -792,6 +793,12 @@ class HPUCompressedTensorsWNA16MoEMethod(CompressedTensorsWNA16MarlinMoEMethod):
         self.actorder = weight_quant.actorder
         self.quant_type = WNA16_SUPPORTED_TYPES_MAP[self.num_bits]
         self.layer_name = layer_name
+        # The bypassed base __init__ normally sets self.wna16_backend from the
+        # WNA16 backend oracle. The HPU path supplies its own MoE op and never
+        # uses a CUDA backend, but inherited methods (get_fused_moe_quant_config,
+        # supports_eplb) still read this attribute. Pin it to the non-accelerated
+        # EMULATION sentinel so those inherited paths take the generic branch.
+        self.wna16_backend = WNA16MoEBackend.EMULATION
 
     def create_weights(self, layer: torch.nn.Module, num_experts: int, hidden_size: int,
                        intermediate_size_per_partition: int, params_dtype: torch.dtype, **extra_weight_attrs):


### PR DESCRIPTION
This PR consolidates 4 hourly-CI fixes against vllm@`14617c2b6c1257ac0d6c7b5e05b195ca30013827`.

## Bug 1: guard HPUMLAImpl W_UV/W_UK_T reregistration

- **State machine id**: hpu_mla_impl_missing_w_uv_attribute
- **Commit**: 1ddb418859d629ed889272a9aee6bffbbcae6536

### Root cause
Upstream vLLM relocated MLA W_UV/W_UK_T weight packing from the attention impl (MLACommonImpl) onto the MLAAttention module. The impl-side base process_weights_after_loading now resolves to the AttentionImplBase no-op, so HPUMLAImpl no longer inherits self.W_UV/self.W_UK_T and crashed with AttributeError when moving them to HPU (9 DeepSeek/MLA e2e jobs).

### Upstream PR
vllm-project/vllm#33284 — "[Attention] Move MLA `forward` from backend to layer" (commit `aaa901ad55ee454f061649b4cc24f96c5ea04e33`). Confirmed by before/after ownership: the PR removed `process_weights_after_loading`/`self.W_UV` from the impl class and added them to the MLAAttention module, with no compatibility shim on the impl side. (The move dates to 2026-01-30; CI exposure is recent because the pinned vLLM sha only lately crossed this commit.)

### Fix
Only route W_UV/W_UK_T through replace_parameter(.to("hpu")) when this impl actually owns them; the HPUMLAAttention module performs the split.

## Bug 2: set wna16_backend on HPU WNA16 MoE method

- **State machine id**: hpu_compressed_wna16_moe_missing_wna16_backend
- **Commit**: 8399caf3d3028de500765ee9c0eae80b07149e69

### Root cause
HPUCompressedTensorsWNA16MoEMethod bypasses the upstream base __init__ (to dodge the WNA16 backend oracle NotImplementedError on Gaudi) and so never sets self.wna16_backend, which the inherited get_fused_moe_quant_config/supports_eplb paths now read, raising AttributeError on run_compressed_w4a16_moe_gidx_load_generate_test.

### Upstream PR
vllm-project/vllm#44570 — "[MoE Refactor] Combine CompressedTensorsWNA16MarlinMoEMethod with CompressedTensorsWNA16MoEMethod" (commit `454ea5b52611c933e00581723e2db56f0144cea7`). It made self.wna16_backend a base __init__ attribute and read it from the inherited supports_eplb path. (vllm#48918 later widened the read sites but did not introduce the requirement.)

### Fix
Set self.wna16_backend = WNA16MoEBackend.EMULATION in the HPU constructor so inherited quant-config paths take the generic branch.

## Bug 3: raise preemption test KV cache override above admission check

- **State machine id**: preemption_kv_cache_insufficient_max_model_len
- **Commit**: 64f0f96b95f7fe42a0da917d98dff8842d80f63a

### Root cause
The preemption test hardcoded num_gpu_blocks_override=8 (==max_model_len/block_size); a new upstream get_kv_cache_configs block reserves one KV null block, subtracting it from the memory the enough-KV-cache admission check sees. The check then runs against 7 effective blocks and rejects the request (estimated max len 7*128 = 896 < 1024).

### Upstream PR
vllm-project/vllm#47272 — "[Bugfix][Core] Reserve the KV null block when validating max_model_len" (commit `76fb6d210a57c7efbb61fa6cb029d1fa1911bfb5`). The 896 in the failure message is exactly one reserved null block below the 8-block override.

### Fix
Bump num_gpu_blocks_override 8 -> 12 to clear the admission check while still exercising preemption.

## Bug 4: fix multi-model server launcher imports

- **State machine id**: vllm_entrypoints_launcher_module_missing
- **Commit**: 21d9976c794534c7925f612187c020c29530c4d5

### Root cause
Upstream vLLM moved vllm/entrypoints/launcher.py into the new vllm.entrypoints.launchers package and relocated serve/utils/server_utils.py under launchers/utils, so multi_model_api_server.py's imports of serve_http + get_uvicorn_log_config broke with `ModuleNotFoundError: No module named 'vllm.entrypoints.launcher'` (run_unit_tests + run_online_model_swap_test).

### Upstream PR
vllm-project/vllm#52131 — package move to vllm.entrypoints.launchers.

### Fix
Import serve_http from vllm.entrypoints.launchers.launcher and get_uvicorn_log_config from vllm.entrypoints.launchers.utils.server_utils.
