### PR TITLE
[FIX_FOR_VLLM_CUSTOM=d2906091bfc579cebefe3d8e8fb9077397ce9882] drop removed actorder/g_idx, populate region_num_blocks in (+3 more)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,12 @@ tblib==3.2.2
 # route.path -> 500 on every request. Upstream bug:
 # trallnag/prometheus-fastapi-instrumentator#370. Remove once it ships a fix.
 fastapi<0.137
+# Cap transformers below 5.17: huggingface/transformers#48105 removed
+# position_ids_in_meshgrid and renamed PixtralRotaryEmbedding to
+# PixtralVisionRotaryEmbedding, both imported at the top of upstream vLLM's
+# vllm/model_executor/models/pixtral.py. That module then fails to import, so
+# PixtralForConditionalGeneration cannot be inspected and every Mistral-Small-3.1
+# run dies in ModelConfig validation. vLLM's own CI pins transformers==5.16.1, so
+# it does not see this. Remove once vLLM adopts the new transformers API.
+transformers<5.17
 setuptools>=83.0.0,<85.0.0

--- a/tests/full_tests/ci_e2e_discoverable_tests.sh
+++ b/tests/full_tests/ci_e2e_discoverable_tests.sh
@@ -201,12 +201,12 @@ run_compressed_w4a16_channelwise_load_generate_test() {
     echo "✅ Test with compressed w4a16 (channelwise) passed."
 }
 
-# Compressed w4a16 MoE with g_idx
-run_compressed_w4a16_moe_gidx_load_generate_test() {
-    echo "➡️ Testing compressed w4a16 MoE with g_idx inference..."
-    HABANA_VISIBLE_DEVICES=all VLLM_SKIP_WARMUP=true python -u "${VLLM_GAUDI_PREFIX}/tests/full_tests/generate.py" --model nm-testing/test-w4a16-mixtral-actorder-group --dtype bfloat16
-    echo "✅ Test with compressed w4a16 MoE with g_idx passed."
-}
+# Compressed w4a16 MoE with g_idx (nm-testing/test-w4a16-mixtral-actorder-group)
+# retired: vllm#54809 permanently removed GPTQ group/dynamic activation
+# ordering support on every backend, not just HPU. Any checkpoint declaring
+# actorder=group/dynamic (this model's checkpoint) is now rejected upstream
+# during compressed-tensors config parsing before hardware dispatch, so this
+# test can no longer pass on CUDA either. No HPU-side fix is possible.
 
 # Llama-3.3-70B-Instruct-FP8-dynamic + INC dynamic quant
 run_llama3_70b_inc_dynamic_quant_load_generate_test() {
@@ -680,7 +680,8 @@ launch_all_tests() {
     run_awq_load_generate_test
     run_gptq_load_generate_test
     run_compressed_w4a16_channelwise_load_generate_test
-    run_compressed_w4a16_moe_gidx_load_generate_test
+    # run_compressed_w4a16_moe_gidx_load_generate_test retired: see comment above
+    # its (removed) definition -- vllm#54809 killed actorder=group upstream.
     run_llama3_70b_inc_dynamic_quant_load_generate_test
     run_qwen2_5_vl_load_generate_test
     run_qwen2_5_vl_compile_warmup_test

--- a/vllm_gaudi/distributed/kv_transfer/kv_connector/v1/hpu_nixl_connector.py
+++ b/vllm_gaudi/distributed/kv_transfer/kv_connector/v1/hpu_nixl_connector.py
@@ -326,15 +326,19 @@ def _hpu_transfer_cache_regions(transfer_topo, cache, layer_spec):
 def _hpu_register_kv_caches(self, kv_caches: dict[str, torch.Tensor]) -> None:
     """Register HPU KV caches in NIXL, restoring the pre-#44456 K/V split.
 
-    VERBATIM COPY of ``NixlBaseConnectorWorker.register_kv_caches`` at vllm
-    61c9ef98 (base_worker.py:1024), with exactly three logic deviations: the
-    per-layer cache is expanded via :func:`_hpu_transfer_cache_regions` into a
-    ``cache_list`` so K and V register as two separate blocks-first regions
-    instead of the single packed region the upstream inlined loop assumes;
-    ``physical_page_size`` is divided by ``len(cache_list)``; and the region
-    bookkeeping runs in an inner ``for cache in cache_list`` loop. Everything
-    else mirrors upstream. See the DRIFT HAZARD note above — re-sync on the
-    ``_warn_if_upstream_register_drifted`` warning.
+    Originally a verbatim copy of ``NixlBaseConnectorWorker.register_kv_caches``
+    at vllm 61c9ef98 (base_worker.py:1024); since patched forward layer-by-layer
+    as upstream added fields the copied body never populated (block strides,
+    now region block counts) rather than re-synced wholesale. Deviations from
+    that baseline: the per-layer cache is expanded via
+    :func:`_hpu_transfer_cache_regions` into a ``cache_list`` so K and V register
+    as two separate blocks-first regions instead of the single packed region the
+    upstream inlined loop assumes; ``physical_page_size`` is divided by
+    ``len(cache_list)``; the region bookkeeping runs in an inner
+    ``for cache in cache_list`` loop; and ``block_stride_per_layer`` /
+    ``region_num_blocks`` are populated per-region to satisfy later upstream
+    additions to ``_build_fa_local``. See the DRIFT HAZARD note above — re-sync
+    on the ``_warn_if_upstream_register_drifted`` warning.
 
     Args:
         kv_caches: Mapping of layer name to its device KV cache tensor.
@@ -430,6 +434,13 @@ def _hpu_register_kv_caches(self, kv_caches: dict[str, torch.Tensor]) -> None:
             self.block_stride_per_layer.append(block_len)
             is_mla_region = isinstance(layer_spec, (MLAAttentionSpec, SlidingWindowMLASpec))
             self._region_is_mla.append(is_mla_region)
+            # Upstream vLLM (base_worker.py:register_kv_caches) now tracks the
+            # per-region block count separately from block_len/block_stride so
+            # _build_fa_local can index self.region_num_blocks[i]; this override
+            # never populated it, leaving the list empty and every access an
+            # IndexError. `num_blocks` here is already the per-region physical
+            # count (logical count for Mamba), matching upstream's semantics.
+            self.region_num_blocks.append(num_blocks)
 
             if not is_mla_region:
                 if tensor_size_bytes is None:
@@ -458,10 +469,15 @@ def _hpu_register_kv_caches(self, kv_caches: dict[str, torch.Tensor]) -> None:
 
     logger.debug("Different block lengths collected: %s", set(self.block_len_per_layer))
     assert len(self.block_len_per_layer) == len(seen_base_addresses) == len(self._region_is_mla) == len(
-        self.block_stride_per_layer)
+        self.block_stride_per_layer) == len(self.region_num_blocks)
 
     self.kv_caches_base_addr[self.engine_id][self.tp_rank] = seen_base_addresses
     self.num_regions = len(caches_data)
+    if self._has_mamba:
+        # Mirror upstream: every region (including the shared conv/ssm tensor)
+        # reports the PHYSICAL block count here, not the per-layer logical
+        # count some regions were appended with above.
+        self.region_num_blocks = [self.num_blocks] * self.num_regions
 
     if self.pp_size > 1:
         start_layer, end_layer = self.model_config.get_layers_start_end_indices(self.vllm_config.parallel_config)

--- a/vllm_gaudi/distributed/kv_transfer/kv_connector/v1/hpu_nixl_connector.py
+++ b/vllm_gaudi/distributed/kv_transfer/kv_connector/v1/hpu_nixl_connector.py
@@ -336,8 +336,12 @@ def _hpu_register_kv_caches(self, kv_caches: dict[str, torch.Tensor]) -> None:
     upstream inlined loop assumes; ``physical_page_size`` is divided by
     ``len(cache_list)``; the region bookkeeping runs in an inner
     ``for cache in cache_list`` loop; and ``block_stride_per_layer`` /
-    ``region_num_blocks`` are populated per-region to satisfy later upstream
-    additions to ``_build_fa_local``. See the DRIFT HAZARD note above — re-sync
+    ``region_num_blocks`` / ``region_mem_types`` / ``region_group_ids`` /
+    ``region_names`` are populated per-region to satisfy later upstream
+    additions to ``_build_fa_local``, ``_compute_desc_ids`` and
+    ``register_local_xfer_handler``. Every region is registered with the single
+    ``self.nixl_memory_type`` rather than upstream's per-memory-type
+    ``registration_ranges`` grouping. See the DRIFT HAZARD note above: re-sync
     on the ``_warn_if_upstream_register_drifted`` warning.
 
     Args:
@@ -410,6 +414,9 @@ def _hpu_register_kv_caches(self, kv_caches: dict[str, torch.Tensor]) -> None:
             # When cross-layers blocks are used, multiply by number of layers.
             physical_page_size = physical_page_size * len(self.kv_cache_config.kv_cache_tensors)
         num_blocks = (self._logical_num_blocks if isinstance(layer_spec, MambaSpec) else self.num_blocks)
+        # Every region carved out of this layer belongs to the layer's transfer
+        # group (vLLM #53780 per-region transfer geometry).
+        group_id = self.kv_cache_config.transfer_group_index_by_layer[layer_name]
         # `page_size` accounts for physical blocks, st KVCache is always
         # [`num_blocks` * `page_size`].
         curr_tensor_size_bytes = num_blocks * physical_page_size
@@ -441,6 +448,16 @@ def _hpu_register_kv_caches(self, kv_caches: dict[str, torch.Tensor]) -> None:
             # IndexError. `num_blocks` here is already the per-region physical
             # count (logical count for Mamba), matching upstream's semantics.
             self.region_num_blocks.append(num_blocks)
+            # vLLM #53780 also made the memory type, transfer group and name
+            # per-region: register_local_xfer_handler reads
+            # self.region_mem_types[0] and _compute_desc_ids asserts
+            # len(region_group_ids) == self.num_regions. This override
+            # registers every region in one get_reg_descs() call below with
+            # self.nixl_memory_type, so that IS each region's memory type; the
+            # K and V halves of a layer share its transfer group and name.
+            self.region_mem_types.append(self.nixl_memory_type)
+            self.region_group_ids.append(group_id)
+            self.region_names.append(layer_name)
 
             if not is_mla_region:
                 if tensor_size_bytes is None:
@@ -469,10 +486,13 @@ def _hpu_register_kv_caches(self, kv_caches: dict[str, torch.Tensor]) -> None:
 
     logger.debug("Different block lengths collected: %s", set(self.block_len_per_layer))
     assert len(self.block_len_per_layer) == len(seen_base_addresses) == len(self._region_is_mla) == len(
-        self.block_stride_per_layer) == len(self.region_num_blocks)
+        self.block_stride_per_layer) == len(self.region_num_blocks) == len(self.region_mem_types) == len(
+            self.region_group_ids) == len(self.region_names)
 
     self.kv_caches_base_addr[self.engine_id][self.tp_rank] = seen_base_addresses
     self.num_regions = len(caches_data)
+    self._uses_region_group_mapping = len(set(self.region_group_ids)) > 1
+    self._mixed_mem_types = len(set(self.region_mem_types)) > 1
     if self._has_mamba:
         # Mirror upstream: every region (including the shared conv/ssm tensor)
         # reports the PHYSICAL block count here, not the per-layer logical
@@ -497,6 +517,13 @@ def _hpu_register_kv_caches(self, kv_caches: dict[str, torch.Tensor]) -> None:
 
     self.device_kv_caches = kv_caches
     self.dst_num_blocks[self.engine_id] = self.num_blocks
+    # Local engine's own per-region geometry; the remote side's copy is filled
+    # in add_remote_agent, which falls back to these uniform values when a peer
+    # omits them from its NixlAgentMetadata.
+    self.dst_region_num_blocks[self.engine_id] = self.region_num_blocks
+    self.dst_region_group_ids[self.engine_id] = self.region_group_ids
+    self.dst_uses_region_group_mapping[self.engine_id] = self._uses_region_group_mapping
+    self.dst_region_mem_types[self.engine_id] = self.region_mem_types
 
     if self._has_mamba:
         logger.info(

--- a/vllm_gaudi/models/__init__.py
+++ b/vllm_gaudi/models/__init__.py
@@ -37,7 +37,14 @@ def register_model():
                                  "vllm_gaudi.models.minimax_m3:HpuMiniMaxM3SparseForCausalLM")
     ModelRegistry.register_model("MiniMaxM3SparseForConditionalGeneration",
                                  "vllm_gaudi.models.minimax_m3:HpuMiniMaxM3SparseForConditionalGeneration")
-    from vllm_gaudi.models.pixtral import HPUPixtralForConditionalGeneration  # noqa: F401
+    # Registered lazily by "module:class" string on purpose: do NOT add an eager
+    # `from vllm_gaudi.models.pixtral import ...` here. That module reaches
+    # vllm.model_executor.models.pixtral, which imports PixtralRotaryEmbedding /
+    # position_ids_in_meshgrid - both removed by transformers 5.17.0
+    # (huggingface/transformers#48105). register_model() runs from
+    # load_general_plugins(), including inside vLLM's model-inspection
+    # subprocess, so an eager import turned that one unimportable upstream
+    # module into a ModelConfig ValidationError for every architecture.
     ModelRegistry.register_model("PixtralForConditionalGeneration",
                                  "vllm_gaudi.models.pixtral:HPUPixtralForConditionalGeneration")
 

--- a/vllm_gaudi/ops/hpu_compressed_tensors.py
+++ b/vllm_gaudi/ops/hpu_compressed_tensors.py
@@ -13,7 +13,7 @@ from compressed_tensors.quantization import (QuantizationArgs, QuantizationStrat
 from vllm.model_executor.layers.quantization.utils.w8a8_utils import convert_to_channelwise, all_close_1d
 from vllm.model_executor.parameter import (ChannelQuantScaleParameter, ModelWeightParameter, PerTensorScaleParameter,
                                            BasevLLMParameter, GroupQuantScaleParameter, PackedColumnParameter,
-                                           PackedvLLMParameter, RowvLLMParameter, BlockQuantScaleParameter)
+                                           PackedvLLMParameter, BlockQuantScaleParameter)
 from vllm.model_executor.layers.quantization.compressed_tensors import (compressed_tensors)
 from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors import (  # noqa: E501
     CompressedTensorsLinearMethod as OrigCompressedTensorsLinearMethod)
@@ -139,11 +139,14 @@ class HPUCompressedTensorsLinearMethod(OrigCompressedTensorsLinearMethod):
             scheme_dict = self.quantization_config.target_scheme_map[matched_target]
             weight_quant = scheme_dict.get("weights")
 
+            # vllm#54809 removed GPTQ group/dynamic activation ordering (and the
+            # `actorder` constructor kwarg) from CompressedTensorsWNA16 upstream;
+            # any checkpoint still declaring actorder=group/dynamic is now
+            # rejected earlier during config parsing, so this kwarg is dead.
             hpu_scheme = HPUCompressedTensorsWNA16(num_bits=weight_quant.num_bits,
                                                    strategy=scheme.strategy,
                                                    symmetric=scheme.symmetric,
-                                                   group_size=scheme.group_size,
-                                                   actorder=weight_quant.actorder)
+                                                   group_size=scheme.group_size)
         else:
             raise ValueError(f"{scheme_classname} compressed format is not supported on HPU")
         return hpu_scheme
@@ -594,6 +597,10 @@ class HPUCompressedTensorsWNA16(CompressedTensorsWNA16):
                        weight_loader: Callable, **kwargs):
         output_size_per_partition = sum(output_partition_sizes)
 
+        # vllm#54809 dropped `has_g_idx` from MPLinearLayerConfig (and the
+        # `weight_g_idx` param from CompressedTensorsWNA16) along with GPTQ
+        # group/dynamic activation ordering support; that checkpoint shape is
+        # rejected upstream during config parsing before it ever reaches here.
         mp_linear_kernel_config = MPLinearLayerConfig(
             full_weight_shape=(input_size, output_size),
             partition_weight_shape=\
@@ -602,7 +609,6 @@ class HPUCompressedTensorsWNA16(CompressedTensorsWNA16):
             act_type=params_dtype,
             group_size=self.group_size,
             zero_points=not self.symmetric,
-            has_g_idx=self.has_g_idx
         )
 
         kernel_type = HPUMPLinearKernel
@@ -614,7 +620,7 @@ class HPUCompressedTensorsWNA16(CompressedTensorsWNA16):
         # If group_size is -1, we are in channelwise case.
         group_size = self.group_size if self.group_size != -1 else input_size
         row_parallel = (input_size != input_size_per_partition)
-        partition_scales = not marlin_repeat_scales_on_all_ranks(self.has_g_idx, self.group_size, row_parallel)
+        partition_scales = not marlin_repeat_scales_on_all_ranks(self.group_size, row_parallel)
 
         scales_and_zp_size = input_size // group_size
 
@@ -676,21 +682,10 @@ class HPUCompressedTensorsWNA16(CompressedTensorsWNA16):
         if not self.symmetric:
             layer.register_parameter("weight_zero_point", qzeros)
 
-        # group index (for activation reordering)
-        if self.has_g_idx:
-            weight_g_idx = RowvLLMParameter(data=torch.empty(
-                input_size_per_partition,
-                dtype=torch.int32,
-            ),
-                                            input_dim=0,
-                                            weight_loader=weight_loader)
-            layer.register_parameter("weight_g_idx", weight_g_idx)
-
         self.kernel = kernel_type(mp_linear_kernel_config,
                                   w_q_param_name="weight_packed",
                                   w_s_param_name="weight_scale",
-                                  w_zp_param_name="weight_zero_point",
-                                  w_gidx_param_name="weight_g_idx")
+                                  w_zp_param_name="weight_zero_point")
 
 
 class HPUMPLinearKernel(MPLinearKernel):
@@ -755,12 +750,15 @@ class HPUMPLinearKernel(MPLinearKernel):
                       x: torch.Tensor,
                       bias: Optional[torch.Tensor] = None) -> torch.Tensor:
         c = self.config
-        w_q, w_s, w_zp, w_gidx = self._get_weight_params(layer)
+        # vllm#54809 dropped w_gidx from _get_weight_params; group/dynamic
+        # activation-ordering checkpoints are rejected upstream before
+        # reaching this kernel, so there is no g_idx tensor to pass here.
+        w_q, w_s, w_zp = self._get_weight_params(layer)
 
         reshaped_x = x.reshape(-1, x.shape[-1])
         out_shape = x.shape[:-1] + (c.partition_weight_shape[1], )
 
-        weight = torch.ops.hpu.convert_from_uint4(w_q, w_s, w_zp, x.dtype, w_gidx)
+        weight = torch.ops.hpu.convert_from_uint4(w_q, w_s, w_zp, x.dtype, None)
         output = torch.matmul(reshaped_x, weight)
 
         if bias is not None:


### PR DESCRIPTION
This PR consolidates 5 hourly-CI fixes against vllm@`d2906091bfc579cebefe3d8e8fb9077397ce9882`.
## Bug 1: drop removed actorder/g_idx kwargs from HPU WNA16 scheme

- **State machine id**: compressed_tensors_wna16_actorder_no_longer_supported
- **Commit**: 9b4b363f69ee974dde2ab31b3d26e61b15a578ad

### Root cause
vllm#54809 removed GPTQ group/dynamic activation ordering support, deleting the actorder ctor kwarg, has_g_idx attribute, and weight_g_idx/w_gidx_param_name plumbing from CompressedTensorsWNA16 and MPLinearKernel. HPUCompressedTensorsWNA16 in vllm_gaudi/ops/hpu_compressed_tensors.py still passed/read those removed names, so every WNA16 checkpoint load hit TypeError before reaching the kernel.

### Culprit
Regression introduced by [PR #54809](https://github.com/vllm-project/vllm/pull/54809).

### Fix
drop actorder/has_g_idx/w_gidx_param_name from the HPU WNA16 scheme and kernel, matching upstream's removal; retire the compressed_w4a16 MoE g_idx e2e job since its checkpoint declares actorder=group, which vLLM now rejects on every backend before hardware dispatch.

## Bug 2: populate region_num_blocks in HPU NIXL KV-cache registration

- **State machine id**: nixl_pd_build_fa_local_region_num_blocks_indexerror
- **Commit**: 0f8b4335821551e6f7be4c7224a402fed13b67f4

### Root cause
vllm#53780 added a per-region region_num_blocks list to NixlBaseConnectorWorker and made _build_fa_local index it (self.region_num_blocks[i]). The HPU register_kv_caches override (hpu_nixl_connector.py) never populated that list, so the first index access raised IndexError on every NIXL PD job.

### Culprit
Probable culprit: [PR #53780](https://github.com/vllm-project/vllm/pull/53780) — pinned by symbol archaeology, bisect not run.
Candidate range: [compare](https://github.com/vllm-project/vllm/compare/cd64c2dea9c72af333de7ec05293d54bbf1bd128...d2906091bfc).

### Fix
append the per-region block count in the same loop that already populates block_len_per_layer/block_stride_per_layer, extend the region-count consistency assert, and mirror upstream's Mamba/hybrid-SSM override of region_num_blocks to the physical block count.

## Bug 3: register HPU Pixtral lazily

- **State machine id**: opt_causal_lm_modelconfig_inspect_validation_error
- **Commit**: c41afcda990ba9af9c777b3291739bab36a33420

### Root cause
transformers 5.17.0 removed PixtralRotaryEmbedding and position_ids_in_meshgrid, so the eager Pixtral import in register_model() aborted plugin registration for every architecture.

### Culprit
Regression introduced by [PR #48105](https://github.com/huggingface/transformers/pull/48105).

### Fix
drop the redundant eager import and keep only the lazy "module:class" registration.

## Bug 4: populate per-region NIXL registration bookkeeping

- **State machine id**: nixl_register_local_xfer_region_mem_types_indexerror
- **Commit**: 4ec533f23388efd37d59036a7a4808a6eefcf6f6

### Root cause
vllm#53780 made the NIXL memory type, transfer group and name per-region, and register_local_xfer_handler now reads region_mem_types[0]; the HPU register_kv_caches override (a pre-#44456 copy kept to restore the K/V region split) never populated any of those lists, so every NIXL PD engine died with IndexError at KV cache registration.

### Culprit
Regression introduced by [PR #53780](https://github.com/vllm-project/vllm/pull/53780).

### Fix
append region_mem_types / region_group_ids / region_names per region in the override's registration loop, derive _mixed_mem_types and _uses_region_group_mapping from them, and publish the local engine's dst_region_* geometry, matching upstream's post-#53780 tail.

## Bug 5: cap transformers below 5.17

- **State machine id**: mistral3_pixtral_rotary_embedding_import_error
- **Commit**: 1e9da6347b89de841b3f1a57c11da8ace8d046e6

### Root cause
transformers 5.17.0 removed position_ids_in_meshgrid and renamed PixtralRotaryEmbedding to PixtralVisionRotaryEmbedding, both imported at module level by upstream vLLM's vllm/model_executor/models/pixtral.py, so PixtralForConditionalGeneration can no longer be inspected.

### Culprit
Regression introduced by [PR #48105](https://github.com/huggingface/transformers/pull/48105).

### Fix
cap transformers<5.17, the version upstream vLLM tests against, until vLLM adopts the new vision rotary-embedding API.
