### PR TITLE
[FIX_FOR_VLLM_CUSTOM=a56654d6de060495ff2db3b1d9ff0b187084d1a9] Accept bias_vl and image_sentinel_lo in HPU MoE router factory

### DIFF
--- a/vllm_gaudi/ops/hpu_fused_moe.py
+++ b/vllm_gaudi/ops/hpu_fused_moe.py
@@ -828,6 +828,9 @@ def create_fused_moe_router(
     zero_expert_type: str | None = None,
     num_logical_experts: int | None = None,
     hash_indices_table: torch.Tensor | None = None,
+    # Deepseek V4 vision routing bias parameters
+    bias_vl: torch.Tensor | None = None,
+    image_sentinel_lo: int = 0,
 ) -> FusedMoERouter:
     """
     Factory function to create the appropriate FusedMoERouter subclass based on
@@ -875,6 +878,12 @@ def create_fused_moe_router(
     Hash Indices Table:
         hash_indices_table: Used to map input_ids to experts, needed for
             Deepseek V4
+
+    Vision routing bias arguments (upstream vLLM PR 54566+):
+        bias_vl: Vision routing bias for image tokens (Deepseek V4).
+        image_sentinel_lo: First of five consecutive in-vocab image sentinel
+            ids (0 = vision routing disabled). Both are forwarded to
+            FusedTopKBiasRouter, which owns the vision-bias routing path.
 
     Returns:
         An instance of the appropriate FusedMoERouter subclass
@@ -944,6 +953,8 @@ def create_fused_moe_router(
             hash_indices_table=hash_indices_table,
             num_fused_shared_experts=num_fused_shared_experts,
             shared_expert_weight=shared_expert_weight,
+            bias_vl=bias_vl,
+            image_sentinel_lo=image_sentinel_lo,
         )
 
     return FusedTopKRouter(


### PR DESCRIPTION
This PR consolidates 1 hourly-CI fix against vllm@`a56654d6de060495ff2db3b1d9ff0b187084d1a9`.
## Bug 1: Accept bias_vl and image_sentinel_lo in HPU MoE router factory

- **State machine id**: fused_moe_router_bias_vl_kwarg_mismatch
- **Commit**: 03d42dfc3d41600fda39959cc71acde4c0d5b9db

### Root cause
upstream vllm#54566 added bias_vl and image_sentinel_lo to create_fused_moe_router, and FusedMoEFactory forwards both unconditionally, so the HPU override raised TypeError on every MoE model build.

### Culprit
Regression introduced by [PR #54566](https://github.com/vllm-project/vllm/pull/54566).

### Fix
mirror the upstream signature and forward both kwargs to FusedTopKBiasRouter, which owns the vision-bias routing path.