### PR TITLE
[Bugfix][HPU] Fix Kimi-K2.5 vision 2D-RoPE warmup crash after upstream fused-kernel inlining (#50400)

### DIFF
--- a/vllm_gaudi/models/kimi_k25_vit.py
+++ b/vllm_gaudi/models/kimi_k25_vit.py
@@ -5,14 +5,25 @@ Two independent HPU incompatibilities in the shared vision tower are fixed by
 swapping the offending callables in the upstream module at import time (the same
 approach ``qwen3_5.py`` uses for GDN attention):
 
-1. **complex-dtype 2D-RoPE** — upstream ``apply_rope`` and
-   ``Rope2DPosEmbRepeated`` build the rotary embedding with ``torch.polar`` /
-   ``view_as_complex`` (``complex64``). HPU has no complex-dtype support
-   ("Complex datatype is not supported on HPU device"), so the ``freqs_cis``
-   buffer is stored as a real ``(..., head_dim/2, 2)`` (cos, sin) tensor and the
-   rotation is done with real arithmetic —
+1. **complex-dtype 2D-RoPE** — ``Rope2DPosEmbRepeated`` builds the rotary
+   embedding with ``torch.polar`` / ``view_as_complex`` (``complex64``). HPU has
+   no complex-dtype support ("Complex datatype is not supported on HPU device"),
+   so the ``freqs_cis`` buffer is stored as a real ``(..., head_dim/2, 2)``
+   (cos, sin) tensor and the rotation is done with real arithmetic —
    ``(a + i b)(cos + i sin) = (a cos - b sin) + i(a sin + b cos)`` — which is
    numerically identical to the complex path.
+
+   Upstream vllm ``c8de519917`` ("[Kernel][Kimi] fused vision q/k roper kernel",
+   #50400) removed the free ``apply_rope`` function and inlined its logic into
+   ``MoonViTEncoderLayer.attention_qkvpacked``, which now assumes a ``complex64``
+   ``freqs_cis`` and reads ``rope_freqs_cis.real`` / ``.imag`` after a
+   ``_apply_rope_input_validation`` that asserts the complex layout. On HPU the
+   real ``(..., head_dim/2, 2)`` buffer makes that validation fail
+   (``x.ndim == freqs_cis.ndim + 1`` -> ``3 == 4``) and ``.real`` / ``.imag`` are
+   unavailable on a real tensor. We therefore replace the whole
+   ``attention_qkvpacked`` method with a real-arithmetic equivalent that reads
+   ``cos = freqs_cis[..., 0]`` / ``sin = freqs_cis[..., 1]`` and feeds the same
+   ``ApplyRotaryEmb`` (is_neox_style=False) kernel the method already builds.
 
 2. **Inductor-compiled ``get_rope_shape``** — upstream wraps it in a bare
    ``@torch.compile`` whose default Inductor backend has no 'hpu' device
@@ -27,12 +38,14 @@ import torch.nn.functional as F
 import vllm.model_executor.models.kimi_k25_vit as _vit
 
 
-def apply_rope(xq: torch.Tensor, xk: torch.Tensor, freqs_cis: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-    """Real-valued replacement for ``kimi_k25_vit.apply_rope``.
+def _legacy_apply_rope(xq: torch.Tensor, xk: torch.Tensor,
+                       freqs_cis: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Real-valued replacement for the pre-#50400 free ``kimi_k25_vit.apply_rope``.
 
-    ``freqs_cis`` is the real ``(..., head_dim/2, 2)`` (cos, sin) tensor produced
-    by the patched ``_precompute_freqs_cis``; the rotation uses real arithmetic
-    instead of complex multiply (HPU has no complex dtype).
+    Kept as a fallback for upstreams that still expose ``apply_rope`` as a module
+    function. ``freqs_cis`` is the real ``(..., head_dim/2, 2)`` (cos, sin) tensor
+    produced by the patched ``_precompute_freqs_cis``; the rotation uses real
+    arithmetic instead of complex multiply (HPU has no complex dtype).
     """
     freqs_cis = freqs_cis.unsqueeze(-3)  # ..., 1, head_dim/2, 2  (broadcast over heads)
     cos = freqs_cis[..., 0]
@@ -46,6 +59,61 @@ def apply_rope(xq: torch.Tensor, xk: torch.Tensor, freqs_cis: torch.Tensor) -> t
     xq_out = torch.stack([xq_r * cos - xq_i * sin, xq_r * sin + xq_i * cos], dim=-1).flatten(-2)
     xk_out = torch.stack([xk_r * cos - xk_i * sin, xk_r * sin + xk_i * cos], dim=-1).flatten(-2)
     return xq_out.type_as(xq), xk_out.type_as(xk)
+
+
+def attention_qkvpacked(
+    self,
+    x: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    rope_freqs_cis: torch.Tensor,
+    max_seqlen: torch.Tensor | None = None,
+    sequence_lengths: torch.Tensor | None = None,
+):
+    """Real-valued replacement for ``MoonViTEncoderLayer.attention_qkvpacked``.
+
+    Same as upstream except the 2D-RoPE step: ``rope_freqs_cis`` is the real
+    ``(seqlen, head_dim/2, 2)`` (cos, sin) tensor produced by the patched
+    ``_precompute_freqs_cis`` / ``get_freqs_cis`` (HPU has no complex dtype), so
+    we skip the complex-only ``_apply_rope_input_validation`` and read
+    ``cos``/``sin`` from the trailing axis instead of ``.real`` / ``.imag``. The
+    same ``self.apply_rotary_emb`` (``ApplyRotaryEmb(is_neox_style=False)``) the
+    upstream ``__init__`` already builds consumes ``cos``/``sin`` of shape
+    ``(seqlen, head_dim/2)`` — identical to the complex path's ``.real``/``.imag``
+    (both carry the interleaved ``[x0, y0, x1, y1, ...]`` component ordering).
+    """
+    seq_length = x.size(0)
+    xqkv, _ = self.wqkv(x)
+
+    qkv_shape = xqkv.size()[:-1] + (
+        3,
+        self.num_attention_heads_per_partition,
+        self.hidden_size_per_attention_head,
+    )
+    # xqkv: (seqlen, 3, nheads, headdim)
+    xqkv = xqkv.view(*qkv_shape)
+    xq, xk, xv = torch.unbind(xqkv, dim=-3)
+
+    rope_cos = rope_freqs_cis[..., 0].contiguous()  # (seqlen, head_dim/2)
+    rope_sin = rope_freqs_cis[..., 1].contiguous()
+    xq = self.apply_rotary_emb(xq, rope_cos, rope_sin)
+    xk = self.apply_rotary_emb(xk, rope_cos, rope_sin)
+
+    if max_seqlen is None:
+        max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max()
+    attn_out = self.attn(
+        xq.unsqueeze(0),
+        xk.unsqueeze(0),
+        xv.unsqueeze(0),
+        cu_seqlens=cu_seqlens,
+        max_seqlen=max_seqlen,
+        sequence_lengths=sequence_lengths,
+    )
+    attn_out = attn_out.reshape(
+        seq_length,
+        self.num_attention_heads_per_partition * self.hidden_size_per_attention_head,
+    )
+    attn_out, _ = self.wo(attn_out)
+    return attn_out
 
 
 def _precompute_freqs_cis(self, device: torch.device) -> torch.Tensor:
@@ -120,8 +188,17 @@ def get_rope_shape(org, interpolation_mode, shape):
 # Swap the complex-dtype / Inductor-compiled callables in the upstream module so
 # the Kimi-K2.5 vision tower runs on HPU.  Guarded so an upstream rewrite (or a
 # renamed symbol) makes this a no-op rather than an error.
-if hasattr(_vit, "apply_rope"):
-    _vit.apply_rope = apply_rope
+#
+# Upstream historically exposed a free ``apply_rope`` function that we replaced;
+# vllm #50400 inlined it into ``MoonViTEncoderLayer.attention_qkvpacked`` and
+# switched to ``ApplyRotaryEmb`` + ``.real``/``.imag`` on a complex ``freqs_cis``.
+# Patch whichever shape the installed upstream has: prefer the method swap, and
+# fall back to the free-function swap for older upstreams.
+_layer_cls = getattr(_vit, "MoonViTEncoderLayer", None)
+if _layer_cls is not None and hasattr(_layer_cls, "attention_qkvpacked"):
+    _layer_cls.attention_qkvpacked = attention_qkvpacked
+elif hasattr(_vit, "apply_rope"):
+    _vit.apply_rope = _legacy_apply_rope
 
 _rope_cls = getattr(_vit, "Rope2DPosEmbRepeated", None)
 if _rope_cls is not None:


### PR DESCRIPTION
## Problem

The Kimi-K2.5 vision tower crashes during HPU warmup, killing engine startup
(all TP workers die, `EngineCore failed to start`):
```
File ".../vllm/model_executor/models/kimi_k25_vit.py", line 45, in _apply_rope_input_validation
assert x.ndim == freqs_cis.ndim + 1, (x.shape, freqs_cis.shape)
AssertionError: (torch.Size([2232, 2, 72]), torch.Size([2232, 36, 2]))
```

This worked up to vllm `b05ae5dc` / vllm-gaudi `a68090c3` and regressed since.

## Root cause

An **upstream vllm change**, not a new HPU limitation.

HPU has no complex-dtype support, so `vllm_gaudi/models/kimi_k25_vit.py` already
overrides `Rope2DPosEmbRepeated` to store `freqs_cis` as a real
`(..., head_dim/2, 2)` (cos, sin) tensor, and it used to swap the module-level
`apply_rope` function for a real-arithmetic version.

vllm **c8de519917** — *"[Kernel][Kimi] fused vision q/k roper kernel"* (#50400) —
removed the free `apply_rope` function and inlined its logic into
`MoonViTEncoderLayer.attention_qkvpacked`, which now:
- calls the complex-only `_apply_rope_input_validation`, and
- reads `rope_freqs_cis.real` / `.imag` before an `ApplyRotaryEmb` kernel.

As a result our `_vit.apply_rope = ...` swap silently became a no-op (the symbol
no longer exists), while the `_precompute_freqs_cis` / `get_freqs_cis` overrides
kept producing a **real** buffer. The real tensor then flows into the
complex-assuming inlined code:
- `x.ndim (3) == freqs_cis.ndim (3) + 1` → `3 == 4` → **AssertionError**;
- `.real` / `.imag` don't exist on a real tensor even if the assert is bypassed.

## Fix

Monkeypatch `MoonViTEncoderLayer.attention_qkvpacked` with a real-arithmetic
equivalent (option A): read `cos = rope_freqs_cis[..., 0]` /
`sin = rope_freqs_cis[..., 1]` and feed the **same**
`ApplyRotaryEmb(is_neox_style=False, enable_fp32_compute=True)` instance the
upstream `__init__` already constructs. The method body is otherwise identical
to upstream.

The pre-#50400 free-function swap is kept as `_legacy_apply_rope` behind a guard
so older upstreams still work.

## Correctness / no regression

- `freqs_cis = polar(1, θ) = cos θ + i·sin θ`, so upstream's `.real` / `.imag`
  are exactly `cos θ` / `sin θ` — identical to our `[..., 0]` / `[..., 1]`.
- Same kernel (`ApplyRotaryEmb`, `is_neox_style=False`), same fp32 compute, same
  interleaved `[x0, y0, x1, y1, ...]` component ordering as the previous HPU
  known-good path.
- No performance impact: keeps the #50400 fused kernel; only adds two
  `(seqlen, dim/2)` slice+contiguous ops.