### PR TITLE
[FIX_FOR_VLLM_CUSTOM=8f816a3f665489d7f0d222115d4f72ebab01076b] set fuse_qkv_rmsnorm on HPU MLA wrapper

### DIFF
--- a/vllm_gaudi/attention/oot_mla.py
+++ b/vllm_gaudi/attention/oot_mla.py
@@ -278,6 +278,11 @@ class HPUMultiHeadLatentAttentionWrapper(MultiHeadLatentAttentionWrapper):
         # accept-and-ignore the kwarg to keep the constructor signature in sync
         # with the base MultiHeadLatentAttentionWrapper / deepseek_v2 call site.
         allow_short_prefill_indexer_scoring_skip: bool = False,
+        # Added upstream by vllm#53906 (GLM-5.3-Flash). Opt-in fusion of the q_a
+        # and kv_a RMSNorms into one launch; the kernel behind it
+        # (vllm.models.common.ops.fused_q_kv_rmsnorm) is Triton/CUDA-only, so we
+        # accept-and-ignore the kwarg and keep HPU on the unfused path.
+        fuse_qkv_rmsnorm: bool = False,
     ) -> None:
         # Skip MultiHeadLatentAttentionWrapper.__init__() because it creates
         # MLAAttention → FlashAttnPrefillBackend which crashes on HPU.
@@ -314,6 +319,12 @@ class HPUMultiHeadLatentAttentionWrapper(MultiHeadLatentAttentionWrapper):
         # dense MLA and the indexer must never be invoked (its kernels and the
         # DeepseekV32IndexerBackend are CUDA-only).
         self.skip_topk = skip_topk or self.is_sparse
+        # vllm#53906 added `self.fuse_qkv_rmsnorm`, which the base
+        # MultiHeadLatentAttentionWrapper.forward (inherited here, since we do not
+        # override forward) reads to pick the fused RMSNorm path. Because we bypass
+        # super().__init__(), replicate the assignment - pinned False because the
+        # fused kernel is Triton/CUDA-only.
+        self.fuse_qkv_rmsnorm = False
         # vllm#45964 (DCP query replication) added `self.dcp_q_replicate`, which
         # the base MultiHeadLatentAttentionWrapper.forward (inherited here, since
         # we do not override forward) reads and forwards to mla_attn. Because we


### PR DESCRIPTION
This PR consolidates 1 hourly-CI fix against vllm@`8f816a3f665489d7f0d222115d4f72ebab01076b`.

## Bug 1: set fuse_qkv_rmsnorm on HPU MLA wrapper

- **State machine id**: hpu_mla_fuse_qkv_rmsnorm_missing_attr
- **Commit**: e445d167accb4954cfe28248d4e20fe1f1a524d7

### Root cause
vllm#53906 added self.fuse_qkv_rmsnorm to the base MLA wrapper __init__ and made the inherited forward read it, but the HPU wrapper inlines that __init__ and never set it, so every DeepSeek/MLA forward raised AttributeError at the first token.

### Culprit
Regression introduced by [PR #53906](https://github.com/vllm-project/vllm/pull/53906).

### Fix
Accept the new fuse_qkv_rmsnorm kwarg and pin the field to False - the fused q_a/kv_a RMSNorm kernel is Triton/CUDA-only, so HPU stays unfused.