### PR TITLE
[FIX_FOR_VLLM_CUSTOM=cd64c2dea9c72af333de7ec05293d54bbf1bd128] handle key=None on, pass default_chat_template_kwargs into

### DIFF
--- a/vllm_gaudi/attention/backends/hpu_attn.py
+++ b/vllm_gaudi/attention/backends/hpu_attn.py
@@ -510,8 +510,8 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
         self,
         layer: AttentionLayer,
         query: torch.Tensor,
-        key: torch.Tensor,
-        value: torch.Tensor,
+        key: Optional[torch.Tensor],
+        value: Optional[torch.Tensor],
         kv_cache: torch.Tensor,
         attn_metadata: HPUAttentionMetadata,
         output: Optional[torch.Tensor] = None,
@@ -520,8 +520,10 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
 
         Args:
             query: shape = [num_tokens, num_heads * head_size]
-            key: shape = [num_tokens, num_kv_heads * head_size]
-            value: shape = [num_tokens, num_kv_heads * head_size]
+            key: shape = [num_tokens, num_kv_heads * head_size], None on
+                KV-shared layers that project Q only
+            value: shape = [num_tokens, num_kv_heads * head_size], None on
+                KV-shared layers that project Q only
             kv_cache = [2, num_blocks, block_size * num_kv_heads * head_size]
             attn_metadata: Metadata for attention.
         Returns:
@@ -552,8 +554,12 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
         else:
             batch_size, seq_len, hidden_size = query.shape
 
-        key = key.view(-1, self.num_kv_heads, self.head_size)
-        value = value.view(-1, self.num_kv_heads, self.head_size)
+        # key/value are None on KV-shared (YOCO) layers since vllm#54917: those
+        # layers project Q only and read K/V back from the target layer's cache.
+        if key is not None:
+            key = key.view(-1, self.num_kv_heads, self.head_size)
+        if value is not None:
+            value = value.view(-1, self.num_kv_heads, self.head_size)
         slot_mapping = attn_metadata.slot_mapping.flatten() if attn_metadata.slot_mapping is not None else None
         key_cache = None
         value_cache = None
@@ -562,11 +568,11 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
         if kv_cache is not None and isinstance(kv_cache, tuple):
             key_cache, value_cache, k_scales, v_scales = \
                 HPUPagedAttention.split_kv_cache(kv_cache, self.num_kv_heads, self.head_size)
-            if key.dtype == torch.float32 and key.dtype != key_cache.dtype:
+            if key is not None and key.dtype == torch.float32 and key.dtype != key_cache.dtype:
                 key = key.to(key_cache.dtype)
-            if value.dtype == torch.float32 and value.dtype != value_cache.dtype:
+            if value is not None and value.dtype == torch.float32 and value.dtype != value_cache.dtype:
                 value = value.to(value_cache.dtype)
-            if query.dtype != key.dtype:
+            if key is not None and query.dtype != key.dtype:
                 query = query.to(key.dtype)
             if self.kv_sharing_target_layer_name is None:
                 # Reshape the input keys and values and store them in the cache.
@@ -584,18 +590,30 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
                                            scales=v_scales,
                                            block_size=attn_metadata.block_size,
                                            is_prompt=attn_metadata.is_prompt)
-            elif attn_metadata.is_prompt and slot_mapping is not None:
-                # KV sharing (YOCO): the local key/value are intentionally
-                # un-normed/un-RoPE'd (see Gemma4Attention shared-layer path).
-                # Read the target layer's normalized+RoPE'd K/V back from the
-                # shared cache at these slots (it wrote them earlier this pass).
-                key = key_cache.index_select(0, slot_mapping).view(key.shape)
-                value = value_cache.index_select(0, slot_mapping).view(value.shape)
+            elif slot_mapping is not None and (attn_metadata.is_prompt or seq_len > 1):
+                # KV sharing (YOCO): the local key/value are absent (vllm#54917)
+                # or un-normed/un-RoPE'd on older vLLM. Either way read the
+                # target layer's normalized+RoPE'd K/V back from the shared
+                # cache at these slots (it wrote them earlier this pass). The
+                # cache is [num_blocks * block_size, num_kv_heads, head_size],
+                # so the gather already has the per-token K/V layout.
+                key = key_cache.index_select(0, slot_mapping)
+                value = value_cache.index_select(0, slot_mapping)
 
         if attn_metadata.is_prompt or seq_len > 1:
             # Prompt run.
             query_shape = (batch_size, seq_len, self.num_heads, self.head_size)
             kv_shape = (batch_size, -1, self.num_kv_heads, self.head_size)
+
+            if key is None or value is None:
+                # KV-shared layer with no cache to read back from, i.e. the
+                # memory-profiling run before the KV cache exists. Feed zeros so
+                # the prompt kernel still sees well-shaped K/V.
+                zeros = torch.zeros((batch_size * seq_len, self.num_kv_heads, self.head_size),
+                                    dtype=query.dtype,
+                                    device=query.device)
+                key = zeros if key is None else key
+                value = zeros if value is None else value
 
             attn_bias = attn_metadata.attn_bias
             position_bias = None

--- a/vllm_gaudi/entrypoints/openai/multi_model_api_server.py
+++ b/vllm_gaudi/entrypoints/openai/multi_model_api_server.py
@@ -24,7 +24,9 @@ from vllm.entrypoints.chat_utils import load_chat_template
 from vllm.entrypoints.launchers.launcher import serve_http
 from vllm.entrypoints.serve.utils.request_logger import RequestLogger
 from vllm.entrypoints.openai.api_server import build_app, setup_server
-from vllm.entrypoints.launchers.cli_args import make_arg_parser, validate_parsed_serve_args
+from vllm.entrypoints.launchers.cli_args import (make_arg_parser, resolve_default_chat_template_kwargs,
+                                                 validate_parsed_serve_args)
+from vllm.entrypoints.mcp.tool_server import init_tool_server
 from vllm.entrypoints.openai.models.protocol import BaseModelPath
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
 from vllm.entrypoints.launchers.utils.server_utils import get_uvicorn_log_config
@@ -499,6 +501,13 @@ async def _init_multi_model_state(
     frontend_settings = _resolve_frontend_settings(args, model_frontend_overrides, active_model_name)
     resolved_chat_template = load_chat_template(frontend_settings.chat_template)
 
+    # Upstream vllm#50195 hoisted both of these out of init_generate_state into
+    # the caller: default_chat_template_kwargs is now a required positional
+    # argument (the helper folds --cohere-format into it), and the tool server
+    # is read from state.tool_server instead of being built there.
+    default_chat_template_kwargs = resolve_default_chat_template_kwargs(args)
+    state.tool_server = await init_tool_server(args) if "generate" in supported_tasks else None
+
     # Upstream vllm#44285 split OpenAIServingRender into a thin entrypoint
     # (ServingRender) plus an OnlineRenderer that owns the chat-template, tool
     # and reasoning configuration. Mirror that construction here so the
@@ -515,7 +524,7 @@ async def _init_multi_model_state(
         enable_auto_tools=frontend_settings.enable_auto_tool_choice,
         exclude_tools_when_tool_choice_none=args.exclude_tools_when_tool_choice_none,
         tool_parser=frontend_settings.tool_call_parser,
-        default_chat_template_kwargs=args.default_chat_template_kwargs,
+        default_chat_template_kwargs=default_chat_template_kwargs,
         log_error_stack=args.log_error_stack,
     )
     state.online_renderer = OnlineRenderer(**render_kwargs)
@@ -524,6 +533,7 @@ async def _init_multi_model_state(
         state.openai_serving_models,
         state.online_renderer,
         request_logger=request_logger,
+        tool_server=state.tool_server,
     )
 
     state.serving_tokenization = ServingTokenization(
@@ -532,7 +542,7 @@ async def _init_multi_model_state(
         request_logger=request_logger,
         chat_template=resolved_chat_template,
         chat_template_content_format=args.chat_template_content_format,
-        default_chat_template_kwargs=args.default_chat_template_kwargs,
+        default_chat_template_kwargs=default_chat_template_kwargs,
         trust_request_chat_template=args.trust_request_chat_template,
     )
 
@@ -543,7 +553,8 @@ async def _init_multi_model_state(
         state_args.enable_auto_tool_choice = frontend_settings.enable_auto_tool_choice
         state_args.tool_call_parser = frontend_settings.tool_call_parser
         state_args.chat_template = frontend_settings.chat_template
-        await init_generate_state(engine_client, state, state_args, request_logger, supported_tasks)
+        await init_generate_state(engine_client, state, state_args, request_logger, supported_tasks,
+                                  default_chat_template_kwargs)
 
     if "transcription" in supported_tasks or "realtime" in supported_tasks:
         from vllm.entrypoints.speech_to_text.factories import init_speech_to_text_state

--- a/vllm_gaudi/ops/hpu_rotary_embedding.py
+++ b/vllm_gaudi/ops/hpu_rotary_embedding.py
@@ -39,9 +39,9 @@ class HPURotaryEmbedding(RotaryEmbedding):
         self,
         positions: torch.Tensor,
         query: torch.Tensor,
-        key: torch.Tensor,
+        key: Optional[torch.Tensor],
         offsets: Optional[torch.Tensor] = None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
         from habana_frameworks.torch.hpex.kernels import (RotaryPosEmbeddingMode, apply_rotary_pos_emb)
 
         # Prepare cos-sin caches for long-context + LoRA with offsets for every
@@ -63,13 +63,18 @@ class HPURotaryEmbedding(RotaryEmbedding):
         sin = self.sin
         cos = self.cos
         query_shape = query.shape
-        key_shape = key.shape
         query = query.view(num_tokens, -1, self.head_size)
-        key = key.view(num_tokens, -1, self.head_size)
+        # key is None on KV-shared (YOCO) layers, which rotate Q only - Gemma4 /
+        # Gemma4 MTP / Gemma3n. Upstream forward_static guards it the same way.
+        key_shape = key.shape if key is not None else None
+        if key is not None:
+            key = key.view(num_tokens, -1, self.head_size)
 
         if self.head_size == self.rotary_dim:
             # Avoid unnecessary slicing and concatenation
             query = apply_rotary_pos_emb(query, cos, sin, None, 0, rope_mode)
+            if key is None:
+                return query.reshape(query_shape), None
             key = apply_rotary_pos_emb(key, cos, sin, None, 0, rope_mode)
             return query.reshape(query_shape), key.reshape(key_shape)
 
@@ -77,6 +82,9 @@ class HPURotaryEmbedding(RotaryEmbedding):
         query_pass = query[..., self.rotary_dim:]
         query_rot = apply_rotary_pos_emb(query_rot, cos, sin, None, 0, rope_mode)
         query = torch.cat((query_rot, query_pass), dim=-1).reshape(query_shape)
+
+        if key is None:
+            return query, None
 
         key_rot = key[..., :self.rotary_dim]
         key_pass = key[..., self.rotary_dim:]


### PR DESCRIPTION
This PR consolidates 2 hourly-CI fixes against vllm@`cd64c2dea9c72af333de7ec05293d54bbf1bd128`.
## Bug 1: handle key=None on KV-shared layers

- **State machine id**: e2e_gsm8k_gemma4_parallel_nonetype_shape
- **Commit**: d4f9edbb8cec9be992f8297aa71805f58617c1e8

### Root cause
vllm#54917 made Gemma4/Gemma3n KV-shared layers project Q only and call rope and attention with key=value=None, which the HPU overrides deref.

### Culprit
Regression introduced by [PR #54917](https://github.com/vllm-project/vllm/pull/54917).

### Fix
guard the None key/value in HPURotaryEmbedding.forward_oot and HPUAttentionImpl.forward, reading the shared K/V back from the target layer's cache as before.

## Bug 2: pass default_chat_template_kwargs into init_generate_state

- **State machine id**: e2e_online_model_swap_init_generate_state
- **Commit**: 86b8b3cdf017f50688bb68700e791215e4a65489

### Root cause
upstream vllm#50195 hoisted default_chat_template_kwargs and the tool server out of init_generate_state into its caller init_app_state, making the kwargs a 6th required positional argument and reading state.tool_server; the HPU multi-model clone of init_app_state still made the old 5-argument call, so the APIServer died at startup with a TypeError and run_online_model_swap_test never reached the model switch.

### Culprit
Regression introduced by [PR #50195](https://github.com/vllm-project/vllm/pull/50195).

### Fix
resolve the kwargs once via resolve_default_chat_template_kwargs, reuse them for OnlineRenderer and ServingTokenization, set state.tool_server from init_tool_server for generate-capable models, and pass the resolved dict as the 6th argument to init_generate_state.
