### PR TITLE
ci(hourly): mark backed-off ticks red (fail the gate) instead of cancelling

### DIFF
--- a/.github/workflows/hourly-ci.yaml
+++ b/.github/workflows/hourly-ci.yaml
@@ -28,9 +28,7 @@ jobs:
     # Runs on a cheap GitHub-hosted runner so a "skip" never locks an HPU runner.
     runs-on: ubuntu-latest
     permissions:
-      # read: query this workflow's previous runs and their jobs;
-      # write: self-cancel the run on a skipped (backed-off) tick.
-      actions: write
+      actions: read # Required to query this workflow's previous runs and their jobs
     outputs:
       should_run: ${{ steps.decide.outputs.should_run }}
       # ISO-8601 start time of the last real run; empty on bootstrap/manual runs.
@@ -62,11 +60,12 @@ jobs:
             "$API/actions/workflows/hourly-ci.yaml/runs?branch=main&event=schedule&status=completed&per_page=30")
 
           # Find the most recent *real* run: one that actually executed the pipeline,
-          # i.e. run_unit_tests finished as 'success' or 'failure'. This must ignore
-          # both skipped ticks (run_unit_tests=skipped) AND backed-off ticks we
-          # cancel (run_unit_tests=cancelled). Matching only "!= skipped" was the bug:
-          # a cancelled tick looked like a failing "real" run, so the gate saw a fresh
-          # non-success run every 8h and backed off forever.
+          # i.e. run_unit_tests finished as 'success' or 'failure'. A backed-off tick
+          # only fails this cheap 'gate' job, so its run_unit_tests never starts and
+          # stays 'skipped' -- which this whitelist ignores. That is the whole point of
+          # failing the gate (rather than cancelling the run): the run is marked red in
+          # the UI, but the health signal we read here is left untouched, so the gate
+          # never mistakes its own skip for a failing pipeline and loops forever.
           LAST_CONCLUSION=""
           LAST_STARTED=""
           for RUN_ID in $(echo "$RUNS" | jq -r '.workflow_runs[].id'); do
@@ -117,29 +116,16 @@ jobs:
             echo "should_run=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Cancel this run on a skipped tick
-        # On a backed-off tick, cancel the run so it shows as 'cancelled' (grey)
-        # in the Actions UI instead of a misleading green 'success'.
+      - name: Fail this run on a skipped tick
+        # On a backed-off tick, fail this cheap gate job so the whole run is marked
+        # red (failed) in the Actions UI instead of a misleading green 'success'.
+        # Failing the gate (rather than cancelling the run) leaves run_unit_tests as
+        # 'skipped', so the health query above never mistakes this skip for a real
+        # failing run. The 'should_run=false' output is already set, so downstream
+        # jobs skip regardless of this failure.
         if: steps.decide.outputs.should_run == 'false'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          RUN_ID: ${{ github.run_id }}
         run: |
-          set -euo pipefail
-          echo "Adaptive back-off: cancelling this run so it is marked 'cancelled', not 'success'."
-          curl -fsSL -X POST \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/$REPO/actions/runs/$RUN_ID/cancel"
-          # Cancellation is asynchronous: block so GitHub terminates this job as
-          # 'cancelled' rather than letting the step finish and record 'success'.
-          # If it hasn't taken effect within ~3 min, fail loudly (red beats green).
-          for i in $(seq 1 18); do
-            echo "Waiting for cancellation to take effect... ($i)"
-            sleep 10
-          done
-          echo "::error::Run cancellation did not take effect in time." >&2
+          echo "::notice::Adaptive back-off: skipping this tick (last hourly failed, <23h elapsed). Marking the run as failed (red)."
           exit 1
 
   # JOB 1: (NEW) Discovers an available runner and locks it for all subsequent jobs.


### PR DESCRIPTION
## Background

The adaptive gate on *Hourly Commit Check and Tests* runs the pipeline every 8h when healthy and backs off to every 24h after a failure. A backed-off ("skipped") tick needs a visible mark. We've now tried green (misleading — looks like a pass) and cancelled/grey (fragile — see below). This switches skipped ticks to **red (failed)**.

## Why not cancelled

Cancelling a skipped tick cancels the **whole run**, including `run_unit_tests`. But that job's conclusion is the exact signal the gate reads to judge pipeline health. So a cancelled skip can be mistaken by the next gate for a *real failing run* — that is the root cause of the perpetual-back-off loop we hit earlier. It also required an async cancel-and-wait polling loop and `actions: write`.

## This change

On a backed-off tick, simply **fail the cheap `gate` job** (`exit 1`):

- The whole run is marked **red** in the Actions UI — no misleading green success.
- `run_unit_tests` never starts, so it stays `skipped`. The gate's health query (`run_unit_tests` ∈ {`success`,`failure`}) cleanly ignores it — **the signal the gate depends on is left untouched**, so it can never mistake its own skip for a failing pipeline.
- Downstream jobs already skip via the existing `should_run=false` output.

Removes the self-cancel step, the ~3-min polling loop, and the `actions: write` permission (`read` is sufficient). The adaptive cadence logic (8h on pass / 24h back-off on fail, keyed to scheduled runs only) and the `last_started` commit-diff window are unchanged.

## Behavior

| Situation | Run mark |
|---|---|
| Manual dispatch | pass / fail (always runs) |
| Last scheduled hourly passed | pass / fail (8h cadence) |
| Last scheduled hourly failed, <23h ago | **failed / red** (skipped tick) |
| Last scheduled hourly failed, ≥23h ago | pass / fail (24h back-off tick) |

Note: a red skip is intentionally indistinguishable from a real test failure in the list — chosen deliberately over green/grey.