### PR TITLE
[FIX_FOR_VLLM_CUSTOM=39e276eaeb9daed06a180f6a8d187bbb8790e97b] Retarget engine/protocol imports moved by vllm#54492

### DIFF
--- a/vllm_gaudi/entrypoints/openai/multi_model_api_server.py
+++ b/vllm_gaudi/entrypoints/openai/multi_model_api_server.py
@@ -248,7 +248,7 @@ class MultiModelServingModels(OpenAIServingModels):
         return self.base_model_paths[0].name == model_name
 
     async def show_available_models(self):
-        from vllm.entrypoints.openai.engine.protocol import (
+        from vllm.entrypoints.serve.engine.protocol import (
             ModelCard,
             ModelList,
             ModelPermission,

--- a/vllm_gaudi/entrypoints/openai/tool_parsers/minimax_m3.py
+++ b/vllm_gaudi/entrypoints/openai/tool_parsers/minimax_m3.py
@@ -61,7 +61,7 @@ import re
 from collections.abc import Sequence
 
 from vllm.entrypoints.chat_utils import make_tool_call_id
-from vllm.entrypoints.openai.engine.protocol import (
+from vllm.entrypoints.generate.base.protocol import (
     DeltaFunctionCall,
     DeltaMessage,
     DeltaToolCall,


### PR DESCRIPTION
This PR consolidates 1 hourly-CI fix against vllm@`39e276eaeb9daed06a180f6a8d187bbb8790e97b`.

## Bug 1: Retarget engine/protocol imports moved by vllm#54492

- **State machine id**: entrypoints_openai_engine_module_moved
- **Commit**: e92972a21b9d9d346a8f089e06025dae0eb33282

### Root cause
upstream vllm#54492 (eeb549a74d) deleted vllm/entrypoints/openai/engine/ and split protocol.py into vllm/entrypoints/generate/base/protocol.py (tool-call and delta types) plus the new vllm/entrypoints/serve/engine/protocol.py (ModelCard/ModelList/ModelPermission), leaving no shim at the old path.

### Culprit
Regression introduced by [PR #54492](https://github.com/vllm-project/vllm/pull/54492).

### Fix
import the tool-call types from vllm.entrypoints.generate.base.protocol and the model-card types from vllm.entrypoints.serve.engine.protocol.