### PR TITLE
Fix VLLM_PROFILE_DECODE profiling a coarser bucket than requested

### DIFF
--- a/docs/dev_guide/profiling/profiling-prompt-decode.md
+++ b/docs/dev_guide/profiling/profiling-prompt-decode.md
@@ -25,6 +25,20 @@ To execute the profiling, follow these steps:
     VLLM_PT_PROFILE=decode_256_2048_t
     ``` 
 
+    Alternatively, define the scope per phase. These take a comma-separated
+    list and always use HPU graphs, so they must not be combined with
+    `--enforce-eager`:
+
+    ```
+    VLLM_PROFILE_PROMPT=<batch_size>,<query_len>,<ctx_blocks>
+    VLLM_PROFILE_DECODE=<batch_size>,<num_blocks>
+    ```
+
+    `<num_blocks>` is the total block count across the batch, in kernel block
+    units, i.e. `batch_size * ceil(context / block_size)`. The equivalent of the
+    example above is `VLLM_PROFILE_DECODE=256,2048`. When either variable is
+    set, `VLLM_PT_PROFILE` is ignored.
+
 2. Run the inference command with the appropriate profiling flag, as in the following example.
 
     ```bash

--- a/tests/unit_tests/test_bucketing.py
+++ b/tests/unit_tests/test_bucketing.py
@@ -201,6 +201,43 @@ def test_generate_decode_buckets():
     assert all(ctx <= bs * (max_model_len // block_size) for bs, _, ctx in buckets)
 
 
+# --- Explicitly added buckets ---
+
+
+def _manager_with_buckets(prompt_buckets, decode_buckets):
+    manager = HPUBucketingManager.__new__(HPUBucketingManager)
+    manager.initialized = True
+    manager._fallback_max_ctx = 0
+    manager.seed_decode_buckets = None
+    manager.prompt_buckets = list(prompt_buckets)
+    manager.decode_buckets = list(decode_buckets)
+    return manager
+
+
+def test_add_decode_bucket_is_returned_by_lookup():
+    # Requested bucket is finer than the generated ladder. Lookups use bisect,
+    # so an out-of-order insert stays invisible and a coarser bucket wins.
+    manager = _manager_with_buckets([], [(1, 1, 64), (26, 1, 1664), (50, 1, 3200)])
+    manager.add_decode_bucket((32, 1, 416))
+    assert manager.decode_buckets == sorted(manager.decode_buckets)
+    assert manager.find_decode_bucket(32, 416) == (32, 1, 416)
+
+
+def test_add_prompt_bucket_is_returned_by_lookup():
+    manager = _manager_with_buckets([(1, 128, 0), (1, 2048, 0)], [])
+    manager.add_prompt_bucket((1, 1664, 0))
+    assert manager.prompt_buckets == sorted(manager.prompt_buckets)
+    assert manager.find_prompt_bucket(1, 1664, 0) == (1, 1664, 0)
+
+
+def test_add_bucket_does_not_duplicate():
+    manager = _manager_with_buckets([(1, 128, 0)], [(32, 1, 416)])
+    manager.add_decode_bucket((32, 1, 416))
+    manager.add_prompt_bucket((1, 128, 0))
+    assert manager.decode_buckets == [(32, 1, 416)]
+    assert manager.prompt_buckets == [(1, 128, 0)]
+
+
 # --- Exponential bucketing tests ---
 
 

--- a/vllm_gaudi/extension/bucketing/common.py
+++ b/vllm_gaudi/extension/bucketing/common.py
@@ -287,6 +287,16 @@ class HPUBucketingManager():
                     new_ctx = self._fallback_max_ctx
         return (new_batch_size, new_seq_len, new_ctx)
 
+    def add_prompt_bucket(self, bucket):
+        # Lookups use bisect, so the list must stay sorted.
+        if bucket not in self.prompt_buckets:
+            bisect.insort(self.prompt_buckets, bucket)
+
+    def add_decode_bucket(self, bucket):
+        # Lookups use bisect, so the list must stay sorted.
+        if bucket not in self.decode_buckets:
+            bisect.insort(self.decode_buckets, bucket)
+
     def find_prompt_bucket(self, batch_size, seq_len, ctx=0):
         if self.initialized:
             found_bucket = find_equal_or_closest_greater_config(self.prompt_buckets, (batch_size, seq_len, ctx))
@@ -553,6 +563,7 @@ def is_greater_or_equal(tuple1, tuple2):
 
 
 def find_equal_or_closest_greater_config(sorted_list, target_tuple):
+    # `sorted_list` must be sorted; an unsorted entry is invisible to bisect.
     idx = bisect.bisect_left(sorted_list, target_tuple)
     for i in range(idx, len(sorted_list)):
         if is_greater_or_equal(sorted_list[i], target_tuple):

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -1310,6 +1310,11 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
             self.scheduler_config.max_num_seqs = self.max_model_len
             if prompt_profile_cfg:
                 self.scheduler_config.max_num_batched_tokens = prompt_profile_cfg[0] * prompt_profile_cfg[1]
+            if decode_profile_cfg:
+                # Decode bucket ranges are derived from max_num_seqs, so the
+                # inflated value above would round the requested batch and block
+                # count up to a much coarser bucket. Pin it to the request.
+                self.scheduler_config.max_num_seqs = decode_profile_cfg[0]
         self.max_num_tokens = scheduler_config.max_num_batched_tokens
 
         # Attention layers that are only in the KVCacheConfig of the runner
@@ -5775,10 +5780,10 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
     def _generate_profiling(self, prompt_cfg, decode_cfg):
         steps = 3
         profiler = setup_profiler(warmup=steps - 1, active=1)
-        if prompt_cfg and prompt_cfg not in self.bucketing_manager.prompt_buckets:
-            self.bucketing_manager.prompt_buckets.insert(0, prompt_cfg)
-        elif decode_cfg and decode_cfg not in self.bucketing_manager.decode_buckets:
-            self.bucketing_manager.decode_buckets.insert(0, decode_cfg)
+        if prompt_cfg:
+            self.bucketing_manager.add_prompt_bucket(prompt_cfg)
+        elif decode_cfg:
+            self.bucketing_manager.add_decode_bucket(decode_cfg)
         torch.hpu.synchronize()
         profiler.start()
         for _ in range(steps):

--- a/vllm_gaudi/v1/worker/hpu_model_runner.py
+++ b/vllm_gaudi/v1/worker/hpu_model_runner.py
@@ -1310,10 +1310,14 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
             self.scheduler_config.max_num_seqs = self.max_model_len
             if prompt_profile_cfg:
                 self.scheduler_config.max_num_batched_tokens = prompt_profile_cfg[0] * prompt_profile_cfg[1]
-            if decode_profile_cfg:
+            elif decode_profile_cfg:
                 # Decode bucket ranges are derived from max_num_seqs, so the
                 # inflated value above would round the requested batch and block
                 # count up to a much coarser bucket. Pin it to the request.
+                # `elif` mirrors _generate_profiling: when both phases are
+                # requested only the prompt one is profiled, and pinning here
+                # would also shrink the prompt ladder under merged prefill,
+                # where max_num_prefill_seqs follows max_num_seqs.
                 self.scheduler_config.max_num_seqs = decode_profile_cfg[0]
         self.max_num_tokens = scheduler_config.max_num_batched_tokens
 
@@ -5809,6 +5813,12 @@ class HPUModelRunner(HpuKVConnectorModelRunnerMixin):
     def _read_profiling_cfg(self):
         prompt_cfg = self._parse_profile_cfg(os.environ.get('VLLM_PROFILE_PROMPT', None))
         decode_cfg = self._parse_profile_cfg(os.environ.get('VLLM_PROFILE_DECODE', None))
+        # Only the first two decode values are used, so a third one would be
+        # silently dropped and the block count taken from the wrong position.
+        assert prompt_cfg is None or len(prompt_cfg) == 3, \
+            "VLLM_PROFILE_PROMPT expects '<bs>,<query_len>,<ctx_blocks>'"
+        assert decode_cfg is None or len(decode_cfg) == 2, \
+            "VLLM_PROFILE_DECODE expects '<bs>,<num_blocks>'"
         legacy_cfg = self._parse_legacy_profile_cfg(os.environ.get('VLLM_PT_PROFILE', None))
         if legacy_cfg and not (prompt_cfg or decode_cfg):
             phase, bs, seq_or_blocks, use_graphs = legacy_cfg


### PR DESCRIPTION
## Problem

Decode bucket ranges are derived from `max_num_seqs`, which the profiling path inflates to `max_model_len`. A requested decode shape is therefore rounded up to a much coarser bucket — `VLLM_PROFILE_DECODE=32,416` runs as `(50, 1, 3200)`.

`_generate_profiling` does add the requested bucket, but via `insert(0, ...)`, which breaks the sort order that `find_equal_or_closest_greater_config` relies on (`bisect.bisect_left`). The inserted entry is therefore never found by the lookup and only affects graph capture.

Net effect: the profiled step is not the shape that was asked for, and it contains several times more KV-gather work than the serving path does for the same request shape.

Separately, `VLLM_PROFILE_DECODE` uses only its first two values, so a third one is silently dropped and the block count is taken from the wrong position — e.g. `32,1,400`, written to mirror the bucket triple, profiles a single block. Neither per-phase variable is documented.

## Change

- Pin `max_num_seqs` to the requested decode batch, mirroring the existing prompt-side pinning of `max_num_batched_tokens`, and keep it at the prompt batch when both phases are requested.
- Add `HPUBucketingManager.add_{prompt,decode}_bucket()`, which insert with `bisect.insort` so the lookup invariant holds; `_generate_profiling` now uses them.
- Assert the expected arity of `VLLM_PROFILE_PROMPT` / `VLLM_PROFILE_DECODE`, and document both in `docs/dev_guide/profiling/profiling-prompt-decode.md`.

## Test

- New unit tests in `tests/unit_tests/test_bucketing.py`: an explicitly added bucket is returned by the lookup, the list stays sorted, and re-adding an existing bucket does not duplicate it. Without this change the lookup returns the coarser generated bucket instead.
- On Gaudi2, `VLLM_PROFILE_DECODE=32,400` (a shape absent from the generated ladder) now yields a decode bucket ladder identical to the serving one and executes batch 32 with exactly 400 block-table entries. Before the change the same request executed a coarser batch and block count.
- On Gaudi3 with a 40-layer hybrid MoE at TP=2 and ~100k context, the legacy `VLLM_PT_PROFILE=decode_8_6400_t` executed 8192 block-table entries before the change and exactly the requested 6400 after, so the profiled KV-gather volume drops by ~22% to what was asked for. Executed shapes verified from each run's post-graph, not inferred.
- `VLLM_PROFILE_DECODE=32,1,400` now fails fast with the expected-format message instead of silently profiling a single block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
