### PR TITLE
[FIX_FOR_VLLM_CUSTOM=0a21947d710f5aedb1865038ebef20e141b29c58] Pre-tokenize ProcessorInputs prompt after upstream processor change

### DIFF
--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -5901,10 +5901,22 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
         dummy_text = dummy_builder.get_dummy_text({modality: count})
         mm_data_items = processor.info.parse_mm_data({modality: mm_items}, validate=False)
 
+        # Upstream vllm#53093 removed the text components (str prompt +
+        # tokenization_kwargs) from ProcessorInputs; the prompt is now a
+        # pre-tokenized list[int] and tokenization happens in the caller.
+        # Mirror get_dummy_processor_inputs' tokenization exactly.
+        tokenizer = processor.info.ctx.tokenizer
+        if tokenizer is None:
+            dummy_prompt: list[int] = []
+        else:
+            dummy_prompt = tokenizer.encode(
+                dummy_text,
+                **processor.info.default_tok_params.get_encode_kwargs(),
+            )
+
         return ProcessorInputs(
-            prompt=dummy_text,
+            prompt=dummy_prompt,
             mm_data_items=mm_data_items,
-            tokenization_kwargs={"truncation": False},
         )
 
     def _get_mm_warmup_processor(self):


### PR DESCRIPTION
## Bug 1: Pre-tokenize ProcessorInputs prompt after upstream processor change

- **State machine id**: processor_inputs_tokenization_kwargs_typeerror
- **Commit**: e7b20597466a47cddb683a78e1a681c2ef9e1964

### Root cause
Upstream removed the text components (str prompt + tokenization_kwargs) from ProcessorInputs; prompt is now list[int] and tokenization moved to the caller.

### Culprit
Probable culprit: [PR #53093](https://github.com/vllm-project/vllm/pull/53093) — pinned by symbol archaeology, bisect not run.

### Fix
Mirror get_dummy_processor_inputs — tokenize dummy_text to list[int] and drop the tokenization_kwargs kwarg in _build_raw_image_processor_inputs.