### PR TITLE
FusedSDPA: tile the query dim to avoid the 2**31-byte prompt-bias overflow

### DIFF
--- a/docs/configuration/env_variables.md
+++ b/docs/configuration/env_variables.md
@@ -166,3 +166,23 @@ The slicing is only activated if all the following additional conditions are sat
 - It's a causal attention model.
 - The padding side is 'right'.
 - No sliding window nor sinks (BF16 only; FP8 does not support sinks).
+
+## Query Tiling for Large Prompt Attention Biases
+
+FusedSDPA addresses the attention bias with a 32-bit signed byte offset, so a dense prompt bias of
+2 GiB or more (`batch_size * query_len * (context_blocks * block_size + query_len) * itemsize >=
+2**31`) makes the offset wrap and the kernel silently returns `NaN` instead of raising. Long
+contexts combined with a wide context bucket can reach this, for example a
+`[1, 1, 8192, 131072]` bf16 bias, which is exactly `2**31` bytes.
+
+Query tiling splits the query dimension of prompt attention into the smallest number of tiles that
+keeps every per-call bias below the limit. Attention rows are independent, so each tile attends the
+full K/V and the results simply concatenate; the output is unchanged apart from the tiling itself.
+
+| Parameter name                    | Description                                                                | Default value |
+| --------------------------------- | -------------------------------------------------------------------------- | ------------- |
+| `VLLM_HPU_FSDPA_Q_TILE_ENABLE`    | Enable query tiling when the prompt attention bias would reach `2**31` bytes. | `false`     |
+
+!!! note
+    This is independent of `VLLM_HPU_FSDPA_SLICE_ENABLED` and works with any bucketing strategy.
+    When enabled, shapes whose bias already fits below the limit take the untiled path unchanged.

--- a/docs/configuration/env_variables.md
+++ b/docs/configuration/env_variables.md
@@ -165,3 +165,23 @@ The slicing is only activated if all the following additional conditions are sat
 - It's a causal attention model.
 - The padding side is 'right'.
 - No sliding window nor sinks (BF16 only; FP8 does not support sinks).
+
+## Query Tiling for Large Prompt Attention Biases
+
+FusedSDPA addresses the attention bias with a 32-bit signed byte offset, so a dense prompt bias of
+2 GiB or more (`batch_size * query_len * (context_blocks * block_size + query_len) * itemsize >=
+2**31`) makes the offset wrap and the kernel silently returns `NaN` instead of raising. Long
+contexts combined with a wide context bucket can reach this, for example a
+`[1, 1, 8192, 131072]` bf16 bias, which is exactly `2**31` bytes.
+
+Query tiling splits the query dimension of prompt attention into the smallest number of tiles that
+keeps every per-call bias below the limit. Attention rows are independent, so each tile attends the
+full K/V and the results simply concatenate; the output is unchanged apart from the tiling itself.
+
+| Parameter name                    | Description                                                                | Default value |
+| --------------------------------- | -------------------------------------------------------------------------- | ------------- |
+| `VLLM_HPU_FSDPA_Q_TILE_ENABLE`    | Enable query tiling when the prompt attention bias would reach `2**31` bytes. | `false`     |
+
+!!! note
+    This is independent of `VLLM_HPU_FSDPA_SLICE_ENABLED` and works with any bucketing strategy.
+    When enabled, shapes whose bias already fits below the limit take the untiled path unchanged.

--- a/tests/unit_tests/test_fsdpa_slicing.py
+++ b/tests/unit_tests/test_fsdpa_slicing.py
@@ -21,7 +21,8 @@ from vllm_gaudi.extension.bucketing.linear import LinearBucketingStrategy
 from vllm_gaudi.extension.bucketing.padding_aware import PaddingAwareBucketingStrategy
 from vllm_gaudi.extension.config import Config, Eq, All, Disabled, Kernel, Value, Env, boolean
 from vllm_gaudi.extension.features import get_user_flags, get_features
-from vllm_gaudi.extension.ops import _fsdpa_prompt_attention, dynamic_quant
+from vllm_gaudi.extension.ops import (_fsdpa_prompt_attention, _fsdpa_num_q_tiles, _FSDPA_PLANE_MAX_BYTES,
+                                       dynamic_quant)
 from vllm_gaudi.extension.utils import (
     ModuleFP8FusedSDPA,
     ModuleFusedSDPA,
@@ -1273,6 +1274,74 @@ class TestFsdpaSlicingAccuracyFP8:
                                                             dim=0).item()
 
         assert cos_sim > 0.99, f"FP8 cosine similarity too low: {cos_sim}"
+
+
+@requires_hpu
+class TestFsdpaQTilingAccuracy:
+    """Query-tiling (VLLM_HPU_FSDPA_Q_TILE_ENABLE) fixes the FusedSDPA overflow NaN.
+
+    A query tile attends to the *full* K/V, so each tile's softmax is already
+    complete and the tiles simply concatenate -- there is no online-softmax
+    rescaling as in KV slicing. Splitting the query dim is therefore exact, and it
+    keeps every q x kv bias plane under the 2**31-byte 32-bit-offset limit that the
+    kernel overflows.
+    """
+
+    HEAD_DIM = 128
+
+    @staticmethod
+    def _fsdpa_apply():
+        from habana_frameworks.torch.hpex.kernels import FusedSDPA
+        return FusedSDPA.apply
+
+    def _run_fn(self, q, k, v, bias, scale, enable, limit):
+        """Run _fsdpa_prompt_attention with the q-tiling flag and byte limit patched.
+
+        q/k/v arrive as [bs, heads, seq, dim]; the function transposes internally,
+        so we hand it [bs, seq, heads, dim]. Returns (output, num_q_tiles)."""
+        cfg = MagicMock()
+        cfg.fp32_softmax = False
+        cfg.enable_fsdpa_q_tiling = enable
+        with patch('vllm_gaudi.extension.ops.get_config', return_value=cfg), \
+             patch('vllm_gaudi.extension.ops._FSDPA_PLANE_MAX_BYTES', limit):
+            num_tiles = _fsdpa_num_q_tiles(bias)
+            with torch.inference_mode():
+                out = _fsdpa_prompt_attention(query=q.transpose(1, 2),
+                                              key=k.transpose(1, 2),
+                                              value=v.transpose(1, 2),
+                                              scale=scale,
+                                              fsdpa_op=self._fsdpa_apply(),
+                                              is_causal=False,
+                                              attn_bias=bias)
+        torch.hpu.synchronize()
+        return out, num_tiles
+
+    def test_qtiling_fixes_nan_at_overflow_size(self):
+        """Regression: with the flag ON, a *real* overflow-sized bias plane is finite.
+
+        Untiled, at q_len x kv_len x 2 >= 2**31 bytes the FusedSDPA kernel wraps a
+        signed-int32 byte offset while striding the bias plane, reads garbage, and
+        silently returns NaN/Inf. With the flag ON the query dim is tiled so every
+        plane stays under 2**31 bytes; the output must be fully finite.
+
+        Allocates a ~2 GiB bias plane, so it is HPU-only and comparatively slow.
+        """
+        bs, heads, kv_heads, head_dim = 1, 8, 2, self.HEAD_DIM
+        q_len, kv_len = 8192, 131072  # 8192 * 131072 * 2 == 2**31 bytes exactly
+        assert q_len * kv_len * 2 >= _FSDPA_PLANE_MAX_BYTES
+
+        torch.manual_seed(42)
+        q = torch.randn(bs, heads, q_len, head_dim, dtype=torch.bfloat16, device='hpu') * 3.0
+        k = torch.randn(bs, kv_heads, kv_len, head_dim, dtype=torch.bfloat16, device='hpu')
+        v = torch.randn(bs, kv_heads, kv_len, head_dim, dtype=torch.bfloat16, device='hpu')
+        bias = torch.zeros(bs, 1, q_len, kv_len, dtype=torch.bfloat16, device='hpu')
+        scale = head_dim**-0.5
+
+        # flag ON -> tiled -> every plane < 2**31 bytes -> finite output.
+        tiled, n_on = self._run_fn(q, k, v, bias, scale, enable=True, limit=_FSDPA_PLANE_MAX_BYTES)
+        assert n_on > 1, f"overflow-sized plane should tile, got num_q_tiles={n_on}"
+        assert torch.isfinite(tiled).all(), \
+            f"q-tiling still produced non-finite output (tiles={n_on})"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/test_fsdpa_slicing.py
+++ b/tests/unit_tests/test_fsdpa_slicing.py
@@ -22,7 +22,7 @@ from vllm_gaudi.extension.bucketing.padding_aware import PaddingAwareBucketingSt
 from vllm_gaudi.extension.config import Config, Eq, All, Disabled, Kernel, Value, Env, boolean
 from vllm_gaudi.extension.features import get_user_flags, get_features
 from vllm_gaudi.extension.ops import (_fsdpa_prompt_attention, _fsdpa_num_q_tiles, _FSDPA_PLANE_MAX_BYTES,
-                                       dynamic_quant)
+                                      dynamic_quant)
 from vllm_gaudi.extension.utils import (
     ModuleFP8FusedSDPA,
     ModuleFusedSDPA,

--- a/vllm_gaudi/extension/features.py
+++ b/vllm_gaudi/extension/features.py
@@ -61,6 +61,9 @@ def get_user_flags():
         Env('VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD', int),
         Env('VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE', int),
         Env('VLLM_HPU_FSDPA_SLICE_WITH_GRAPH_BREAKS', boolean),
+
+        # FusedSDPA query tiling flags
+        Env('VLLM_HPU_FSDPA_Q_TILE_ENABLE', boolean),
     ]
     return to_dict(flags)
 
@@ -126,5 +129,9 @@ def get_features():
                   Kernel(fsdpa)),
               env_var='VLLM_HPU_FSDPA_SLICE_ENABLED',
               env_var_type=boolean),
+        # Splits the query dim of prompt attention so no per-call attn_bias reaches 2**31 bytes,
+        # which FusedSDPA cannot index (it silently returns NaN). Off by default: only long
+        # contexts with a wide context bucket can hit the limit.
+        Value('enable_fsdpa_q_tiling', False, env_var='VLLM_HPU_FSDPA_Q_TILE_ENABLE', env_var_type=boolean),
     ]
     return split_values_and_flags(features)

--- a/vllm_gaudi/extension/features.py
+++ b/vllm_gaudi/extension/features.py
@@ -61,6 +61,9 @@ def get_user_flags():
         Env('VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD', int),
         Env('VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE', int),
         Env('VLLM_HPU_FSDPA_SLICE_WITH_GRAPH_BREAKS', boolean),
+
+        # FusedSDPA query tiling flags
+        Env('VLLM_HPU_FSDPA_Q_TILE_ENABLE', boolean),
     ]
     return to_dict(flags)
 
@@ -128,5 +131,9 @@ def get_features():
                   Kernel(fsdpa)),
               env_var='VLLM_HPU_FSDPA_SLICE_ENABLED',
               env_var_type=boolean),
+        # Splits the query dim of prompt attention so no per-call attn_bias reaches 2**31 bytes,
+        # which FusedSDPA cannot index (it silently returns NaN). Off by default: only long
+        # contexts with a wide context bucket can hit the limit.
+        Value('enable_fsdpa_q_tiling', False, env_var='VLLM_HPU_FSDPA_Q_TILE_ENABLE', env_var_type=boolean),
     ]
     return split_values_and_flags(features)

--- a/vllm_gaudi/extension/ops.py
+++ b/vllm_gaudi/extension/ops.py
@@ -391,6 +391,53 @@ def _naive_prompt_attention(query: torch.Tensor,
 
 USING_INC = os.getenv("QUANT_CONFIG") is not None
 
+# FusedSDPA indexes each q x kv plane of the attention bias with a 32-bit signed byte offset, so at
+# 2**31 bytes the offset wraps and the forward silently returns NaN instead of raising. Measured on
+# Gaudi3: a [1, 1, 8192, 130944] bf16 plane (2,145,386,496 B) is clean, [1, 1, 8192, 131072] (2**31 B)
+# is not. The offset resets per plane, so batch size does not enter (a bs=2 tensor of 2.02 GiB whose
+# planes are 1.01 GiB each runs clean).
+_FSDPA_PLANE_MAX_BYTES = 2**31
+
+_fsdpa_q_tiling_logged: set = set()
+
+
+def _fsdpa_num_q_tiles(attn_bias: Optional[torch.Tensor], plane_elem_bytes: Optional[int] = None) -> int:
+    """Number of query tiles that keep each indexed q x kv plane under _FSDPA_PLANE_MAX_BYTES.
+
+    Returns 1 (no tiling) when enable_fsdpa_q_tiling is off or the plane already fits, so shapes
+    that are not at risk keep taking a byte-identical path through the kernel.
+
+    plane_elem_bytes is the size of one element of the plane the kernel strides through; it defaults
+    to the bias's own element size. See the call site for why the fp32 path passes 4.
+    """
+    if attn_bias is None or not get_config().enable_fsdpa_q_tiling:
+        return 1
+    if plane_elem_bytes is None:
+        plane_elem_bytes = attn_bias.element_size()
+    # bias is [bs, 1, q_len, kv_len]; the kernel indexes one q_len x kv_len plane at a time.
+    q_len = attn_bias.size(-2)
+    kv_len = attn_bias.size(-1)
+    plane_bytes = q_len * kv_len * plane_elem_bytes
+    if plane_bytes < _FSDPA_PLANE_MAX_BYTES or q_len <= 1:
+        return 1
+    # tiling splits q_len, so the cost per query row is fixed.
+    row_bytes = plane_bytes // q_len
+    num_tiles = math.ceil(plane_bytes / _FSDPA_PLANE_MAX_BYTES)
+    # Guard the rounding: ceil(q_len / num_tiles) can exceed the even split, so confirm the
+    # resulting tile really fits and grow the count if it does not.
+    while num_tiles < q_len and math.ceil(q_len / num_tiles) * row_bytes >= _FSDPA_PLANE_MAX_BYTES:
+        num_tiles += 1
+
+    key = (tuple(attn_bias.shape), plane_elem_bytes, num_tiles)
+    if key not in _fsdpa_q_tiling_logged:
+        _fsdpa_q_tiling_logged.add(key)
+        logger.warning(
+            "Q-tiling FusedSDPA prompt attention: bias %s indexed plane is %d bytes (%dB/elem, "
+            ">= %d, the 32-bit FusedSDPA limit); splitting the query dim into %d tiles of <= %d rows.",
+            tuple(attn_bias.shape), plane_bytes, plane_elem_bytes, _FSDPA_PLANE_MAX_BYTES, num_tiles,
+            math.ceil(q_len / num_tiles))
+    return num_tiles
+
 
 def _fsdpa_prompt_attention(query: torch.Tensor,
                             key: torch.Tensor,
@@ -421,18 +468,47 @@ def _fsdpa_prompt_attention(query: torch.Tensor,
         is_causal = False
         valid_seq_lengths = None
 
-    args = [
-        query, key, value, attn_bias, 0.0, is_causal, scale, softmax_mode, recompute_mode, valid_seq_lengths,
-        padding_side
-    ]
-    if sinks is not None:
-        args += [window_size] if window_size else [None]
+    def call_fsdpa(q, bias):
+        args = [
+            q, key, value, bias, 0.0, is_causal, scale, softmax_mode, recompute_mode, valid_seq_lengths, padding_side
+        ]
+        if sinks is not None:
+            args += [window_size] if window_size else [None]
+        else:
+            args += [window_size] if window_size else []
+        # use sinks in fsdpa
+        if sinks is not None:
+            args += [sinks]
+        return fsdpa_op(*args)
+
+    # FusedSDPA upcasts the score/mask plane to fp32 when softmax is fp32 or an input is fp32, so
+    # the indexed plane is 4 B/elem there even though a bf16 bias is 2 B/elem. Precautionary: fp32
+    # softmax was not observed to overflow at a 1.06 GiB bf16 bias, so this only ever over-tiles.
+    plane_elem_bytes = 4 if (softmax_mode == 'fp32' or query.dtype == torch.float32 or
+                             (attn_bias is not None and attn_bias.dtype == torch.float32)) else 2
+    num_q_tiles = _fsdpa_num_q_tiles(attn_bias, plane_elem_bytes)
+    if num_q_tiles == 1:
+        attn_weights = call_fsdpa(query, attn_bias)
     else:
-        args += [window_size] if window_size else []
-    # use sinks in fsdpa
-    if sinks is not None:
-        args += [sinks]
-    attn_weights = fsdpa_op(*args)
+        # Attention rows are independent: a query tile attends to the full K/V, so its softmax is
+        # already complete and the tiles simply concatenate. No online rescaling is needed, unlike
+        # the KV chunking done by SlicedFusedSDPA. The explicit bias carries the causal structure,
+        # so each tile only needs the matching rows of it.
+        q_len = query.size(-2)
+        tile = math.ceil(q_len / num_q_tiles)
+        # Graph breaks between tiles are only safe in lazy mode. Mirrors
+        # SlicedFusedSDPABase._setup_slicing: in eager/compile mode a mark_step inside the
+        # attention op can trip the Synapse compiler, so there the tiles stay in one graph.
+        break_graph = htorch.utils.internal.is_lazy()
+        tiles = []
+        for start in range(0, q_len, tile):
+            end = min(start + tile, q_len)
+            # Views, not copies: the bias slice is already contiguous (the trailing dim is whole),
+            # and the untiled path likewise hands the kernel a transposed, non-contiguous query.
+            tiles.append(call_fsdpa(query[..., start:end, :], attn_bias[..., start:end, :]))
+            if break_graph:
+                htcore.mark_step()
+        attn_weights = torch.cat(tiles, dim=-2)
 
     attn_weights = attn_weights.transpose(1, 2)
     if sinks is not None:

--- a/vllm_gaudi/extension/ops.py
+++ b/vllm_gaudi/extension/ops.py
@@ -398,22 +398,21 @@ USING_INC = os.getenv("QUANT_CONFIG") is not None
 # planes are 1.01 GiB each runs clean).
 _FSDPA_PLANE_MAX_BYTES = 2**31
 
-_fsdpa_q_tiling_logged: set = set()
 
-
-def _fsdpa_num_q_tiles(attn_bias: Optional[torch.Tensor], plane_elem_bytes: Optional[int] = None) -> int:
+def _fsdpa_num_q_tiles(attn_bias: Optional[torch.Tensor]) -> int:
     """Number of query tiles that keep each indexed q x kv plane under _FSDPA_PLANE_MAX_BYTES.
 
     Returns 1 (no tiling) when enable_fsdpa_q_tiling is off or the plane already fits, so shapes
     that are not at risk keep taking a byte-identical path through the kernel.
 
-    plane_elem_bytes is the size of one element of the plane the kernel strides through; it defaults
-    to the bias's own element size. See the call site for why the fp32 path passes 4.
+    The overflow is a signed-int32 byte offset the kernel forms while striding the bias plane, so
+    the limit is byte-based on the bias's own element size and independent of the softmax precision
+    (fp32 softmax upcasts internally but still strides the 2 B/elem bias -- confirmed no overflow at
+    a 1.06 GiB bf16 plane under fp32 softmax).
     """
     if attn_bias is None or not get_config().enable_fsdpa_q_tiling:
         return 1
-    if plane_elem_bytes is None:
-        plane_elem_bytes = attn_bias.element_size()
+    plane_elem_bytes = attn_bias.element_size()
     # bias is [bs, 1, q_len, kv_len]; the kernel indexes one q_len x kv_len plane at a time.
     q_len = attn_bias.size(-2)
     kv_len = attn_bias.size(-1)
@@ -428,14 +427,11 @@ def _fsdpa_num_q_tiles(attn_bias: Optional[torch.Tensor], plane_elem_bytes: Opti
     while num_tiles < q_len and math.ceil(q_len / num_tiles) * row_bytes >= _FSDPA_PLANE_MAX_BYTES:
         num_tiles += 1
 
-    key = (tuple(attn_bias.shape), plane_elem_bytes, num_tiles)
-    if key not in _fsdpa_q_tiling_logged:
-        _fsdpa_q_tiling_logged.add(key)
-        logger.warning(
-            "Q-tiling FusedSDPA prompt attention: bias %s indexed plane is %d bytes (%dB/elem, "
-            ">= %d, the 32-bit FusedSDPA limit); splitting the query dim into %d tiles of <= %d rows.",
-            tuple(attn_bias.shape), plane_bytes, plane_elem_bytes, _FSDPA_PLANE_MAX_BYTES, num_tiles,
-            math.ceil(q_len / num_tiles))
+    # logger.warning(
+    #     "Q-tiling FusedSDPA prompt attention: bias %s indexed plane is %d bytes (%dB/elem, "
+    #     ">= %d, the 32-bit FusedSDPA limit); splitting the query dim into %d tiles.",
+    #     tuple(attn_bias.shape), plane_bytes, plane_elem_bytes, _FSDPA_PLANE_MAX_BYTES, num_tiles)
+
     return num_tiles
 
 
@@ -481,12 +477,10 @@ def _fsdpa_prompt_attention(query: torch.Tensor,
             args += [sinks]
         return fsdpa_op(*args)
 
-    # FusedSDPA upcasts the score/mask plane to fp32 when softmax is fp32 or an input is fp32, so
-    # the indexed plane is 4 B/elem there even though a bf16 bias is 2 B/elem. Precautionary: fp32
-    # softmax was not observed to overflow at a 1.06 GiB bf16 bias, so this only ever over-tiles.
-    plane_elem_bytes = 4 if (softmax_mode == 'fp32' or query.dtype == torch.float32 or
-                             (attn_bias is not None and attn_bias.dtype == torch.float32)) else 2
-    num_q_tiles = _fsdpa_num_q_tiles(attn_bias, plane_elem_bytes)
+    # The kernel overflows a signed-int32 *byte* offset while striding the bias plane, so the limit
+    # tracks the bias element size regardless of softmax precision (fp32 softmax upcasts internally
+    # but still strides the 2 B/elem bias). No fp32 special-casing needed.
+    num_q_tiles = _fsdpa_num_q_tiles(attn_bias)
     if num_q_tiles == 1:
         attn_weights = call_fsdpa(query, attn_bias)
     else:
@@ -496,18 +490,12 @@ def _fsdpa_prompt_attention(query: torch.Tensor,
         # so each tile only needs the matching rows of it.
         q_len = query.size(-2)
         tile = math.ceil(q_len / num_q_tiles)
-        # Graph breaks between tiles are only safe in lazy mode. Mirrors
-        # SlicedFusedSDPABase._setup_slicing: in eager/compile mode a mark_step inside the
-        # attention op can trip the Synapse compiler, so there the tiles stay in one graph.
-        break_graph = htorch.utils.internal.is_lazy()
         tiles = []
         for start in range(0, q_len, tile):
             end = min(start + tile, q_len)
             # Views, not copies: the bias slice is already contiguous (the trailing dim is whole),
             # and the untiled path likewise hands the kernel a transposed, non-contiguous query.
             tiles.append(call_fsdpa(query[..., start:end, :], attn_bias[..., start:end, :]))
-            if break_graph:
-                htcore.mark_step()
         attn_weights = torch.cat(tiles, dim=-2)
 
     attn_weights = attn_weights.transpose(1, 2)


### PR DESCRIPTION
## Problem

FusedSDPA indexes each `q × kv` plane of the prompt-attention bias with a **32-bit
signed byte offset**. Once a single plane reaches `2**31` bytes the offset wraps to
negative, the kernel reads a garbage address, and the forward **silently returns NaN**
(no exception). Long contexts with a wide context bucket hit this — e.g. Gemma-4 E4B-it
at 128k on the full-attention layers that builds a dense `[1, 1, 8192, 131072]` bf16 bias (exactly `2**31` bytes).

## Fix

Split the **query dimension** of prompt attention into the smallest number of tiles that
keeps every per-call bias plane under `2**31` bytes. Attention rows are independent —
each query tile attends the full K/V, so its softmax is already complete and the tiles
simply `cat` on the query dim. **No online-softmax rescaling** is needed (unlike the KV
chunking in `SlicedFusedSDPA`), so the output is bit-for-bit the untiled result apart
from the split itself.

Gated behind a new feature flag, **off by default**:

| Flag | Default | Effect |
| --- | --- | --- |
| `VLLM_HPU_FSDPA_Q_TILE_ENABLE` | `false` | Tile the query dim when the prompt bias would reach `2**31` bytes. |

Shapes whose bias already fits below the limit take a **byte-identical** path through the
kernel (`num_q_tiles == 1`), so nothing changes for workloads that don't need it. The cap
is per `q × kv` plane, not the whole batched tensor — the offset resets per plane, so
batch size does not enter (confirmed on Gaudi3).

## Byte-based limit, dtype-agnostic (no fp32 special-casing)

The overflow is a signed-int32 **byte** offset formed while striding the bias, so the
limit tracks the bias element size and is **independent of softmax precision** — fp32
softmax upcasts internally but still strides the 2 B/elem bias. This is corroborated by
the GC Complex GUID large-tensor check (`isLargeSizeTensor`), which on Gaudi2/3 is
element-based and dtype-agnostic. 

## Validation (LongBench, Gemma-4 E4B-it, TP1, `--limit 100`)

| Config | LongBench | Note |
| --- | --- | --- |
| baseline (no contiguous PA) | 0.4338 | reference |
| contiguous PA | **0.0119** | known-bad: overflow → NaN |
| contiguous PA + Q-tiling | **0.4383** | restored to baseline |
| baseline + Q-tiling | 0.4328 | no-op on the healthy path (within noise) |

Perf is neutral (tiling never fires at the benchmark's input length): E4B clean
back-to-back pair 453.6 tok/s (off) vs 454.6 tok/s (on); 26B and 31B within ±2%.

## Testing

Reproduced the overflow and verified the fix with `reproduce_fusedsdpa_overflow.py`,
which builds a long prompt, runs prefill with `enforce_eager=True`, and inspects the
output logprobs for `NaN` (the corruption signature).

**Result:** without the flag these cases return all-invalid (`NaN`) output; with
`VLLM_HPU_FSDPA_Q_TILE_ENABLE=1` they return correct output. The warning log confirms
tiling engaged and that every resulting tile drops below the `2**31`-byte limit:

| Model / run | bias plane (`1,1,q,kv`) | plane bytes | → tiles | per-tile bytes |
| --- | --- | --- | --- | --- |
| E4B-it, TP1, 60k tok  | `8192 × 131072`  | 2.00 GiB (`2**31`) | **2** (≤4096 rows) | 1.00 GiB |
| 31B-it, TP4, 180k tok | `8192 × 262144`  | 4.00 GiB (`2**32`) | **3** (≤2731 rows) | 1.33 GiB |
| 31B-it, TP4, 180k tok | `4096 × 262144`  | 2.00 GiB (`2**31`) | **2** (≤2048 rows) | 1.00 GiB |


# E4B, TP1 — 8192 x 131072 bias -> 2 tiles
# 31B, TP4 — 8192 x 262144 (-> 3 tiles) and 4096 x 262144 (-> 2 tiles) biases

## Files

- `vllm_gaudi/extension/ops.py` — `_fsdpa_num_q_tiles` + query-tiling path in `_fsdpa_prompt_attention`
- `vllm_gaudi/extension/features.py` — `enable_fsdpa_q_tiling` / `VLLM_HPU_FSDPA_Q_TILE_ENABLE`
- `docs/configuration/env_variables.md` — flag documentation

