### PR TITLE
[CI] Pin VLLM_COMMUNITY_COMMIT together with VLLM_STABLE_COMMIT on hourly pass

### DIFF
--- a/.github/workflows/hourly-ci.yaml
+++ b/.github/workflows/hourly-ci.yaml
@@ -398,13 +398,25 @@ jobs:
 
       - name: Store last stable vllm commit sha
         run: |
+          set -euo pipefail
           LATEST_COMMIT_SHA=${{ needs.setup_and_build.outputs.latest_commit }}
           echo "Storing latest stable vLLM commit SHA: $LATEST_COMMIT_SHA"
           echo "$LATEST_COMMIT_SHA" > VLLM_STABLE_COMMIT
-
-          # Only commit and push if the file has changed to avoid empty commits
           git add VLLM_STABLE_COMMIT
-          git commit --allow-empty -m "Update stable vLLM commit to ${LATEST_COMMIT_SHA}"
+
+          # This job only runs once every test job passed, so the same SHA also
+          # becomes the pin for upstream's HPU CI.
+          echo "Pinning VLLM_COMMUNITY_COMMIT to ${LATEST_COMMIT_SHA}"
+          if [[ -s VLLM_COMMUNITY_COMMIT ]]; then
+            # Replace only the first line so the trailing comment block survives.
+            { printf '%s\n' "$LATEST_COMMIT_SHA"; tail -n +2 VLLM_COMMUNITY_COMMIT; } > VLLM_COMMUNITY_COMMIT.tmp
+          else
+            printf '%s\n' "$LATEST_COMMIT_SHA" > VLLM_COMMUNITY_COMMIT.tmp
+          fi
+          mv VLLM_COMMUNITY_COMMIT.tmp VLLM_COMMUNITY_COMMIT
+          git add VLLM_COMMUNITY_COMMIT
+
+          git commit --allow-empty -m "Update stable and community vLLM commit to ${LATEST_COMMIT_SHA}"
 
           echo "Pushing changes to remote branch..."
           # Explicitly set the remote URL with the token to prevent hanging on auth


### PR DESCRIPTION
The hourly CI job store_last_stable_vllm_commit writes the verified upstream
vLLM SHA to VLLM_STABLE_COMMIT on the vllm/last-good-commit-for-vllm-gaudi
branch. VLLM_COMMUNITY_COMMIT, which selects the vLLM revision upstream's HPU
job builds against, had to be moved to the same SHA by hand afterwards through
the Update vLLM Community Commit workflow. The branch history shows these two
updates repeatedly landing back to back with an identical SHA, and any gap
between them leaves upstream building a different revision than the one the
hourly run actually validated.

Write both files in the same step, commit, and push. The job already depends on
every test job and carries no if: condition, so a failing or backed-off hourly
run still leaves both files untouched. The first line of VLLM_COMMUNITY_COMMIT
is replaced in place so the explanatory comment block below it is preserved,
matching what the manual workflow does.

The manual workflows remain available for overriding either file, including
setting VLLM_COMMUNITY_COMMIT back to 'latest'. Such an override now holds only
until the next passing hourly run, which is the same lifetime a manual
VLLM_STABLE_COMMIT override already had.