### PR TITLE
ci(hourly): fix adaptive gate stuck in perpetual back-off after skipped ticks

### DIFF
--- a/.github/workflows/hourly-ci.yaml
+++ b/.github/workflows/hourly-ci.yaml
@@ -56,27 +56,34 @@ jobs:
             exit 0
           fi
 
-          # Look at recent completed runs of THIS workflow on main and find the most
-          # recent *real* run: one where the unit-test job actually executed. This
-          # deliberately ignores earlier "backed-off" ticks (whose test jobs were
-          # skipped and whose overall conclusion is misleadingly 'success').
+          # Only *scheduled* runs define the "hourly" health; manual dispatches
+          # always run (handled above) and must not skew the cadence.
           RUNS=$(curl -fsSL -H "$AUTH" -H "$ACCEPT" \
-            "$API/actions/workflows/hourly-ci.yaml/runs?branch=main&status=completed&per_page=20")
+            "$API/actions/workflows/hourly-ci.yaml/runs?branch=main&event=schedule&status=completed&per_page=30")
 
+          # Find the most recent *real* run: one that actually executed the pipeline,
+          # i.e. run_unit_tests finished as 'success' or 'failure'. This must ignore
+          # both skipped ticks (run_unit_tests=skipped) AND backed-off ticks we
+          # cancel (run_unit_tests=cancelled). Matching only "!= skipped" was the bug:
+          # a cancelled tick looked like a failing "real" run, so the gate saw a fresh
+          # non-success run every 8h and backed off forever.
           LAST_CONCLUSION=""
           LAST_STARTED=""
           for RUN_ID in $(echo "$RUNS" | jq -r '.workflow_runs[].id'); do
             JOBS=$(curl -fsSL -H "$AUTH" -H "$ACCEPT" \
               "$API/actions/runs/$RUN_ID/jobs?per_page=100")
-            # First run_unit_tests conclusion, or empty if the job is absent/null.
-            # Done inside jq (no 'head', which would SIGPIPE under 'set -o pipefail').
+            # run_unit_tests conclusion (empty if the job is absent/null). Selected
+            # inside jq (no 'head', which would SIGPIPE under 'set -o pipefail').
             UT=$(echo "$JOBS" | jq -r 'first(.jobs[] | select(.name=="run_unit_tests") | .conclusion) // empty')
-            if [ -n "$UT" ] && [ "$UT" != "skipped" ]; then
-              LAST_CONCLUSION=$(echo "$RUNS" | jq -r ".workflow_runs[] | select(.id==$RUN_ID) | .conclusion")
-              # Prefer run_started_at (when the run actually began); fall back to created_at.
-              LAST_STARTED=$(echo "$RUNS" | jq -r ".workflow_runs[] | select(.id==$RUN_ID) | (.run_started_at // .created_at)")
-              break
-            fi
+            case "$UT" in
+              success|failure)
+                # A run that actually produced a pass/fail verdict.
+                LAST_CONCLUSION=$(echo "$RUNS" | jq -r ".workflow_runs[] | select(.id==$RUN_ID) | .conclusion")
+                # Prefer run_started_at (when the run actually began); fall back to created_at.
+                LAST_STARTED=$(echo "$RUNS" | jq -r ".workflow_runs[] | select(.id==$RUN_ID) | (.run_started_at // .created_at)")
+                break
+                ;;
+            esac
           done
 
           if [ -z "$LAST_CONCLUSION" ]; then


### PR DESCRIPTION
## Problem

Production runs of *Hourly Commit Check and Tests* went into a run of consecutive skips (last several ticks completed in 11–21s and never ran the pipeline), and the skip marks were inconsistent — some green **success**, some grey **cancelled**.

Two distinct defects:

1. **Perpetual back-off (the "21–11s skip streak").** The gate finds the "last real run" by scanning previous runs and taking the first whose `run_unit_tests` conclusion is *not* `skipped`. But a backed-off tick **cancels itself** (PR #1747), so its `run_unit_tests` conclusion is `cancelled` — which passed the `!= skipped` filter and was treated as a *failing real run*. So every 8h the gate saw a fresh non-`success` run, computed "<23h elapsed", and skipped again. It could never climb out of 24h back-off.

2. **Green skips vs cancelled skips.** Older skipped ticks predate the cancel-mark change (#1747) and show as green `success`; newer ones show as `cancelled`. Both are non-real and must be ignored when judging health.

## Fix

- **Whitelist real runs:** a run counts only when `run_unit_tests` finished as `success` **or** `failure`. This naturally excludes *both* `skipped` ticks and the `cancelled` back-off ticks — regardless of the run's misleading overall conclusion.
- **Scope health to scheduled runs:** the query now filters `event=schedule`, so only the actual hourly cron defines the cadence. Manual `workflow_dispatch` runs always run (handled earlier) and no longer skew the decision — implementing "skip only after the last hourly failed".

Net behavior:
- Real full run → ends **pass/fail** (never cancelled).
- Skipped tick → **cancelled** (grey), never green success.
- Skip only when the **last scheduled hourly** run actually failed, and only until ~24h have elapsed — so at most ~2 consecutive skips, not an unbounded streak.

Cancel step, `last_started` diff-window output, and the elapsed-time back-off logic are unchanged.